### PR TITLE
Suspend local video tracks in background

### DIFF
--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -559,10 +559,7 @@ extension Room: AppStateDelegate {
         guard options.suspendLocalVideoTracksInBackground else { return }
 
         guard let localParticipant = localParticipant else { return }
-        let promises = localParticipant.videoTracks.values
-            .compactMap { $0 as? LocalTrackPublication }
-            .filter { $0.kind == .video }
-            .map { $0.suspend() }
+        let promises = localParticipant.localVideoTracks.map { $0.suspend() }
 
         guard !promises.isEmpty else { return }
 
@@ -574,10 +571,7 @@ extension Room: AppStateDelegate {
     func appWillEnterForeground() {
 
         guard let localParticipant = localParticipant else { return }
-        let promises = localParticipant.videoTracks.values
-            .compactMap { $0 as? LocalTrackPublication }
-            .filter { $0.kind == .video }
-            .map { $0.resume() }
+        let promises = localParticipant.localVideoTracks.map { $0.resume() }
 
         guard !promises.isEmpty else { return }
 

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -23,6 +23,8 @@ public class Room: MulticastDelegate<RoomDelegate> {
     public var url: String? { engine.url }
     public var token: String? { engine.token }
 
+    internal let appStateListener = AppStateListener()
+
     public init(delegate: RoomDelegate? = nil,
                 connectOptions: ConnectOptions = ConnectOptions(),
                 roomOptions: RoomOptions = RoomOptions()) {

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -3,8 +3,8 @@ import Promises
 
 public class LocalParticipant: Participant {
 
-    public var localAudioTrackPublications: [TrackPublication] { Array(audioTracks.values) }
-    public var localVideoTrackPublications: [TrackPublication] { Array(videoTracks.values) }
+    public var localAudioTracks: [LocalTrackPublication] { audioTracks.compactMap { $0 as? LocalTrackPublication } }
+    public var localVideoTracks: [LocalTrackPublication] { videoTracks.compactMap { $0 as? LocalTrackPublication } }
 
     convenience init(from info: Livekit_ParticipantInfo,
                      room: Room) {

--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -34,12 +34,12 @@ public class Participant: MulticastDelegate<ParticipantDelegate> {
     public private(set) var joinedAt: Date?
     public internal(set) var tracks = [String: TrackPublication]()
 
-    public var audioTracks: [String: TrackPublication] {
-        tracks.filter { $0.value.kind == .audio }
+    public var audioTracks: [TrackPublication] {
+        tracks.values.filter { $0.kind == .audio }
     }
 
-    public var videoTracks: [String: TrackPublication] {
-        tracks.filter { $0.value.kind == .video }
+    public var videoTracks: [TrackPublication] {
+        tracks.values.filter { $0.kind == .video }
     }
 
     var info: Livekit_ParticipantInfo?

--- a/Sources/LiveKit/Publications/LocalTrackPublication.swift
+++ b/Sources/LiveKit/Publications/LocalTrackPublication.swift
@@ -3,6 +3,9 @@ import Promises
 
 public class LocalTrackPublication: TrackPublication {
 
+    // indicates whether the track was suspended(muted) by the SDK
+    internal var suspended: Bool = false
+
     @discardableResult
     public func mute() -> Promise<Void> {
 
@@ -55,6 +58,27 @@ public class LocalTrackPublication: TrackPublication {
         self?.recomputeSenderParameters()
     })
     #endif
+}
+
+internal extension LocalTrackPublication {
+
+    @discardableResult
+    func suspend() -> Promise<Void> {
+        // do nothing if already muted
+        guard !muted else { return Promise(()) }
+        return mute().then {
+            self.suspended = true
+        }
+    }
+
+    @discardableResult
+    func resume() -> Promise<Void> {
+        // do nothing if was not suspended
+        guard suspended else { return Promise(()) }
+        return unmute().then {
+            self.suspended = false
+        }
+    }
 }
 
 #if LK_COMPUTE_VIDEO_SENDER_PARAMETERS

--- a/Sources/LiveKit/Support/AppStateListener.swift
+++ b/Sources/LiveKit/Support/AppStateListener.swift
@@ -1,0 +1,34 @@
+import Foundation
+#if os(iOS)
+import UIKit
+#endif
+
+internal class AppStateListener: Loggable {
+
+    typealias EventHandler = () -> Void
+
+    var onEnterBackground: EventHandler?
+    var onEnterForeground: EventHandler?
+
+    init() {
+        let center = NotificationCenter.default
+
+        #if os(iOS)
+        center.addObserver(forName: UIScene.didEnterBackgroundNotification,
+                           object: nil,
+                           queue: OperationQueue.main) { (_) in
+
+            self.log("UIScene.didEnterBackgroundNotification")
+            self.onEnterBackground?()
+        }
+
+        center.addObserver(forName: UIScene.didDisconnectNotification,
+                           object: nil,
+                           queue: OperationQueue.main) { (_) in
+
+            self.log("UIScene.didDisconnectNotification")
+            self.onEnterForeground?()
+        }
+        #endif
+    }
+}

--- a/Sources/LiveKit/SwiftUI/ObservableParticipant.swift
+++ b/Sources/LiveKit/SwiftUI/ObservableParticipant.swift
@@ -107,15 +107,15 @@ open class ObservableParticipant: ObservableObject {
     }
 
     public var firstCameraPublication: TrackPublication? {
-        participant.videoTracks.values.first(where: { $0.source == .camera })
+        participant.videoTracks.first(where: { $0.source == .camera })
     }
 
     public var firstScreenSharePublication: TrackPublication? {
-        participant.videoTracks.values.first(where: { $0.source == .screenShareVideo })
+        participant.videoTracks.first(where: { $0.source == .screenShareVideo })
     }
 
     public var firstAudioPublication: TrackPublication? {
-        participant.audioTracks.values.first
+        participant.audioTracks.first
     }
 
     public var firstCameraVideoTrack: VideoTrack? {

--- a/Sources/LiveKit/Types/Options/RoomOptions.swift
+++ b/Sources/LiveKit/Types/Options/RoomOptions.swift
@@ -27,6 +27,10 @@ public struct RoomOptions {
 
     public let stopLocalTrackOnUnpublish: Bool
 
+    /// Automatically suspend(mute) video tracks when the app enters background and
+    /// resume(unmute) when the app enters foreground again.
+    public let suspendLocalVideoTracksInBackground: Bool
+
     /// **Experimental**
     /// Report ``TrackStats`` every second to ``TrackDelegate`` for each local and remote tracks.
     /// This may consume slightly more CPU resources.
@@ -40,6 +44,7 @@ public struct RoomOptions {
                 adaptiveStream: Bool = false,
                 dynacast: Bool = false,
                 stopLocalTrackOnUnpublish: Bool = true,
+                suspendLocalVideoTracksInBackground: Bool = true,
                 reportStats: Bool = false) {
 
         self.defaultCameraCaptureOptions = defaultCameraCaptureOptions
@@ -50,6 +55,7 @@ public struct RoomOptions {
         self.adaptiveStream = adaptiveStream
         self.dynacast = dynacast
         self.stopLocalTrackOnUnpublish = stopLocalTrackOnUnpublish
+        self.suspendLocalVideoTracksInBackground = suspendLocalVideoTracksInBackground
         self.reportStats = reportStats
     }
 }


### PR DESCRIPTION
This will mute local video tracks when the app goes background and unmutes when back to the foreground.
Would like to hear opinions 🙂

Without this, when the app goes background the video will appear to be stuck to the other participants.