### PR TITLE
Fix: Local track rendering

### DIFF
--- a/Sources/LiveKit/Publications/TrackPublication.swift
+++ b/Sources/LiveKit/Publications/TrackPublication.swift
@@ -104,7 +104,7 @@ public class TrackPublication: TrackDelegate, Loggable {
     public func track(_ track: VideoTrack, videoView: VideoView, didUpdate size: CGSize) {
         //
     }
-    
+
     public func track(_ track: VideoTrack, videoView: VideoView, didLayout size: CGSize) {
         //
     }

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -166,8 +166,11 @@ extension Track: RTCVideoRenderer {
     public func renderFrame(_ frame: RTCVideoFrame?) {
 
         if let frame = frame {
-            set(dimensions: Dimensions(width: frame.width,
-                                       height: frame.height))
+            let dimensions = Dimensions(width: frame.width,
+                                        height: frame.height)
+                .apply(rotation: frame.rotation)
+
+            set(dimensions: dimensions)
         } else {
             set(dimensions: nil)
         }

--- a/Sources/LiveKit/Types/Dimensions.swift
+++ b/Sources/LiveKit/Types/Dimensions.swift
@@ -71,6 +71,10 @@ extension Dimensions {
         width * height
     }
 
+    func swapped() -> Dimensions {
+        Dimensions(width: height, height: width)
+    }
+
     func aspectFit(size: Int32) -> Dimensions {
         let c = width >= height
         let r = c ? Double(height) / Double(width) : Double(width) / Double(height)
@@ -156,6 +160,15 @@ extension Dimensions {
 
     func toCGSize() -> CGSize {
         CGSize(width: Int(width), height: Int(height))
+    }
+
+    func apply(rotation: RTCVideoRotation) -> Dimensions {
+
+        if ._90 == rotation || ._270 == rotation {
+            return swapped()
+        }
+
+        return self
     }
 }
 

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -150,6 +150,7 @@ public class VideoView: NativeView, Loggable {
         self.preferMetal = preferMetal
         self.nativeRenderer = VideoView.createNativeRendererView(preferMetal: preferMetal)
         super.init(frame: frame)
+        self.clipsToBounds = true
         addSubview(nativeRenderer)
     }
 

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -157,7 +157,7 @@ public class VideoView: NativeView, Loggable {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     deinit {
         log()
         self.track = nil


### PR DESCRIPTION
Fixes reported issue of local video view.

Local tracks are rotated by default (for unknown reason) which confuses the VideoView's layout computation.

This fix adjusts the dimensions.
