### PR TITLE
Adjust timing of creating timed-promises

### DIFF
--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -282,10 +282,9 @@ internal extension SignalClient {
             self.log("Waiting for join response...")
             listen.fulfill(())
         }
-        // convert to a timed-promise
-        .timeout(.defaultConnect)
 
-        return (listen, wait)
+        // convert to a timed-promise only after called
+        return (listen, { wait.timeout(.defaultJoinResponse) })
     }
 }
 

--- a/Sources/LiveKit/Extensions/TimeInterval.swift
+++ b/Sources/LiveKit/Extensions/TimeInterval.swift
@@ -18,9 +18,15 @@ import Foundation
 
 /// Default timeout `TimeInterval`s used throughout the SDK.
 internal extension TimeInterval {
-    static let captureStart: Self = 5
-    static let defaultConnect: Self = 15
+    static let defaultCaptureStart: Self = 5
     static let defaultConnectivity: Self = 10
     static let defaultPublish: Self = 10
-    static let quickReconnectDelay: Self = 3
+    static let defaultQuickReconnectRetry: Self = 2
+    // the following 3 timeouts are used for a typical connect sequence
+    static let defaultSocketConnect: Self = 10
+    static let defaultJoinResponse: Self = 7
+    static let defaultTransportState: Self = 10
+    // used for validation mode
+    static let defaultHTTPConnect: Self = 5
+    static let defaultPublisherDataChannelOpen: Self = 7
 }

--- a/Sources/LiveKit/Support/HTTP.swift
+++ b/Sources/LiveKit/Support/HTTP.swift
@@ -33,7 +33,7 @@ internal class HTTP: NSObject, URLSessionDelegate {
 
             let request = URLRequest(url: url,
                                      cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
-                                     timeoutInterval: .defaultConnect)
+                                     timeoutInterval: .defaultHTTPConnect)
 
             let task = self.session.dataTask(with: request) { data, response, error in
                 if let error = error {

--- a/Sources/LiveKit/Support/WebSocket.swift
+++ b/Sources/LiveKit/Support/WebSocket.swift
@@ -63,7 +63,7 @@ internal class WebSocket: NSObject, URLSessionWebSocketDelegate, Loggable {
 
         request = URLRequest(url: url,
                              cachePolicy: .useProtocolCachePolicy,
-                             timeoutInterval: .defaultConnect)
+                             timeoutInterval: .defaultSocketConnect)
 
         self.onMessage = onMessage
         self.onDisconnect = onDisconnect

--- a/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
@@ -66,7 +66,7 @@ internal extension VideoCapturer {
     func waitForDimensions(allowCurrent: Bool = true) -> WaitPromises<Void> {
 
         if allowCurrent, dimensions != nil {
-            return (Promise(()), Promise(()))
+            return (Promise(()), { Promise(()) })
         }
 
         let listen = Promise<Void>.pending()
@@ -84,10 +84,9 @@ internal extension VideoCapturer {
             self.log("Waiting for dimensions...")
             listen.fulfill(())
         }
-        // convert to a timed-promise
-        .timeout(.captureStart)
 
-        return (listen, wait)
+        // convert to a timed-promise only after called
+        return (listen, { wait.timeout(.defaultCaptureStart) })
     }
 }
 

--- a/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
@@ -50,7 +50,7 @@ public class LocalVideoTrack: LocalTrack, VideoTrack {
         }.then {
             self.capturer.startCapture()
         }.then {
-            wait.wait
+            wait.wait()
         }
     }
 

--- a/Sources/LiveKit/Types/Other.swift
+++ b/Sources/LiveKit/Types/Other.swift
@@ -23,7 +23,7 @@ public typealias Sid = String
 // A tuple of Promises.
 // listen: resolves when started listening
 // wait: resolves when wait is complete or rejects when timeout
-internal typealias WaitPromises<T> = (listen: Promise<Void>, wait: Promise<T>)
+internal typealias WaitPromises<T> = (listen: Promise<Void>, wait: () -> Promise<T>)
 
 public enum Reliability {
     case reliable


### PR DESCRIPTION
The timer of promises may have been starting at the defined time instead of when actually being called.
This ensures the logic is correct. I'm not sure if this will resolve any issues.
