### PR TITLE
Fix: Logic to trigger AdaptiveStream

### DIFF
--- a/Sources/LiveKit/Protocols/TrackDelegate.swift
+++ b/Sources/LiveKit/Protocols/TrackDelegate.swift
@@ -24,6 +24,8 @@ public protocol TrackDelegate: AnyObject {
     func track(_ track: VideoTrack, didUpdate dimensions: Dimensions?)
     /// Dimensions of the VideoView has updated
     func track(_ track: VideoTrack, videoView: VideoView, didUpdate size: CGSize)
+    /// VideoView performed a layout
+    func track(_ track: VideoTrack, videoView: VideoView, didLayout size: CGSize)
     /// VideoView updated the render state
     func track(_ track: VideoTrack, videoView: VideoView, didUpdate renderState: VideoView.RenderState)
     /// A ``VideoView`` was attached to the ``VideoTrack``
@@ -41,6 +43,7 @@ public protocol TrackDelegate: AnyObject {
 extension TrackDelegate {
     public func track(_ track: VideoTrack, didUpdate dimensions: Dimensions?) {}
     public func track(_ track: VideoTrack, videoView: VideoView, didUpdate size: CGSize) {}
+    public func track(_ track: VideoTrack, videoView: VideoView, didLayout size: CGSize) {}
     public func track(_ track: VideoTrack, videoView: VideoView, didUpdate renderState: VideoView.RenderState) {}
     public func track(_ track: VideoTrack, didAttach videoView: VideoView) {}
     public func track(_ track: VideoTrack, didDetach videoView: VideoView) {}

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -183,7 +183,7 @@ public class RemoteTrackPublication: TrackPublication {
 
     override public func track(_ track: VideoTrack,
                                videoView: VideoView,
-                               didUpdate size: CGSize) {
+                               didLayout size: CGSize) {
 
         videoViewVisibilities[videoView.hash] = VideoViewVisibility(visible: true,
                                                                     size: size)

--- a/Sources/LiveKit/Publications/TrackPublication.swift
+++ b/Sources/LiveKit/Publications/TrackPublication.swift
@@ -104,6 +104,10 @@ public class TrackPublication: TrackDelegate, Loggable {
     public func track(_ track: VideoTrack, videoView: VideoView, didUpdate size: CGSize) {
         //
     }
+    
+    public func track(_ track: VideoTrack, videoView: VideoView, didLayout size: CGSize) {
+        //
+    }
 
     public func track(_ track: VideoTrack, didAttach videoView: VideoView) {
         //

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -100,7 +100,7 @@ public class VideoView: NativeView, Loggable {
     }
 
     /// Calls addRenderer and/or removeRenderer internally for convenience.
-    public var track: VideoTrack? {
+    public weak var track: VideoTrack? {
         didSet {
             guard !(oldValue?.isEqual(track) ?? false) else { return }
 

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -176,8 +176,13 @@ public class VideoView: NativeView, Loggable {
         assert(Thread.current.isMainThread, "shouldLayout must be called from main thread")
 
         defer {
+            let size = self.frame.size
             DispatchQueue.main.async {
-                self.viewSize = self.frame.size
+                self.viewSize = size
+            }
+            track?.notify { [weak track] in
+                guard let track = track else { return }
+                $0.track(track, videoView: self, didLayout: size)
             }
         }
 


### PR DESCRIPTION
Fixes issue that adaptive stream may not resume.
Previously the logic relies that the VideoView's size to update (if no changes it wont trigger)

Changed it to trigger debounce func if VideoView's layout is requested by the OS.
https://developer.apple.com/documentation/uikit/uiview/1622482-layoutsubviews

I'm still thinking if this is the best logic.
