### PR TITLE
Don't notify initial empty metadata

### DIFF
--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -89,7 +89,9 @@ public class Room: MulticastDelegate<RoomDelegate> {
             guard let self = self else { return }
 
             // metadata updated
-            if let metadata = state.metadata, metadata != oldState.metadata, (oldState.metadata == nil && !metadata.isEmpty) {
+            if let metadata = state.metadata, metadata != oldState.metadata,
+               // don't notify if empty string (first time only)
+               (oldState.metadata == nil ? !metadata.isEmpty : true) {
 
                 self.engine.executeIfConnected { [weak self] in
 

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -82,6 +82,25 @@ public class Room: MulticastDelegate<RoomDelegate> {
 
         // listen to app states
         AppStateListener.shared.add(delegate: self)
+
+        // trigger events when state mutates
+        _state.onMutate = { [weak self] state, oldState in
+
+            guard let self = self else { return }
+
+            // metadata updated
+            if let metadata = state.metadata, metadata != oldState.metadata, (oldState.metadata == nil && !metadata.isEmpty) {
+
+                self.engine.executeIfConnected { [weak self] in
+
+                    guard let self = self else { return }
+
+                    self.notify(label: { "room.didUpdate metadata: \(metadata)" }) {
+                        $0.room(self, didUpdate: metadata)
+                    }
+                }
+            }
+        }
     }
 
     deinit {
@@ -196,27 +215,6 @@ private extension Room {
         }
 
         return participant.cleanUp(notify: true)
-    }
-}
-
-// MARK: - Internal
-
-internal extension Room {
-
-    func set(metadata: String?) {
-        guard self.metadata != metadata else { return }
-
-        self._state.mutate { state in
-            state.metadata = metadata
-        }
-
-        engine.executeIfConnected { [weak self] in
-            guard let self = self else { return }
-
-            self.notify(label: { "room.didUpdate metadata: \(metadata ?? "nil")" }) {
-                $0.room(self, didUpdate: metadata)
-            }
-        }
     }
 }
 
@@ -339,7 +337,7 @@ extension Room: SignalClientDelegate {
     }
 
     func signalClient(_ signalClient: SignalClient, didUpdate room: Livekit_Room) -> Bool {
-        set(metadata: room.metadata)
+        _state.mutate { $0.metadata = room.metadata }
         return true
     }
 

--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -88,7 +88,10 @@ public class Participant: MulticastDelegate<ParticipantDelegate> {
             }
 
             // metadata updated
-            if let metadata = state.metadata, metadata != oldState.metadata, !metadata.isEmpty {
+            if let metadata = state.metadata, metadata != oldState.metadata,
+               // don't notify if empty string (first time only)
+               (oldState.metadata == nil ? !metadata.isEmpty : true) {
+
                 self.notify(label: { "participant.didUpdate metadata: \(metadata)" }) {
                     $0.participant(self, didUpdate: metadata)
                 }

--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -87,12 +87,13 @@ public class Participant: MulticastDelegate<ParticipantDelegate> {
                 }
             }
 
-            if state.metadata != oldState.metadata {
-                self.notify(label: { "participant.didUpdate metadata: \(self.metadata ?? "nil")" }) {
-                    $0.participant(self, didUpdate: self.metadata)
+            // metadata updated
+            if let metadata = state.metadata, metadata != oldState.metadata, !metadata.isEmpty {
+                self.notify(label: { "participant.didUpdate metadata: \(metadata)" }) {
+                    $0.participant(self, didUpdate: metadata)
                 }
-                self.room.notify(label: { "room.didUpdate metadata: \(self.metadata ?? "nil")" }) {
-                    $0.room(self.room, participant: self, didUpdate: self.metadata)
+                self.room.notify(label: { "room.didUpdate metadata: \(metadata)" }) {
+                    $0.room(self.room, participant: self, didUpdate: metadata)
                 }
             }
 


### PR DESCRIPTION
Currently, didUpdate metadata notification is always emitted upon connection (empty string).
Changes this behavior.