### PR TITLE
Update computations

### DIFF
--- a/Sources/LiveKit/Types/Dimensions.swift
+++ b/Sources/LiveKit/Types/Dimensions.swift
@@ -61,7 +61,7 @@ extension Dimensions {
     //               height: abs(self.height - dimensions.height))
     // }
 
-    func computeSuggestedPresets(isScreenShare: Bool = false) -> [VideoParameters] {
+    func computeSuggestedPresets(isScreenShare: Bool) -> [VideoParameters] {
         if isScreenShare {
             return VideoParameters.presetsScreenShare
         }
@@ -69,6 +69,16 @@ extension Dimensions {
             return VideoParameters.presets169
         }
         return VideoParameters.presets43
+    }
+
+    func defaultSimulcastLayers(isScreenShare: Bool) -> [VideoParameters] {
+        if isScreenShare {
+            return []
+        }
+        if abs(aspectRatio - Dimensions.aspectRatio169) < abs(aspectRatio - Dimensions.aspectRatio43) {
+            return VideoParameters.defaultSimulcastPresets169
+        }
+        return VideoParameters.defaultSimulcastPresets43
     }
 
     func computeSuggestedPreset(in presets: [VideoParameters]) -> VideoEncoding {

--- a/Sources/LiveKit/Types/Options/PublishOptions.swift
+++ b/Sources/LiveKit/Types/Options/PublishOptions.swift
@@ -17,13 +17,21 @@ public class VideoPublishOptions: PublishOptions {
     /// true to enable simulcasting, publishes three tracks at different sizes
     public let simulcast: Bool
 
+    public let simulcastLayers: [VideoParameters]
+
+    public let screenShareSimulcastLayers: [VideoParameters]
+
     public init(encoding: VideoEncoding? = nil,
                 screenShareEncoding: VideoEncoding? = nil,
-                simulcast: Bool = true) {
+                simulcast: Bool = true,
+                simulcastLayers: [VideoParameters] = [],
+                screenShareSimulcastLayers: [VideoParameters] = [.presetScreenShareH360FPS3, .presetScreenShareH720FPS5]) {
 
         self.encoding = encoding
         self.screenShareEncoding = screenShareEncoding
         self.simulcast = simulcast
+        self.simulcastLayers = simulcastLayers
+        self.screenShareSimulcastLayers = screenShareSimulcastLayers
     }
 }
 

--- a/Sources/LiveKit/Types/VideoEncoding.swift
+++ b/Sources/LiveKit/Types/VideoEncoding.swift
@@ -10,3 +10,15 @@ public struct VideoEncoding {
         self.maxFps = maxFps
     }
 }
+
+extension VideoEncoding: Comparable {
+
+    public static func < (lhs: VideoEncoding, rhs: VideoEncoding) -> Bool {
+
+        if lhs.maxBitrate == rhs.maxBitrate {
+            return lhs.maxFps < rhs.maxFps
+        }
+
+        return lhs.maxBitrate < rhs.maxBitrate
+    }
+}

--- a/Sources/LiveKit/Types/VideoParameters.swift
+++ b/Sources/LiveKit/Types/VideoParameters.swift
@@ -74,6 +74,16 @@ public extension VideoParameters {
         presetScreenShareH1080FPS30
     ]
 
+    static let defaultSimulcastPresets169 = [
+        presetH180_169,
+        presetH360_169
+    ]
+
+    static let defaultSimulcastPresets43 = [
+        presetH180_43,
+        presetH360_43
+    ]
+
     // 16:9 aspect ratio
 
     static let presetH90_169 = VideoParameters(
@@ -194,6 +204,23 @@ public extension VideoParameters {
         dimensions: .h1080_169,
         encoding: VideoEncoding(maxBitrate: 3_000_000, maxFps: 30)
     )
+}
+
+extension VideoParameters: Comparable {
+
+    public static func < (lhs: VideoParameters, rhs: VideoParameters) -> Bool {
+
+        if lhs.dimensions.area == rhs.dimensions.area {
+            return lhs.encoding < rhs.encoding
+        }
+
+        return lhs.dimensions.area < rhs.dimensions.area
+    }
+
+    public static func == (lhs: VideoParameters, rhs: VideoParameters) -> Bool {
+        lhs.dimensions == rhs.dimensions &&
+            lhs.encoding == rhs.encoding
+    }
 }
 
 // MARK: - Presets(Deprecated)


### PR DESCRIPTION
from PRs 👉
https://github.com/livekit/client-sdk-js/pull/146
https://github.com/livekit/client-sdk-js/pull/149

But I think dimensions should be compared by area (width * height) instead of the largest side (max)
👉 https://github.com/livekit/client-sdk-js/pull/146/files#diff-4c7fc41e072f8a2f5272ccae3b53d650e87c64d6f4b74541343e28fbb0a7100aR180-R195

for example comparing by max would be
1000 x 300 > 900 x 900
but comparing the area would be
300,000 < 810,000

Just want to check if this is intended behavior 🙂