### PR TITLE
Attach custom logger metadata to instance

### DIFF
--- a/Sources/LiveKit/Core/Engine.swift
+++ b/Sources/LiveKit/Core/Engine.swift
@@ -64,6 +64,9 @@ internal class Engine: MulticastDelegate<EngineDelegate> {
         self.roomOptions = roomOptions
         super.init()
 
+        // log sdk & os versions
+        log("sdk: \(LiveKit.version), os: \(String(describing: Utils.os()))(\(Utils.osVersionString())), modelId: \(String(describing: Utils.modelIdentifier() ?? "unknown"))")
+
         signalClient.add(delegate: self)
         ConnectivityListener.shared.add(delegate: self)
 
@@ -80,8 +83,6 @@ internal class Engine: MulticastDelegate<EngineDelegate> {
 
             self.notify { $0.engine(self, didMutate: state, oldState: oldState) }
         }
-
-        log()
     }
 
     deinit {

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -70,6 +70,8 @@ public class Room: MulticastDelegate<RoomDelegate> {
                              roomOptions: roomOptions)
         super.init()
 
+        log()
+
         // listen to engine & signalClient
         engine.add(delegate: self)
         engine.signalClient.add(delegate: self)

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -58,6 +58,8 @@ internal class SignalClient: MulticastDelegate<SignalClientDelegate> {
     init() {
         super.init()
 
+        log()
+
         // trigger events when state mutates
         self._state.onMutate = { [weak self] state, oldState in
 

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -91,6 +91,9 @@ internal class Transport: MulticastDelegate<TransportDelegate> {
         self.pc = pc
 
         super.init()
+
+        log()
+
         DispatchQueue.webRTC.sync { pc.delegate = self }
         add(delegate: delegate)
 

--- a/Sources/LiveKit/Extensions/Logger.swift
+++ b/Sources/LiveKit/Extensions/Logger.swift
@@ -18,26 +18,43 @@ import Foundation
 import Logging
 
 /// Allows to extend with custom `log` method which automatically captures current type (class name).
-internal protocol Loggable: Any {
+public protocol Loggable {
 
 }
 
-internal extension Loggable {
+private var _scopedMetadataKey = "scopedMetadata"
+
+public typealias ScopedMetadata = CustomStringConvertible
+internal typealias ScopedMetadataContainer = [String: ScopedMetadata]
+
+public extension Loggable {
+
+    /// attach logger metadata to this instance that will be automatically included in every log onward
+    func set(scopedMetadata data: ScopedMetadata?, for key: String) {
+        var _data = _scopedMetadata()
+        _data[key] = data
+        objc_setAssociatedObject(self, &_scopedMetadataKey, _data, .OBJC_ASSOCIATION_RETAIN)
+    }
+
+    private func _scopedMetadata() -> ScopedMetadataContainer {
+        (objc_getAssociatedObject(self, &_scopedMetadataKey) as? ScopedMetadataContainer) ?? ScopedMetadataContainer()
+    }
 
     /// Automatically captures current type (class name) to ``Logger.Metadata``
-    func log(_ message: Logger.Message? = nil,
-             _ level: Logger.Level = .debug,
-             file: String = #file,
-             type type_: Any.Type? = nil,
-             function: String = #function,
-             line: UInt = #line) {
+    internal func log(_ message: Logger.Message? = nil,
+                      _ level: Logger.Level = .debug,
+                      file: String = #file,
+                      type type_: Any.Type? = nil,
+                      function: String = #function,
+                      line: UInt = #line) {
 
         logger.log(message ?? "",
                    level,
                    file: file,
                    type: type_ ?? type(of: self),
                    function: function,
-                   line: line)
+                   line: line,
+                   metaData: _scopedMetadata())
     }
 }
 
@@ -50,10 +67,16 @@ internal extension Logger {
              file: String = #file,
              type: Any.Type,
              function: String = #function,
-             line: UInt = #line) {
+             line: UInt = #line,
+             metaData: ScopedMetadataContainer = ScopedMetadataContainer()) {
+
+        func _buildScopedMetadataString() -> String {
+            guard !metaData.isEmpty else { return "" }
+            return " [\(metaData.map { "\($0): \($1)" }.joined(separator: ", "))]"
+        }
 
         log(level: level,
-            "\(String(describing: type)).\(function) \(message)",
+            "\(String(describing: type)).\(function) \(message)\(_buildScopedMetadataString())",
             file: file,
             function: function,
             line: line)

--- a/Sources/LiveKit/Extensions/Logger.swift
+++ b/Sources/LiveKit/Extensions/Logger.swift
@@ -30,7 +30,7 @@ internal typealias ScopedMetadataContainer = [String: ScopedMetadata]
 public extension Loggable {
 
     /// attach logger metadata to this instance that will be automatically included in every log onward
-    func set(scopedMetadata data: ScopedMetadata?, for key: String) {
+    func set(loggerMetadata data: ScopedMetadata?, for key: String) {
         var _data = _scopedMetadata()
         _data[key] = data
         objc_setAssociatedObject(self, &_scopedMetadataKey, _data, .OBJC_ASSOCIATION_RETAIN)

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -314,7 +314,7 @@ extension RemoteTrackPublication {
             let viewsString = asViews.enumerated().map { (i, view) in "view\(i).isVisible: \(view.isVisible)(didLayout: \(view._state.didLayout), isHidden: \(view._state.isHidden), isEnabled: \(view._state.isEnabled))" }.joined(separator: ", ")
             log("[adaptiveStream] disabling sid: \(sid), viewCount: \(asViews.count), \(viewsString)")
         }
-        
+
         if let videoTrack = track?.mediaTrack as? RTCVideoTrack {
             log("VideoTrack.shouldReceive: \(enabled)")
             DispatchQueue.webRTC.sync { videoTrack.shouldReceive = enabled }


### PR DESCRIPTION
Attach custom metadata to any instance of the SDK.
It will be logged together with any call to `log()` on the instance onward.

Useful for attaching app's userId etc to `RemoteParticipant` for example.

I'm not sure if this is what @figelwump was talking about 🙂

<img width="983" alt="スクリーンショット 2022-05-20 3 14 04" src="https://user-images.githubusercontent.com/548776/169371537-c3241264-facf-4ca8-a493-187013497250.png">

