### PR TITLE
VideoView: detect rendering / freeze

### DIFF
--- a/Sources/LiveKit/Protocols/TrackDelegate.swift
+++ b/Sources/LiveKit/Protocols/TrackDelegate.swift
@@ -24,8 +24,8 @@ public protocol TrackDelegate: AnyObject {
     func track(_ track: VideoTrack, didUpdate dimensions: Dimensions?)
     /// Dimensions of the VideoView has updated
     func track(_ track: VideoTrack, videoView: VideoView, didUpdate size: CGSize)
-    /// VideoView updated the render state
-    func track(_ track: VideoTrack, videoView: VideoView, didUpdate renderState: VideoView.RenderState)
+    /// VideoView updated the isRendering property
+    func track(_ track: VideoTrack, videoView: VideoView, didUpdate isRendering: Bool)
     /// A ``VideoView`` was attached to the ``VideoTrack``
     func track(_ track: VideoTrack, didAttach videoView: VideoView)
     /// A ``VideoView`` was detached from the ``VideoTrack``
@@ -41,7 +41,7 @@ public protocol TrackDelegate: AnyObject {
 extension TrackDelegate {
     public func track(_ track: VideoTrack, didUpdate dimensions: Dimensions?) {}
     public func track(_ track: VideoTrack, videoView: VideoView, didUpdate size: CGSize) {}
-    public func track(_ track: VideoTrack, videoView: VideoView, didUpdate renderState: VideoView.RenderState) {}
+    public func track(_ track: VideoTrack, videoView: VideoView, didUpdate isRendering: Bool) {}
     public func track(_ track: VideoTrack, didAttach videoView: VideoView) {}
     public func track(_ track: VideoTrack, didDetach videoView: VideoView) {}
     public func track(_ track: Track, didUpdate muted: Bool, shouldSendSignal: Bool) {}

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -314,7 +314,7 @@ extension RemoteTrackPublication {
             let viewsString = asViews.enumerated().map { (i, view) in "view\(i).isVisible: \(view.isVisible)(didLayout: \(view._state.didLayout), isHidden: \(view._state.isHidden), isEnabled: \(view._state.isEnabled))" }.joined(separator: ", ")
             log("[adaptiveStream] disabling sid: \(sid), viewCount: \(asViews.count), \(viewsString)")
         }
-        
+
         if let videoTrack = track?.mediaTrack as? RTCVideoTrack {
             log("VideoTrack.shouldReceive: \(enabled)")
             DispatchQueue.webRTC.sync { videoTrack.shouldReceive = enabled }

--- a/Sources/LiveKit/Support/StateSync.swift
+++ b/Sources/LiveKit/Support/StateSync.swift
@@ -22,8 +22,8 @@ internal typealias OnStateMutate<Value> = (_ state: Value, _ oldState: Value) ->
 internal final class StateSync<Value> {
 
     // use concurrent queue to allow multiple reads and block writes with barrier.
-    private let queue = DispatchQueue(label: "LiveKitSDK.state", qos: .default,
-                                      attributes: [.concurrent])
+    let queue = DispatchQueue(label: "LiveKitSDK.state", qos: .default,
+                              attributes: [.concurrent])
 
     // actual value
     private var _value: Value

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -24,20 +24,7 @@ public typealias NativeRendererView = NativeViewType & RTCVideoRenderer
 public class VideoView: NativeView, Loggable {
 
     private static let mirrorTransform = CATransform3DMakeScale(-1.0, 1.0, 1.0)
-
-    /// A set of bool values describing the state of rendering.
-    public struct RenderState: OptionSet {
-        public let rawValue: Int
-        public init(rawValue: Int) {
-            self.rawValue = rawValue
-        }
-
-        /// Received first frame and already rendered to the ``VideoView``.
-        /// This can be used to trigger smooth transition of the UI.
-        static let didRenderFirstFrame  = RenderState(rawValue: 1 << 0)
-        /// ``VideoView`` skipped rendering of a frame that could lead to crashes.
-        static let didSkipUnsafeFrame   = RenderState(rawValue: 1 << 1)
-    }
+    private static let _freezeDetectThreshold = 2.0
 
     public enum LayoutMode: String, Codable, CaseIterable {
         case fit
@@ -69,7 +56,9 @@ public class VideoView: NativeView, Loggable {
             _state.mutate {
                 // reset states if track updated
                 if !Self.track($0.track, isEqualWith: newValue) {
-                    $0.renderState = []
+                    $0.renderDate = nil
+                    $0.didRenderFirstFrame = false
+                    $0.isRendering = false
                     $0.rendererSize = nil
                 }
                 $0.track = newValue
@@ -113,14 +102,20 @@ public class VideoView: NativeView, Loggable {
         var rendererSize: CGSize?
         var didLayout: Bool = false
         var layoutMode: LayoutMode = .fill
-
         var mirrorMode: MirrorMode = .auto
-        var renderState = RenderState()
 
         var debugMode: Bool = false
+
+        // render states
+        var renderDate: Date?
+        var didRenderFirstFrame: Bool = false
+        var isRendering: Bool = false
     }
 
     internal var _state: StateSync<State>
+
+    // used for stats timer
+    private lazy var _renderTimer = DispatchQueueTimer(timeInterval: 0.1)
 
     public override init(frame: CGRect = .zero) {
 
@@ -203,9 +198,18 @@ public class VideoView: NativeView, Loggable {
                 }
             }
 
-            // renderState updated
-            if state.renderState != oldState.renderState, let track = state.track {
-                track.notify { $0.track(track, videoView: self, didUpdate: state.renderState) }
+            // isRendering updated
+            if state.isRendering != oldState.isRendering, let track = state.track {
+
+                self.log("isRendering \(oldState.isRendering) -> \(state.isRendering)")
+
+                if state.isRendering {
+                    self._renderTimer.restart()
+                } else {
+                    self._renderTimer.suspend()
+                }
+
+                track.notify { $0.track(track, videoView: self, didUpdate: state.isRendering) }
             }
 
             // viewSize updated
@@ -222,11 +226,26 @@ public class VideoView: NativeView, Loggable {
             if state.debugMode != oldState.debugMode ||
                 state.layoutMode != oldState.layoutMode ||
                 state.mirrorMode != oldState.mirrorMode ||
+                state.didRenderFirstFrame != oldState.didRenderFirstFrame ||
                 shouldRenderDidUpdate || trackDidUpdate {
 
                 // must be on main
                 DispatchQueue.mainSafeAsync {
                     self.setNeedsLayout()
+                }
+            }
+        }
+
+        _renderTimer.handler = { [weak self] in
+
+            guard let self = self else { return }
+
+            self.log("onTimer")
+
+            if self._state.isRendering, let renderDate = self._state.renderDate {
+                let diff = Date().timeIntervalSince(renderDate)
+                if diff >= Self._freezeDetectThreshold {
+                    self._state.mutate { $0.isRendering = false }
                 }
             }
         }
@@ -261,7 +280,7 @@ public class VideoView: NativeView, Loggable {
         if _state.debugMode {
             let _trackSid = _state.track?.sid ?? "nil"
             let _dimensions = _state.track?.dimensions ?? .zero
-            let _didRenderFirstFrame = _state.renderState.contains(.didRenderFirstFrame) ? "true" : "false"
+            let _didRenderFirstFrame = _state.didRenderFirstFrame ? "true" : "false"
             let _viewCount = _state.track?.videoViews.count ?? 0
             let _didLayout = _state.didLayout
             let debugView = ensureDebugTextView()
@@ -456,10 +475,10 @@ extension VideoView: RTCVideoRenderer {
         // cache last rendered frame
         track?.set(videoFrame: frame)
 
-        if !_state.renderState.contains(.didRenderFirstFrame) {
-            _state.mutate { $0.renderState.insert(.didRenderFirstFrame) }
-            self.log("did render first frame, track: \(String(describing: track))")
-            _needsLayout = true
+        _state.mutate {
+            $0.didRenderFirstFrame = true
+            $0.isRendering = true
+            $0.renderDate = Date()
         }
     }
 }


### PR DESCRIPTION
Useful for developers to update UI when frames are not arriving in bad network etc.
Currently there's no way to know if frames are arriving / rendering.

I think @figelwump was suggesting this feature.

Now, (no render) freeze detection is hardcoded to 2.0 seconds.

Simulating bad network:
https://user-images.githubusercontent.com/548776/169492532-2eb7397f-e2ca-490f-9458-34a5227e5d5c.mov


