### PR TITLE
Fix: Subscriber is nil

### DIFF
--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -189,7 +189,11 @@ internal class SignalClient: MulticastDelegate<SignalClientDelegate> {
 
 internal extension SignalClient {
 
-    func waitReceiveJoinResponse() -> Promise<Livekit_JoinResponse> {
+    typealias DidReceiveJoinResponse = (Livekit_JoinResponse) -> Void
+
+    // if onDidReceiveJoinResponse is specified, it will be executed synchronously
+    // before resolving the Promise
+    func waitReceiveJoinResponse(onDidReceiveJoinResponse: DidReceiveJoinResponse? = nil) -> Promise<Livekit_JoinResponse> {
 
         log("Waiting for join response...")
 
@@ -204,6 +208,7 @@ internal extension SignalClient {
             var delegate: SignalClientDelegateClosures?
             delegate = SignalClientDelegateClosures(didReceiveJoinResponse: { _, joinResponse in
                 // wait until connected
+                onDidReceiveJoinResponse?(joinResponse)
                 resolve(joinResponse)
                 delegate = nil
             })


### PR DESCRIPTION
Fixes LK-611
When server sends offer too quickly after joinResponse, Transports are not fully configured yet
and causes Subscriber is nil error.

Reason
after `waitReceiveJoinResponse`
`configureTransports` was called asynchronously by the Promise chain.
If the server sends offer too quickly, offer arrives between that flow, while subscriber is still nil.