### PR TITLE
Fixes that were discussed

### DIFF
--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -506,13 +506,11 @@ extension Room: EngineDelegate {
 
             // only if quick-reconnect
             if case .connected = state.connectionState, case .quick = state.reconnectMode {
+
                 sendSyncState().catch(on: .sdk) { error in
                     self.log("Failed to sendSyncState, error: \(error)", .error)
                 }
-            }
 
-            // alwayws re-send track settings on a reconnect
-            if state.didReconnect {
                 sendTrackSettings().catch(on: .sdk) { error in
                     self.log("Failed to sendTrackSettings, error: \(error)", .error)
                 }

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -37,7 +37,6 @@ public class Room: MulticastDelegate<RoomDelegate> {
     public var url: String? { engine._state.url }
     public var token: String? { engine._state.token }
     public var connectionState: ConnectionState { engine._state.connectionState }
-    public var didReconnect: Bool { engine._state.didReconnect }
     public var connectStopwatch: Stopwatch { engine._state.connectStopwatch }
 
     // MARK: - Internal
@@ -231,10 +230,12 @@ internal extension Room {
 
         log("resetting track settings...")
 
+        // create an array of RemoteTrackPublication
         let remoteTrackPublications = _state.remoteParticipants.values.map {
             $0._state.tracks.values.compactMap { $0 as? RemoteTrackPublication }
         }.joined()
 
+        // reset track settings for all RemoteTrackPublication
         for publication in remoteTrackPublications {
             publication.resetTrackSettings()
         }

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -227,17 +227,17 @@ extension Room {
 
 internal extension Room {
 
-    func sendTrackSettings() -> Promise<Void> {
-        log()
+    func resetTrackSettings() {
 
-        let promises = _state.remoteParticipants.values.map {
-            $0._state.tracks.values
-                .compactMap { $0 as? RemoteTrackPublication }
-                .filter { $0.subscribed }
-                .map { $0.sendCurrentTrackSettings() }
+        log("resetting track settings...")
+
+        let remoteTrackPublications = _state.remoteParticipants.values.map {
+            $0._state.tracks.values.compactMap { $0 as? RemoteTrackPublication }
         }.joined()
 
-        return promises.all(on: .sdk)
+        for publication in remoteTrackPublications {
+            publication.resetTrackSettings()
+        }
     }
 
     func sendSyncState() -> Promise<Void> {
@@ -511,9 +511,7 @@ extension Room: EngineDelegate {
                     self.log("Failed to sendSyncState, error: \(error)", .error)
                 }
 
-                sendTrackSettings().catch(on: .sdk) { error in
-                    self.log("Failed to sendTrackSettings, error: \(error)", .error)
-                }
+                resetTrackSettings()
             }
 
             notify { $0.room(self, didUpdate: state.connectionState, oldValue: oldState.connectionState) }

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -491,12 +491,8 @@ internal extension SignalClient {
     }
 
     func sendUpdateTrackSettings(sid: Sid, settings: TrackSettings) -> Promise<Void> {
-        log("sid: \(sid), settings: \(settings)")
-        // we have to send either width/height or quality. when both are sent, width/height are used.
-        if settings.enabled, settings.dimensions == .zero && settings.videoQuality == .low {
-            assert(false, "either width/height or quality is not set while enabling")
-            log("either width/height or quality is not set while enabling", .warning)
-        }
+
+        log("sending track settings... sid: \(sid), settings: \(settings)")
 
         let r = Livekit_SignalRequest.with {
             $0.trackSetting = Livekit_UpdateTrackSettings.with {

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -334,9 +334,11 @@ extension RemoteTrackPublication {
         send(trackSettings: newSettings).then(on: .main) {
             self.trackSettings = newSettings
         }.catch(on: .main) { [weak self] error in
-            self?.log("[adaptiveStream] failed to send trackSettings, sid: \(sid) error: \(error)", .error)
+            guard let self = self else { return }
+            self.log("[adaptiveStream] failed to send trackSettings, sid: \(self.sid) error: \(error)", .error)
         }.always(on: .main) { [weak self] in
-            self?.asTimer.restart()
+            guard let self = self else { return }
+            self.asTimer.restart()
         }
     }
 }

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -325,6 +325,12 @@ extension RemoteTrackPublication {
             return
         }
 
+        // log when flipping from enabled -> disabled
+        if !newSettings.enabled, trackSettings.enabled {
+            let viewsString = asViews.enumerated().map { (i, view) in "view\(i).isVisible: \(view.isVisible)(didLayout: \(view._state.didLayout), isHidden: \(view._state.isHidden), isEnabled: \(view._state.isEnabled))" }.joined(separator: ", ")
+            log("[adaptiveStream] disabling track sid: \(sid), viewCount: \(asViews.count), \(viewsString)")
+        }
+
         send(trackSettings: newSettings).then(on: .main) {
             self.trackSettings = newSettings
         }.catch(on: .main) { [weak self] error in

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -231,8 +231,6 @@ extension RemoteTrackPublication {
 
     // Send new track settings
     internal func send(trackSettings: TrackSettings) -> Promise<Void> {
-        // no-update
-        guard self.trackSettings != trackSettings else { return Promise(()) }
 
         guard let participant = participant else {
             log("Participant is nil", .warning)

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -124,6 +124,9 @@ public class RemoteTrackPublication: TrackPublication {
 
     @discardableResult
     internal override func set(track newValue: Track?) -> Track? {
+
+        log("RemoteTrackPublication set track: \(String(describing: track))")
+
         let oldValue = super.set(track: newValue)
         if newValue != oldValue {
             // always suspend adaptiveStream timer first
@@ -219,14 +222,9 @@ internal extension RemoteTrackPublication {
 extension RemoteTrackPublication {
 
     // Simply send current track settings without any checks
-    internal func sendCurrentTrackSettings() -> Promise<Void> {
-
-        guard let participant = participant else {
-            log("Participant is nil", .warning)
-            return Promise(EngineError.state(message: "Participant is nil"))
-        }
-
-        return participant.room.engine.signalClient.sendUpdateTrackSettings(sid: sid, settings: self.trackSettings)
+    internal func resetTrackSettings() {
+        let adaptiveStreamEnabled = (participant?.room.options ?? RoomOptions()).adaptiveStream && .video == track?.kind
+        self.trackSettings = TrackSettings(enabled: !adaptiveStreamEnabled)
     }
 
     // Send new track settings

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -165,6 +165,18 @@ public class RemoteTrackPublication: TrackPublication {
 
 private extension RemoteTrackPublication {
 
+    var isAdaptiveStreamEnabled: Bool { (participant?.room.options ?? RoomOptions()).adaptiveStream && .video == kind }
+
+    var engineConnectionState: ConnectionState {
+
+        guard let participant = participant else {
+            log("Participant is nil", .warning)
+            return .disconnected()
+        }
+
+        return participant.room.engine._state.connectionState
+    }
+
     var userCanModifyTrackSettings: Bool {
 
         // adaptiveStream must be disabled and must be subscribed
@@ -209,28 +221,16 @@ internal extension RemoteTrackPublication {
 
 // MARK: - TrackSettings
 
-extension RemoteTrackPublication {
-
-    internal var isAdaptiveStreamEnabled: Bool { (participant?.room.options ?? RoomOptions()).adaptiveStream && .video == kind }
-
-    internal var engineConnectionState: ConnectionState {
-
-        guard let participant = participant else {
-            log("Participant is nil", .warning)
-            return .disconnected()
-        }
-
-        return participant.room.engine._state.connectionState
-    }
+internal extension RemoteTrackPublication {
 
     // reset track settings
-    internal func resetTrackSettings() {
+    func resetTrackSettings() {
         // track is initially disabled when adaptive stream is enabled
         _state.mutate { $0.trackSettings = TrackSettings(enabled: !isAdaptiveStreamEnabled) }
     }
 
     // simply send track settings
-    internal func send(trackSettings: TrackSettings) -> Promise<Void> {
+    func send(trackSettings: TrackSettings) -> Promise<Void> {
 
         guard let participant = participant else {
             log("Participant is nil", .warning)

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -119,6 +119,8 @@ public class RemoteTrackPublication: TrackPublication {
         // attempt to set the new settings
         return checkCanModifyTrackSettings().then(on: .sdk) {
             self.send(trackSettings: newSettings)
+        }.then(on: .sdk) {
+            self.trackSettings = newSettings
         }
     }
 
@@ -227,7 +229,7 @@ extension RemoteTrackPublication {
         self.trackSettings = TrackSettings(enabled: !adaptiveStreamEnabled)
     }
 
-    // Send new track settings
+    // simply send track settings
     internal func send(trackSettings: TrackSettings) -> Promise<Void> {
 
         guard let participant = participant else {

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -225,7 +225,7 @@ extension RemoteTrackPublication {
 
     // Simply send current track settings without any checks
     internal func resetTrackSettings() {
-        let adaptiveStreamEnabled = (participant?.room.options ?? RoomOptions()).adaptiveStream && .video == track?.kind
+        let adaptiveStreamEnabled = (participant?.room.options ?? RoomOptions()).adaptiveStream && .video == kind
         self.trackSettings = TrackSettings(enabled: !adaptiveStreamEnabled)
     }
 
@@ -302,7 +302,7 @@ extension RemoteTrackPublication {
         let asViews = track?.videoViews.allObjects ?? []
 
         if asViews.count > 1 {
-            log("[adaptiveStream] multiple VideoViews attached, count: \(asViews.count), trackId: \(track?.sid ?? "") views: (\(asViews.map { "\($0.hashValue)" }.joined(separator: ", ")))", .warning)
+            log("[adaptiveStream] multiple VideoViews attached, sid: \(sid), count: \(asViews.count), views: (\(asViews.map { "\($0.hashValue)" }.joined(separator: ", ")))", .warning)
         }
 
         let enabled = asViews.hasVisible()
@@ -328,13 +328,13 @@ extension RemoteTrackPublication {
         // log when flipping from enabled -> disabled
         if !newSettings.enabled, trackSettings.enabled {
             let viewsString = asViews.enumerated().map { (i, view) in "view\(i).isVisible: \(view.isVisible)(didLayout: \(view._state.didLayout), isHidden: \(view._state.isHidden), isEnabled: \(view._state.isEnabled))" }.joined(separator: ", ")
-            log("[adaptiveStream] disabling track sid: \(sid), viewCount: \(asViews.count), \(viewsString)")
+            log("[adaptiveStream] disabling sid: \(sid), viewCount: \(asViews.count), \(viewsString)")
         }
 
         send(trackSettings: newSettings).then(on: .main) {
             self.trackSettings = newSettings
         }.catch(on: .main) { [weak self] error in
-            self?.log("[adaptiveStream] failed to send trackSettings, error: \(error)", .error)
+            self?.log("[adaptiveStream] failed to send trackSettings, sid: \(sid) error: \(error)", .error)
         }.always(on: .main) { [weak self] in
             self?.asTimer.restart()
         }

--- a/Sources/LiveKit/Publications/TrackPublication.swift
+++ b/Sources/LiveKit/Publications/TrackPublication.swift
@@ -54,8 +54,11 @@ public class TrackPublication: TrackDelegate, Loggable {
         var mimeType: String
         var simulcasted: Bool = false
         var dimensions: Dimensions?
+        // subscription permission
+        var subscriptionAllowed = true
         //
         var streamState: StreamState = .paused
+        var trackSettings = TrackSettings()
     }
 
     internal var _state: StateSync<State>

--- a/Sources/LiveKit/Support/NativeView.swift
+++ b/Sources/LiveKit/Support/NativeView.swift
@@ -30,7 +30,6 @@ public class NativeView: NativeViewType {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        shouldPrepare()
     }
 
     required init?(coder: NSCoder) {
@@ -40,28 +39,23 @@ public class NativeView: NativeViewType {
     #if os(iOS)
     public override func layoutSubviews() {
         super.layoutSubviews()
-        shouldLayout()
+        performLayout()
     }
     #else
     public override func layout() {
         super.layout()
-        shouldLayout()
+        performLayout()
     }
     #endif
 
-    func markNeedsLayout() {
-        #if os(iOS)
-        setNeedsLayout()
-        #else
+    #if os(macOS)
+    // for compatibility with macOS
+    func setNeedsLayout() {
         needsLayout = true
-        #endif
     }
+    #endif
 
-    func shouldPrepare() {
-        //
-    }
-
-    func shouldLayout() {
+    func performLayout() {
         //
     }
 }

--- a/Sources/LiveKit/Support/TextView.swift
+++ b/Sources/LiveKit/Support/TextView.swift
@@ -82,8 +82,8 @@ internal class TextView: NativeView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func shouldLayout() {
-        super.shouldLayout()
+    override func performLayout() {
+        super.performLayout()
         _textView.frame = bounds
     }
 }

--- a/Sources/LiveKit/Types/ConnectionState.swift
+++ b/Sources/LiveKit/Types/ConnectionState.swift
@@ -101,15 +101,3 @@ protocol ReconnectableState {
     var reconnectMode: ReconnectMode? { get }
     var connectionState: ConnectionState { get }
 }
-
-extension ReconnectableState {
-
-    var didReconnect: Bool {
-
-        if case .connected = connectionState, [.full, .quick].contains(reconnectMode) {
-            return true
-        }
-
-        return false
-    }
-}

--- a/Sources/LiveKit/Types/TrackSettings.swift
+++ b/Sources/LiveKit/Types/TrackSettings.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-internal struct TrackSettings {
+internal struct TrackSettings: Equatable {
 
     let enabled: Bool
     let dimensions: Dimensions
@@ -35,14 +35,5 @@ internal struct TrackSettings {
         TrackSettings(enabled: enabled ?? self.enabled,
                       dimensions: dimensions ?? self.dimensions,
                       videoQuality: videoQuality ?? self.videoQuality)
-    }
-}
-
-extension TrackSettings: Equatable {
-
-    static func == (lhs: TrackSettings, rhs: TrackSettings) -> Bool {
-        lhs.enabled == rhs.enabled
-            && lhs.dimensions == rhs.dimensions
-            && lhs.videoQuality == rhs.videoQuality
     }
 }

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -192,7 +192,7 @@ public class VideoView: NativeView, Loggable {
                         if let frame = track._state.videoFrame {
                             self.log("rendering cached frame tack: \(track._state.sid ?? "nil")")
                             nr.renderFrame(frame)
-                            self.markNeedsLayout()
+                            self.setNeedsLayout()
                         }
 
                         // CapturerDelegate
@@ -226,7 +226,7 @@ public class VideoView: NativeView, Loggable {
 
             if needsLayout {
                 DispatchQueue.mainSafeAsync {
-                    self.markNeedsLayout()
+                    self.setNeedsLayout()
                 }
             }
         }
@@ -240,8 +240,8 @@ public class VideoView: NativeView, Loggable {
         log()
     }
 
-    override func shouldLayout() {
-        super.shouldLayout()
+    override func performLayout() {
+        super.performLayout()
 
         // should always be on main thread
         assert(Thread.current.isMainThread, "must be called on main thread")
@@ -407,7 +407,7 @@ extension VideoView: RTCVideoRenderer {
         defer {
             if _needsLayout {
                 DispatchQueue.mainSafeAsync {
-                    self.markNeedsLayout()
+                    self.setNeedsLayout()
                 }
             }
         }
@@ -454,7 +454,7 @@ extension VideoView: VideoCapturerDelegate {
     public func capturer(_ capturer: VideoCapturer, didUpdate state: VideoCapturer.CapturerState) {
         if case .started = state {
             DispatchQueue.mainSafeAsync {
-                self.markNeedsLayout()
+                self.setNeedsLayout()
             }
         }
     }


### PR DESCRIPTION
- Reset track settings on quick re-connect (resume)
- Remove `didReconnect` (confusing if quick or full)

Few things to confirm:
- [ ] Track settings syncing (sendTrackSettings) is only required for Resume (Quick reconnect) ? 

Todo:
- [x] More logging 