### PR TITLE
Fix encoder & renderer crashes

### DIFF
--- a/Sources/LiveKit/Extensions/RTCVideoCapturerDelegate+Buffer.swift
+++ b/Sources/LiveKit/Extensions/RTCVideoCapturerDelegate+Buffer.swift
@@ -4,12 +4,12 @@ import ReplayKit
 extension Dimensions {
 
     // Ensures width and height are even numbers
-    func toEncodeSafeDimensions() -> Dimensions {
+    internal func toEncodeSafeDimensions() -> Dimensions {
         Dimensions(width: max(encodeSafeSize, width % 2 == 0 ? width : width + 1),
                    height: max(encodeSafeSize, height % 2 == 0 ? height : height + 1))
     }
 
-    static func * (a: Dimensions, b: Double) -> Dimensions {
+    internal static func * (a: Dimensions, b: Double) -> Dimensions {
         Dimensions(width: Int32((Double(a.width) * b).rounded()),
                    height: Int32((Double(a.height) * b).rounded()))
     }

--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -197,7 +197,7 @@ internal class Utils {
             let presets = dimensions.computeSuggestedPresets()
             let presetIndexF = dimensions.computeSuggestedPresetIndex(in: presets)
 
-            encodingF = presets[presetIndexF].encoding
+            encodingF = presets[safe: presetIndexF]?.encoding
             encodingH = encodingF
             encodingQ = encodingF
 

--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -131,10 +131,9 @@ public class MacOSScreenCapturer: VideoCapturer {
         let systemTime = ProcessInfo.processInfo.systemUptime
         let timestampNs = UInt64(systemTime * Double(NSEC_PER_SEC))
 
-        self.delegate?.capturer(self.capturer, didCapture: pixelBuffer, timeStampNs: timestampNs)
-
-        self.dimensions = Dimensions(width: Int32(image.width),
-                                     height: Int32(image.height))
+        self.delegate?.capturer(self.capturer, didCapture: pixelBuffer, timeStampNs: timestampNs) { targetDimensions in
+            self.dimensions = targetDimensions
+        }
     }
 
     public override func startCapture() -> Promise<Void> {

--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -120,7 +120,7 @@ public class MacOSScreenCapturer: VideoCapturer {
         guard let image = CGWindowListCreateImage(CGRect.null,
                                                   .optionIncludingWindow,
                                                   windowId, [.shouldBeOpaque,
-                                                             .nominalResolution,
+                                                             .bestResolution,
                                                              .boundsIgnoreFraming]),
               let pixelBuffer = image.toPixelBuffer(pixelFormatType: kCVPixelFormatType_32ARGB) else { return }
 

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -190,6 +190,12 @@ extension VideoView: RTCVideoRenderer {
 
     public func renderFrame(_ frame: RTCVideoFrame?) {
 
+        // check if dimensions are safe to pass to renderer
+        if let frame = frame, (frame.width < renderSafeSize || frame.height < renderSafeSize) {
+            log("Skipping render for dimension \(frame.width)x\(frame.height)", .warning)
+            return
+        }
+
         nativeRenderer.renderFrame(frame)
 
         // layout after first frame has been rendered

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -174,26 +174,22 @@ extension VideoView: RTCVideoRenderer {
     public func setSize(_ size: CGSize) {
 
         nativeRenderer.setSize(size)
-
-        guard let width = Int32(exactly: size.width),
-              let height = Int32(exactly: size.height) else {
-            // CGSize is used by WebRTC but this should always be an integer
-            log("Size width/height is not an integer", .warning)
-            return
-        }
-
-        DispatchQueue.main.async {
-            self.dimensions = Dimensions(width: width,
-                                         height: height)
-        }
     }
 
     public func renderFrame(_ frame: RTCVideoFrame?) {
 
-        // check if dimensions are safe to pass to renderer
-        if let frame = frame, (frame.width < renderSafeSize || frame.height < renderSafeSize) {
-            log("Skipping render for dimension \(frame.width)x\(frame.height)", .warning)
-            return
+        if let frame = frame {
+
+            let dimensions = Dimensions(width: frame.width,
+                                        height: frame.height)
+
+            // check if dimensions are safe to pass to renderer
+            guard dimensions.isRenderSafe else {
+                log("Skipping render for dimension \(dimensions)", .warning)
+                return
+            }
+
+            DispatchQueue.main.async { self.dimensions = dimensions }
         }
 
         nativeRenderer.renderFrame(frame)

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -14,7 +14,7 @@ public typealias NativeRendererView = NativeViewType & RTCVideoRenderer
 
 public class VideoView: NativeView, Loggable {
 
-    public enum Mode {
+    public enum Mode: String, Codable, CaseIterable {
         case fit
         case fill
     }


### PR DESCRIPTION
Fixes: LK-400

## Renderer
- Never attempt render frames that are smaller than 8x8 to prevent Metal renderer from crashing. (Even if server sends the frame)

## Capture (Encode)
- Never attempt to encode frames that are smaller than 16x16 (16 was reported in assert message of crash) to prevent h264 encoder from crashing.
- Always target even number dimensions when capturing odd size dimensions