### PR TITLE
Fix handling of permissions after resubscribe

### DIFF
--- a/Sources/LiveKit/Participant/RemoteParticipant.swift
+++ b/Sources/LiveKit/Participant/RemoteParticipant.swift
@@ -104,6 +104,7 @@ public class RemoteParticipant: Participant {
         }
 
         publication.set(track: track)
+        publication.set(subscriptionAllowed: true)
         track._state.mutate { $0.sid = publication.sid }
 
         addTrack(publication: publication)


### PR DESCRIPTION
When server sends down a subscription, it's implied permissions are
allowed