### PR TITLE
Don't throw on duplicate calls to `start()` / `stop()`

### DIFF
--- a/Sources/LiveKit/Participant/RemoteParticipant.swift
+++ b/Sources/LiveKit/Participant/RemoteParticipant.swift
@@ -112,7 +112,7 @@ public class RemoteParticipant: Participant {
         publication.set(track: track)
         track.sid = publication.sid
         addTrack(publication: publication)
-        return track.start().then(on: .sdk) {
+        return track.start().then(on: .sdk) { _ -> Void in
             self.notify { $0.participant(self, didSubscribe: publication, track: track) }
             self.room.notify { $0.room(self.room, participant: self, didSubscribe: publication, track: track) }
         }
@@ -146,15 +146,13 @@ public class RemoteParticipant: Participant {
             return notifyUnpublish()
         }
 
-        return track.stop()
-            .recover(on: .sdk) { self.log("Failed to stop track, error: \($0)") }
-            .then(on: .sdk) {
-                guard shouldNotify else { return }
-                // notify unsubscribe
-                self.notify { $0.participant(self, didUnsubscribe: publication, track: track) }
-                self.room.notify { $0.room(self.room, participant: self, didUnsubscribe: publication, track: track) }
-            }.then(on: .sdk) {
-                notifyUnpublish()
-            }
+        return track.stop().then(on: .sdk) { _ -> Void in
+            guard shouldNotify else { return }
+            // notify unsubscribe
+            self.notify { $0.participant(self, didUnsubscribe: publication, track: track) }
+            self.room.notify { $0.room(self.room, participant: self, didUnsubscribe: publication, track: track) }
+        }.then(on: .sdk) {
+            notifyUnpublish()
+        }
     }
 }

--- a/Sources/LiveKit/SwiftUI/ObservableRoom.swift
+++ b/Sources/LiveKit/SwiftUI/ObservableRoom.swift
@@ -47,7 +47,7 @@ open class ObservableRoom: ObservableObject, RoomDelegate, Loggable {
     }
 
     @discardableResult
-    public func switchCameraPosition() -> Promise<Void> {
+    public func switchCameraPosition() -> Promise<Bool> {
 
         guard case .published(let publication) = self.cameraTrackState,
               let track = publication.track as? LocalVideoTrack,

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -77,9 +77,9 @@ public class CameraCapturer: VideoCapturer {
 
     public override func startCapture() -> Promise<Bool> {
 
-        super.startCapture().then(on: .sdk) { [weak self] didStart -> Promise<Bool> in
+        super.startCapture().then(on: .sdk) { didStart -> Promise<Bool> in
 
-            guard let self = self, didStart else {
+            guard didStart else {
                 // already started
                 return Promise(false)
             }

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -53,7 +53,7 @@ public class CameraCapturer: VideoCapturer {
 
     /// Switches the camera position between `.front` and `.back` if supported by the device.
     @discardableResult
-    public func switchCameraPosition() -> Promise<Void> {
+    public func switchCameraPosition() -> Promise<Bool> {
         // cannot toggle if current position is unknown
         guard position != .unspecified else {
             log("Failed to toggle camera position", .warning)
@@ -64,7 +64,7 @@ public class CameraCapturer: VideoCapturer {
     }
 
     /// Sets the camera's position to `.front` or `.back` when supported
-    public func setCameraPosition(_ position: AVCaptureDevice.Position) -> Promise<Void> {
+    public func setCameraPosition(_ position: AVCaptureDevice.Position) -> Promise<Bool> {
 
         log("setCameraPosition(position: \(position)")
 
@@ -75,68 +75,75 @@ public class CameraCapturer: VideoCapturer {
         return restartCapture()
     }
 
-    public override func startCapture() -> Promise<Void> {
+    public override func startCapture() -> Promise<Bool> {
 
-        let preferredPixelFormat = capturer.preferredOutputPixelFormat()
-        log("CameraCapturer.preferredPixelFormat: \(preferredPixelFormat.toString())")
+        super.startCapture().then(on: .sdk) { [weak self] didStart -> Promise<Bool> in
 
-        let devices = CameraCapturer.captureDevices()
-        // TODO: FaceTime Camera for macOS uses .unspecified, fall back to first device
+            guard let self = self, didStart else {
+                // already started
+                return Promise(false)
+            }
 
-        guard let device = devices.first(where: { $0.position == options.position }) ?? devices.first else {
-            log("No camera video capture devices available", .error)
-            return Promise(TrackError.capturer(message: "No camera video capture devices available"))
-        }
+            let preferredPixelFormat = self.capturer.preferredOutputPixelFormat()
+            self.log("CameraCapturer.preferredPixelFormat: \(preferredPixelFormat.toString())")
 
-        // list of all formats in order of dimensions size
-        let formats = DispatchQueue.webRTC.sync { RTCCameraVideoCapturer.supportedFormats(for: device) }
-        // create a dictionary sorted by dimensions size
-        let sortedFormats = OrderedDictionary(uniqueKeysWithValues: formats.map { ($0, CMVideoFormatDescriptionGetDimensions($0.formatDescription)) })
-            .sorted { $0.value.area < $1.value.area }
+            let devices = CameraCapturer.captureDevices()
+            // TODO: FaceTime Camera for macOS uses .unspecified, fall back to first device
 
-        // default to the smallest
-        var selectedFormat = sortedFormats.first
+            guard let device = devices.first(where: { $0.position == self.options.position }) ?? devices.first else {
+                self.log("No camera video capture devices available", .error)
+                throw TrackError.capturer(message: "No camera video capture devices available")
+            }
 
-        // find preferred capture format if specified in options
-        if let preferredFormat = options.preferredFormat,
-           let foundFormat = sortedFormats.first(where: { $0.key == preferredFormat }) {
-            selectedFormat = foundFormat
-        } else {
-            log("formats: \(sortedFormats.map { String(describing: $0.value) }), target: \(options.dimensions)")
-            // find format that satisfies preferred dimensions
-            selectedFormat = sortedFormats.first(where: { $0.value.area >= options.dimensions.area })
-        }
+            // list of all formats in order of dimensions size
+            let formats = DispatchQueue.webRTC.sync { RTCCameraVideoCapturer.supportedFormats(for: device) }
+            // create a dictionary sorted by dimensions size
+            let sortedFormats = OrderedDictionary(uniqueKeysWithValues: formats.map { ($0, CMVideoFormatDescriptionGetDimensions($0.formatDescription)) })
+                .sorted { $0.value.area < $1.value.area }
 
-        // format should be resolved at this point
-        guard let selectedFormat = selectedFormat else {
-            log("Unable to resolve format", .error)
-            return Promise(TrackError.capturer(message: "Unable to determine format for camera capturer"))
-        }
+            // default to the smallest
+            var selectedFormat = sortedFormats.first
 
-        // ensure fps is within range
-        let fpsRange = selectedFormat.key.videoSupportedFrameRateRanges
-            .reduce((min: Int.max, max: 0)) { (min($0.min, Int($1.minFrameRate)), max($0.max, Int($1.maxFrameRate)) ) }
-        log("fpsRange: \(fpsRange)")
+            // find preferred capture format if specified in options
+            if let preferredFormat = self.options.preferredFormat,
+               let foundFormat = sortedFormats.first(where: { $0.key == preferredFormat }) {
+                selectedFormat = foundFormat
+            } else {
+                self.log("formats: \(sortedFormats.map { String(describing: $0.value) }), target: \(self.options.dimensions)")
+                // find format that satisfies preferred dimensions
+                selectedFormat = sortedFormats.first(where: { $0.value.area >= self.options.dimensions.area })
+            }
 
-        guard options.fps >= fpsRange.min && options.fps <= fpsRange.max else {
-            return Promise(TrackError.capturer(message: "Requested framerate is out of range (\(fpsRange)"))
-        }
+            // format should be resolved at this point
+            guard let selectedFormat = selectedFormat else {
+                self.log("Unable to resolve format", .error)
+                throw TrackError.capturer(message: "Unable to determine format for camera capturer")
+            }
 
-        log("Starting camera capturer device: \(device), format: \(selectedFormat), fps: \(options.fps)", .info)
+            // ensure fps is within range
+            let fpsRange = selectedFormat.key.videoSupportedFrameRateRanges
+                .reduce((min: Int.max, max: 0)) { (min($0.min, Int($1.minFrameRate)), max($0.max, Int($1.maxFrameRate)) ) }
+            self.log("fpsRange: \(fpsRange)")
 
-        // adapt if requested dimensions and camera's dimensions don't match
-        if let videoSource = delegate as? RTCVideoSource,
-           selectedFormat.value != options.dimensions {
+            guard self.options.fps >= fpsRange.min && self.options.fps <= fpsRange.max else {
+                throw TrackError.capturer(message: "Requested framerate is out of range (\(fpsRange)")
+            }
 
-            // self.log("adaptOutputFormat to: \(options.dimensions) fps: \(self.options.fps)")
-            videoSource.adaptOutputFormat(toWidth: options.dimensions.width,
-                                          height: options.dimensions.height,
-                                          fps: Int32(options.fps))
-        }
+            self.log("Starting camera capturer device: \(device), format: \(selectedFormat), fps: \(self.options.fps)", .info)
 
-        return super.startCapture().then(on: .sdk) {
+            // adapt if requested dimensions and camera's dimensions don't match
+            if let videoSource = self.delegate as? RTCVideoSource,
+               selectedFormat.value != self.options.dimensions {
+
+                // self.log("adaptOutputFormat to: \(options.dimensions) fps: \(self.options.fps)")
+                videoSource.adaptOutputFormat(toWidth: self.options.dimensions.width,
+                                              height: self.options.dimensions.height,
+                                              fps: Int32(self.options.fps))
+            }
+
             // return promise that waits for capturer to start
-            Promise(on: .webRTC) { resolve, fail in
+            return Promise<Bool>(on: .webRTC) { resolve, fail in
+                // start the RTCCameraVideoCapturer
                 self.capturer.startCapture(with: device, format: selectedFormat.key, fps: self.options.fps) { error in
                     if let error = error {
                         self.log("CameraCapturer failed to start \(error)", .error)
@@ -150,22 +157,30 @@ public class CameraCapturer: VideoCapturer {
                     self.dimensions = self.options.dimensions
 
                     // successfully started
-                    resolve(())
+                    resolve(true)
                 }
             }
         }
     }
 
-    public override func stopCapture() -> Promise<Void> {
-        return super.stopCapture().then(on: .sdk) {
-            Promise(on: .webRTC) { resolve, _ in
+    public override func stopCapture() -> Promise<Bool> {
+
+        super.stopCapture().then(on: .sdk) { [weak self] didStop -> Promise<Bool> in
+
+            guard let self = self, didStop else {
+                // already stopped
+                return Promise(false)
+            }
+
+            return Promise<Bool>(on: .webRTC) { resolve, _ in
+                // stop the RTCCameraVideoCapturer
                 self.capturer.stopCapture {
                     // update internal vars
                     self.device = nil
                     self.dimensions = nil
 
                     // successfully stopped
-                    resolve(())
+                    resolve(true)
                 }
             }
         }

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -165,9 +165,9 @@ public class CameraCapturer: VideoCapturer {
 
     public override func stopCapture() -> Promise<Bool> {
 
-        super.stopCapture().then(on: .sdk) { [weak self] didStop -> Promise<Bool> in
+        super.stopCapture().then(on: .sdk) { didStop -> Promise<Bool> in
 
-            guard let self = self, didStop else {
+            guard didStop else {
                 // already stopped
                 return Promise(false)
             }

--- a/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
@@ -31,9 +31,9 @@ public class InAppScreenCapturer: VideoCapturer {
 
     public override func startCapture() -> Promise<Bool> {
 
-        super.startCapture().then(on: .sdk) { [weak self] didStart -> Promise<Bool> in
+        super.startCapture().then(on: .sdk) {didStart -> Promise<Bool> in
 
-            guard let self = self, didStart else {
+            guard didStart else {
                 // already started
                 return Promise(false)
             }
@@ -71,13 +71,15 @@ public class InAppScreenCapturer: VideoCapturer {
     }
 
     public override func stopCapture() -> Promise<Bool> {
-        return super.stopCapture().then(on: .sdk) { didStop -> Promise<Bool> in
-            Promise<Bool>(on: .sdk) { resolve, fail in
 
-                guard didStop else {
-                    resolve(false)
-                    return
-                }
+        super.stopCapture().then(on: .sdk) { didStop -> Promise<Bool> in
+
+            guard didStop else {
+                // already stopped
+                return Promise(false)
+            }
+
+            return Promise<Bool>(on: .sdk) { resolve, fail in
 
                 RPScreenRecorder.shared().stopCapture { error in
                     if let error = error {

--- a/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
@@ -29,9 +29,17 @@ public class InAppScreenCapturer: VideoCapturer {
         super.init(delegate: delegate)
     }
 
-    public override func startCapture() -> Promise<Void> {
-        return super.startCapture().then(on: .sdk) {
-            Promise(on: .sdk) { resolve, fail in
+    public override func startCapture() -> Promise<Bool> {
+
+        super.startCapture().then(on: .sdk) { [weak self] didStart -> Promise<Bool> in
+
+            guard let self = self, didStart else {
+                // already started
+                return Promise(false)
+            }
+
+            return Promise<Bool>(on: .sdk) { resolve, fail in
+
                 // TODO: force pixel format kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
                 RPScreenRecorder.shared().startCapture { sampleBuffer, type, _ in
                     if type == .video {
@@ -56,21 +64,27 @@ public class InAppScreenCapturer: VideoCapturer {
                         fail(error)
                         return
                     }
-                    resolve(())
+                    resolve(true)
                 }
             }
         }
     }
 
-    public override func stopCapture() -> Promise<Void> {
-        return super.stopCapture().then(on: .sdk) {
-            Promise(on: .sdk) { resolve, fail in
+    public override func stopCapture() -> Promise<Bool> {
+        return super.stopCapture().then(on: .sdk) { didStop -> Promise<Bool> in
+            Promise<Bool>(on: .sdk) { resolve, fail in
+
+                guard didStop else {
+                    resolve(false)
+                    return
+                }
+
                 RPScreenRecorder.shared().stopCapture { error in
                     if let error = error {
                         fail(error)
                         return
                     }
-                    resolve(())
+                    resolve(true)
                 }
 
             }

--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -165,9 +165,9 @@ public class MacOSScreenCapturer: VideoCapturer {
 
     public override func startCapture() -> Promise<Bool> {
 
-        super.startCapture().then(on: .sdk) { [weak self] didStart -> Bool in
+        super.startCapture().then(on: .sdk) { didStart -> Bool in
 
-            guard let self = self, didStart else {
+            guard didStart else {
                 // already started
                 return false
             }
@@ -202,14 +202,20 @@ public class MacOSScreenCapturer: VideoCapturer {
 
     public override func stopCapture() -> Promise<Bool> {
         log()
-        return super.stopCapture().then(on: .sdk) { didStop in
-            if didStop {
-                if case .display = self.source {
-                    self.session.stopRunning()
-                } else if case .window = self.source {
-                    self.stopDispatchSourceTimer()
-                }
+        return super.stopCapture().then(on: .sdk) { didStop -> Bool in
+
+            guard didStop else {
+                // already stopped
+                return false
             }
+
+            if case .display = self.source {
+                self.session.stopRunning()
+            } else if case .window = self.source {
+                self.stopDispatchSourceTimer()
+            }
+
+            return true
         }
     }
 }

--- a/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
@@ -133,9 +133,9 @@ public class VideoCapturer: MulticastDelegate<VideoCapturerDelegate>, VideoCaptu
     // returns true if state updated
     public func startCapture() -> Promise<Bool> {
 
-        Promise(on: .sdk) { [weak self] () -> Bool in
+        Promise(on: .sdk) { () -> Bool in
 
-            guard let self = self, self.state != .started else {
+            guard self.state != .started else {
                 // already started
                 return false
             }
@@ -149,9 +149,9 @@ public class VideoCapturer: MulticastDelegate<VideoCapturerDelegate>, VideoCaptu
     // returns true if state updated
     public func stopCapture() -> Promise<Bool> {
 
-        Promise(on: .sdk) { [weak self] () -> Bool in
+        Promise(on: .sdk) { () -> Bool in
 
-            guard let self = self, self.state != .stopped else {
+            guard self.state != .stopped else {
                 // already stopped
                 return false
             }

--- a/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
@@ -116,8 +116,6 @@ public class VideoCapturer: MulticastDelegate<VideoCapturerDelegate>, VideoCaptu
 
     internal weak var delegate: RTCVideoCapturerDelegate?
 
-    internal let dimensionsResolved = Promise<Dimensions>.pending()
-
     public internal(set) var dimensions: Dimensions? {
         didSet {
             guard oldValue != dimensions else { return }

--- a/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
@@ -58,16 +58,22 @@ public class LocalAudioTrack: LocalTrack, AudioTrack {
     }
 
     @discardableResult
-    internal override func publish() -> Promise<Void> {
-        super.publish().then(on: .sdk) {
-            AudioManager.shared.trackDidStart(.local)
+    internal override func onPublish() -> Promise<Bool> {
+        super.onPublish().then(on: .sdk) { didPublish -> Bool in
+            if didPublish {
+                AudioManager.shared.trackDidStart(.local)
+            }
+            return didPublish
         }
     }
 
     @discardableResult
-    internal override func unpublish() -> Promise<Void> {
-        super.unpublish().then(on: .sdk) {
-            AudioManager.shared.trackDidStop(.local)
+    internal override func onUnpublish() -> Promise<Bool> {
+        super.onUnpublish().then(on: .sdk) { didUnpublish -> Bool in
+            if didUnpublish {
+                AudioManager.shared.trackDidStop(.local)
+            }
+            return didUnpublish
         }
     }
 }

--- a/Sources/LiveKit/Track/Local/LocalTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalTrack.swift
@@ -53,9 +53,9 @@ public class LocalTrack: Track {
     // returns true if state updated
     internal func onPublish() -> Promise<Bool> {
 
-        Promise<Bool>(on: .sdk) { [weak self] () -> Bool in
+        Promise<Bool>(on: .sdk) { () -> Bool in
 
-            guard let self = self, self.publishState != .published else {
+            guard self.publishState != .published else {
                 // already published
                 return false
             }
@@ -68,9 +68,9 @@ public class LocalTrack: Track {
     // returns true if state updated
     internal func onUnpublish() -> Promise<Bool> {
 
-        Promise<Bool>(on: .sdk) { [weak self] () -> Bool in
+        Promise<Bool>(on: .sdk) { () -> Bool in
 
-            guard let self = self, self.publishState != .unpublished else {
+            guard self.publishState != .unpublished else {
                 // already unpublished
                 return false
             }

--- a/Sources/LiveKit/Track/Local/LocalTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalTrack.swift
@@ -32,9 +32,9 @@ public class LocalTrack: Track {
         // Already muted
         if muted { return Promise(()) }
 
-        return disable().then(on: .sdk) {
+        return disable().then(on: .sdk) { _ in
             self.stop()
-        }.then(on: .sdk) {
+        }.then(on: .sdk) { _ -> Void in
             self.set(muted: true, shouldSendSignal: true)
         }
     }
@@ -43,32 +43,40 @@ public class LocalTrack: Track {
         // Already un-muted
         if !muted { return Promise(()) }
 
-        return enable().then(on: .sdk) {
+        return enable().then(on: .sdk) { _ in
             self.start()
-        }.then(on: .sdk) {
+        }.then(on: .sdk) { _ -> Void in
             self.set(muted: false, shouldSendSignal: true)
         }
     }
 
-    internal func publish() -> Promise<Void> {
+    // returns true if state updated
+    internal func onPublish() -> Promise<Bool> {
 
-        Promise(on: .sdk) {
-            guard self.publishState != .published else {
-                throw TrackError.state(message: "Already published")
+        Promise<Bool>(on: .sdk) { [weak self] () -> Bool in
+
+            guard let self = self, self.publishState != .published else {
+                // already published
+                return false
             }
 
             self.publishState = .published
+            return true
         }
     }
 
-    internal func unpublish() -> Promise<Void> {
+    // returns true if state updated
+    internal func onUnpublish() -> Promise<Bool> {
 
-        Promise(on: .sdk) {
-            guard self.publishState != .unpublished else {
-                throw TrackError.state(message: "Already unpublished")
+        Promise<Bool>(on: .sdk) { [weak self] () -> Bool in
+
+            guard let self = self, self.publishState != .unpublished else {
+                // already unpublished
+                return false
             }
 
             self.publishState = .unpublished
+            return true
         }
     }
 }

--- a/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
@@ -30,16 +30,22 @@ class RemoteAudioTrack: RemoteTrack, AudioTrack {
     }
 
     @discardableResult
-    override func start() -> Promise<Void> {
-        super.start().then(on: .sdk) {
-            AudioManager.shared.trackDidStart(.remote)
+    override func start() -> Promise<Bool> {
+        super.start().then(on: .sdk) { didStart -> Bool in
+            if didStart {
+                AudioManager.shared.trackDidStart(.remote)
+            }
+            return didStart
         }
     }
 
     @discardableResult
-    override public func stop() -> Promise<Void> {
-        super.stop().then(on: .sdk) {
-            AudioManager.shared.trackDidStop(.remote)
+    override public func stop() -> Promise<Bool> {
+        super.stop().then(on: .sdk) { didStop -> Bool in
+            if didStop {
+                AudioManager.shared.trackDidStop(.remote)
+            }
+            return didStop
         }
     }
 }

--- a/Sources/LiveKit/Track/Remote/RemoteTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteTrack.swift
@@ -19,16 +19,16 @@ import Promises
 public class RemoteTrack: Track {
 
     @discardableResult
-    override func start() -> Promise<Void> {
-        super.start().then(on: .sdk) {
-            super.enable()
+    override func start() -> Promise<Bool> {
+        super.start().then(on: .sdk) { didStart in
+            self.enable().then { _ in didStart }
         }
     }
 
     @discardableResult
-    override public func stop() -> Promise<Void> {
-        super.stop().then(on: .sdk) {
-            super.disable()
+    override public func stop() -> Promise<Bool> {
+        super.stop().then(on: .sdk) { didStop in
+            super.disable().then { _ in didStop }
         }
     }
 }

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -82,35 +82,61 @@ public class Track: MulticastDelegate<TrackDelegate> {
         log()
     }
 
-    // will fail if already started (to prevent duplicate code execution)
-    internal func start() -> Promise<Void> {
-        guard state != .started else {
-            return Promise(TrackError.state(message: "Already started"))
-        }
+    // returns true if updated state
+    internal func start() -> Promise<Bool> {
 
-        self.state = .started
-        return Promise(())
+        Promise(on: .sdk) { [weak self] () -> Bool in
+
+            guard let self = self, self.state != .started else {
+                // already started
+                return false
+            }
+
+            self.state = .started
+            return true
+        }
     }
 
-    // will fail if already stopped (to prevent duplicate code execution)
-    public func stop() -> Promise<Void> {
-        guard state != .stopped else {
-            return Promise(TrackError.state(message: "Already stopped"))
-        }
+    // returns true if updated state
+    public func stop() -> Promise<Bool> {
 
-        self.state = .stopped
-        return Promise(())
+        Promise(on: .sdk) { [weak self] () -> Bool in
+
+            guard let self = self, self.state != .stopped else {
+                // already stopped
+                return false
+            }
+
+            self.state = .stopped
+            return true
+        }
     }
 
-    internal func enable() -> Promise<Void> {
-        Promise(on: .sdk) {
+    internal func enable() -> Promise<Bool> {
+
+        Promise(on: .sdk) { [weak self] () -> Bool in
+
+            guard let self = self, !self.mediaTrack.isEnabled else {
+                // already enabled
+                return false
+            }
+
             self.mediaTrack.isEnabled = true
+            return true
         }
     }
 
-    internal func disable() -> Promise<Void> {
-        Promise(on: .sdk) {
+    internal func disable() -> Promise<Bool> {
+
+        Promise(on: .sdk) { [weak self] () -> Bool in
+
+            guard let self = self, self.mediaTrack.isEnabled else {
+                // already disabled
+                return false
+            }
+
             self.mediaTrack.isEnabled = false
+            return true
         }
     }
 

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -85,9 +85,9 @@ public class Track: MulticastDelegate<TrackDelegate> {
     // returns true if updated state
     internal func start() -> Promise<Bool> {
 
-        Promise(on: .sdk) { [weak self] () -> Bool in
+        Promise(on: .sdk) { () -> Bool in
 
-            guard let self = self, self.state != .started else {
+            guard self.state != .started else {
                 // already started
                 return false
             }
@@ -100,9 +100,9 @@ public class Track: MulticastDelegate<TrackDelegate> {
     // returns true if updated state
     public func stop() -> Promise<Bool> {
 
-        Promise(on: .sdk) { [weak self] () -> Bool in
+        Promise(on: .sdk) { () -> Bool in
 
-            guard let self = self, self.state != .stopped else {
+            guard self.state != .stopped else {
                 // already stopped
                 return false
             }
@@ -114,9 +114,9 @@ public class Track: MulticastDelegate<TrackDelegate> {
 
     internal func enable() -> Promise<Bool> {
 
-        Promise(on: .sdk) { [weak self] () -> Bool in
+        Promise(on: .sdk) { () -> Bool in
 
-            guard let self = self, !self.mediaTrack.isEnabled else {
+            guard !self.mediaTrack.isEnabled else {
                 // already enabled
                 return false
             }
@@ -128,9 +128,9 @@ public class Track: MulticastDelegate<TrackDelegate> {
 
     internal func disable() -> Promise<Bool> {
 
-        Promise(on: .sdk) { [weak self] () -> Bool in
+        Promise(on: .sdk) { () -> Bool in
 
-            guard let self = self, self.mediaTrack.isEnabled else {
+            guard self.mediaTrack.isEnabled else {
                 // already disabled
                 return false
             }


### PR DESCRIPTION
Change logic to not rely on **throws** for non-critical errors etc.
For example before it throws for `Track.start()` if already started. Same with `VideoCapturer.startCapture()` etc. This wasn't a good design.

Looks like a long PR but it's actually simple...