### PR TITLE
DispatchQueue improvements

### DIFF
--- a/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
+++ b/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
@@ -20,7 +20,8 @@ class BroadcastScreenCapturer: BufferCapturer {
     var frameReader: SocketConnectionFrameReader?
 
     override func startCapture() -> Promise<Bool> {
-        super.startCapture().then(on: .sdk) {didStart -> Promise<Bool> in
+
+        super.startCapture().then(on: queue) {didStart -> Promise<Bool> in
 
             guard didStart, self.frameReader == nil else {
                 // already started
@@ -64,7 +65,8 @@ class BroadcastScreenCapturer: BufferCapturer {
     }
 
     override func stopCapture() -> Promise<Bool> {
-        super.stopCapture().then(on: .sdk) { didStop -> Promise<Bool> in
+
+        super.stopCapture().then(on: queue) { didStop -> Promise<Bool> in
 
             guard didStop, self.frameReader != nil else {
                 // already stopped

--- a/Sources/LiveKit/Extensions/DispatchQueue.swift
+++ b/Sources/LiveKit/Extensions/DispatchQueue.swift
@@ -18,9 +18,7 @@ import Foundation
 
 internal extension DispatchQueue {
 
-    static let sdk = DispatchQueue(label: "LiveKitSDK", qos: .userInitiated)
     static let webRTC = DispatchQueue(label: "LiveKitSDK.webRTC", qos: .default)
-    static let capture = DispatchQueue(label: "LiveKitSDK.capture", qos: .default)
 
     // if already on main, immediately execute block.
     // if not on main, schedule async.

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -59,18 +59,18 @@ public class LocalParticipant: Participant {
         }
 
         // try to start the track
-        return track.start().then(on: .sdk) { _ -> Promise<Dimensions?> in
+        return track.start().then(on: queue) { _ -> Promise<Dimensions?> in
             // ensure dimensions are resolved for VideoTracks
             guard let track = track as? LocalVideoTrack else { return Promise(nil) }
 
             self.log("[publish] waiting for dimensions to resolve...")
 
             // wait for dimensions
-            return track.capturer._state.mutate { $0.dimensionsCompleter.wait(on: .sdk,
+            return track.capturer._state.mutate { $0.dimensionsCompleter.wait(on: self.queue,
                                                                               .defaultCaptureStart,
-                                                                              throw: { TrackError.timedOut(message: "unable to resolve dimensions") }) }.then(on: .sdk) { $0 }
+                                                                              throw: { TrackError.timedOut(message: "unable to resolve dimensions") }) }.then(on: self.queue) { $0 }
 
-        }.then(on: .sdk) { dimensions -> Promise<(result: RTCRtpTransceiverInit, trackInfo: Livekit_TrackInfo)> in
+        }.then(on: queue) { dimensions -> Promise<(result: RTCRtpTransceiverInit, trackInfo: Livekit_TrackInfo)> in
             // request a new track to the server
             self.room.engine.signalClient.sendAddTrack(cid: track.mediaTrack.trackId,
                                                        name: track.name,
@@ -116,20 +116,20 @@ public class LocalParticipant: Participant {
                 return transInit
             }
 
-        }.then(on: .sdk) { (transInit, trackInfo) -> Promise<(transceiver: RTCRtpTransceiver, trackInfo: Livekit_TrackInfo)> in
+        }.then(on: queue) { (transInit, trackInfo) -> Promise<(transceiver: RTCRtpTransceiver, trackInfo: Livekit_TrackInfo)> in
 
             self.log("[publish] server responded trackInfo: \(trackInfo)")
 
             // add transceiver to pc
             return publisher.addTransceiver(with: track.mediaTrack,
-                                            transceiverInit: transInit).then(on: .sdk) { transceiver in
+                                            transceiverInit: transInit).then(on: self.queue) { transceiver in
                                                 // pass down trackInfo and created transceiver
                                                 (transceiver, trackInfo)
                                             }
-        }.then(on: .sdk) { params -> Promise<(RTCRtpTransceiver, trackInfo: Livekit_TrackInfo)> in
+        }.then(on: queue) { params -> Promise<(RTCRtpTransceiver, trackInfo: Livekit_TrackInfo)> in
             self.log("[publish] added transceiver: \(params.trackInfo)...")
-            return track.onPublish().then(on: .sdk) { _ in params }
-        }.then(on: .sdk) { (transceiver, trackInfo) -> LocalTrackPublication in
+            return track.onPublish().then(on: self.queue) { _ in params }
+        }.then(on: queue) { (transceiver, trackInfo) -> LocalTrackPublication in
 
             // store publishOptions used for this track
             track.publishOptions = publishOptions
@@ -161,12 +161,12 @@ public class LocalParticipant: Participant {
             self.log("[publish] success \(publication)", .info)
             return publication
 
-        }.catch(on: .sdk) { error in
+        }.catch(on: queue) { error in
 
             self.log("[publish] failed \(track), error: \(error)", .error)
 
             // stop the track
-            track.stop().catch(on: .sdk) { error in
+            track.stop().catch(on: self.queue) { error in
                 self.log("[publish] failed to stop track, error: \(error)", .error)
             }
         }
@@ -191,8 +191,8 @@ public class LocalParticipant: Participant {
         let promises = _state.tracks.values.compactMap { $0 as? LocalTrackPublication }
             .map { unpublish(publication: $0, notify: _notify) }
         // combine promises to wait all to complete
-        return super.unpublishAll(notify: _notify).then(on: .sdk) {
-            promises.all(on: .sdk)
+        return super.unpublishAll(notify: _notify).then(on: queue) {
+            promises.all(on: self.queue)
         }
     }
 
@@ -202,7 +202,7 @@ public class LocalParticipant: Participant {
 
         func notifyDidUnpublish() -> Promise<Void> {
 
-            Promise<Void>(on: .sdk) {
+            Promise<Void>(on: queue) {
                 guard _notify else { return }
                 // notify unpublish
                 self.notify(label: { "localParticipant.didUnpublish \(publication)" }) {
@@ -232,18 +232,18 @@ public class LocalParticipant: Participant {
         }
 
         // wait for track to stop
-        return stopTrackIfRequired().then(on: .sdk) { _ -> Promise<Void> in
+        return stopTrackIfRequired().then(on: queue) { _ -> Promise<Void> in
 
             guard let publisher = self.room.engine.publisher, let sender = track.sender else {
                 return Promise(())
             }
 
-            return publisher.removeTrack(sender).then(on: .sdk) {
+            return publisher.removeTrack(sender).then(on: self.queue) {
                 self.room.engine.publisherShouldNegotiate()
             }
-        }.then(on: .sdk) {
+        }.then(on: queue) {
             track.onUnpublish()
-        }.then(on: .sdk) { _ -> Promise<Void> in
+        }.then(on: queue) { _ -> Promise<Void> in
             notifyDidUnpublish()
         }
     }
@@ -400,7 +400,7 @@ extension LocalParticipant {
 
         let mediaTracks = _state.tracks.values.map { $0.track }.compactMap { $0 }
 
-        return unpublishAll().then(on: .sdk) { () -> Promise<Void> in
+        return unpublishAll().then(on: queue) { () -> Promise<Void> in
 
             let promises = mediaTracks.map { track -> Promise<LocalTrackPublication>? in
                 guard let track = track as? LocalTrack else { return nil }
@@ -410,7 +410,7 @@ extension LocalParticipant {
             }.compactMap { $0 }
 
             // TODO: use .all extension
-            return all(on: .sdk, promises).then(on: .sdk) { _ in }
+            return all(on: self.queue, promises).then(on: self.queue) { _ in }
         }
     }
 }
@@ -445,18 +445,18 @@ extension LocalParticipant {
         if let publication = publication as? LocalTrackPublication {
             // publication already exists
             if enabled {
-                return publication.unmute().then(on: .sdk) { publication }
+                return publication.unmute().then(on: queue) { publication }
             } else {
-                return publication.mute().then(on: .sdk) { nil }
+                return publication.mute().then(on: queue) { nil }
             }
         } else if enabled {
             // try to create a new track
             if source == .camera {
                 let localTrack = LocalVideoTrack.createCameraTrack(options: room.options.defaultCameraCaptureOptions)
-                return publishVideoTrack(track: localTrack).then(on: .sdk) { return $0 }
+                return publishVideoTrack(track: localTrack).then(on: queue) { return $0 }
             } else if source == .microphone {
                 let localTrack = LocalAudioTrack.createTrack(options: room.options.defaultAudioCaptureOptions)
-                return publishAudioTrack(track: localTrack).then(on: .sdk) { return $0 }
+                return publishAudioTrack(track: localTrack).then(on: queue) { return $0 }
             } else if source == .screenShareVideo {
 
                 var localTrack: LocalVideoTrack?
@@ -476,7 +476,7 @@ extension LocalParticipant {
                 #endif
 
                 if let localTrack = localTrack {
-                    return publishVideoTrack(track: localTrack).then(on: .sdk) { publication in return publication }
+                    return publishVideoTrack(track: localTrack).then(on: queue) { publication in return publication }
                 }
             }
         }

--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -20,6 +20,8 @@ import Promises
 
 public class Participant: MulticastDelegate<ParticipantDelegate> {
 
+    internal let queue = DispatchQueue(label: "LiveKitSDK.participant", qos: .default)
+
     public let sid: Sid
     public var identity: String { _state.identity }
     public var name: String { _state.name }
@@ -114,7 +116,7 @@ public class Participant: MulticastDelegate<ParticipantDelegate> {
     @discardableResult
     internal func cleanUp(notify _notify: Bool = true) -> Promise<Void> {
 
-        unpublishAll(notify: _notify).then(on: .sdk) {
+        unpublishAll(notify: _notify).then(on: queue) {
             // reset state
             self._state.mutate { $0 = State(identity: $0.identity, name: $0.name) }
         }

--- a/Sources/LiveKit/Publications/LocalTrackPublication.swift
+++ b/Sources/LiveKit/Publications/LocalTrackPublication.swift
@@ -69,11 +69,13 @@ public class LocalTrackPublication: TrackPublication {
     }
 
     // create debounce func
-    lazy var shouldRecomputeSenderParameters = Utils.createDebounceFunc(wait: 0.1, onCreateWorkItem: { [weak self] workItem in
-        self?.debounceWorkItem = workItem
-    }, fnc: { [weak self] in
-        self?.recomputeSenderParameters()
-    })
+    lazy var shouldRecomputeSenderParameters = Utils.createDebounceFunc(on: queue,
+                                                                        wait: 0.1,
+                                                                        onCreateWorkItem: { [weak self] workItem in
+                                                                            self?.debounceWorkItem = workItem
+                                                                        }, fnc: { [weak self] in
+                                                                            self?.recomputeSenderParameters()
+                                                                        })
 }
 
 internal extension LocalTrackPublication {
@@ -82,7 +84,7 @@ internal extension LocalTrackPublication {
     func suspend() -> Promise<Void> {
         // do nothing if already muted
         guard !muted else { return Promise(()) }
-        return mute().then(on: .sdk) {
+        return mute().then(on: queue) {
             self.suspended = true
         }
     }
@@ -91,7 +93,7 @@ internal extension LocalTrackPublication {
     func resume() -> Promise<Void> {
         // do nothing if was not suspended
         guard suspended else { return Promise(()) }
-        return unmute().then(on: .sdk) {
+        return unmute().then(on: queue) {
             self.suspended = false
         }
     }
@@ -163,7 +165,7 @@ extension LocalTrackPublication {
         self.log("Using encodings layers: \(layers.map { String(describing: $0) }.joined(separator: ", "))")
 
         participant.room.engine.signalClient.sendUpdateVideoLayers(trackSid: track.sid!,
-                                                                   layers: layers).catch(on: .sdk) { error in
+                                                                   layers: layers).catch(on: queue) { error in
                                                                     self.log("Failed to send update video layers", .error)
                                                                    }
     }

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -87,7 +87,7 @@ public class RemoteTrackPublication: TrackPublication {
             participantSid: participant.sid,
             trackSid: sid,
             subscribed: newValue
-        ).then(on: .sdk) {
+        ).then(on: queue) {
             self.preferSubscribed = newValue
         }
     }
@@ -107,7 +107,7 @@ public class RemoteTrackPublication: TrackPublication {
         // update state
         _state.mutate { $0.trackSettings = $0.trackSettings.copyWith(enabled: newValue) }
         // attempt to set the new settings
-        return send(trackSettings: _state.trackSettings).catch(on: .sdk) { [weak self] error in
+        return send(trackSettings: _state.trackSettings).catch(on: queue) { [weak self] error in
 
             guard let self = self else { return }
 
@@ -327,12 +327,12 @@ extension RemoteTrackPublication {
             DispatchQueue.webRTC.sync { videoTrack.shouldReceive = enabled }
         }
 
-        send(trackSettings: newSettings).catch(on: .sdk) { [weak self] error in
+        send(trackSettings: newSettings).catch(on: queue) { [weak self] error in
             guard let self = self else { return }
             // revert to old settings on failure
             self._state.mutate { $0.trackSettings = oldSettings }
             self.log("[adaptiveStream] failed to send trackSettings, sid: \(self.sid) error: \(error)", .error)
-        }.always(on: .sdk) { [weak self] in
+        }.always(on: queue) { [weak self] in
             guard let self = self else { return }
             self.asTimer.restart()
         }

--- a/Sources/LiveKit/Publications/TrackPublication.swift
+++ b/Sources/LiveKit/Publications/TrackPublication.swift
@@ -20,6 +20,8 @@ import Promises
 
 public class TrackPublication: TrackDelegate, Loggable {
 
+    internal let queue = DispatchQueue(label: "LiveKitSDK.publication", qos: .default)
+
     public let sid: Sid
     public let kind: Track.Kind
     public let source: Track.Source
@@ -157,8 +159,8 @@ public class TrackPublication: TrackDelegate, Loggable {
         }
 
         sendSignal()
-            .recover(on: .sdk) { self.log("Failed to stop all tracks, error: \($0)") }
-            .then(on: .sdk) {
+            .recover(on: queue) { self.log("Failed to stop all tracks, error: \($0)") }
+            .then(on: queue) {
                 participant.notify {
                     $0.participant(participant, didUpdate: self, muted: muted)
                 }

--- a/Sources/LiveKit/Support/HTTP.swift
+++ b/Sources/LiveKit/Support/HTTP.swift
@@ -27,9 +27,9 @@ internal class HTTP: NSObject, URLSessionDelegate {
                    delegateQueue: operationQueue)
     }()
 
-    func get(url: URL) -> Promise<Data> {
+    func get(on: DispatchQueue, url: URL) -> Promise<Data> {
 
-        Promise<Data>(on: .sdk) { resolve, fail in
+        Promise<Data>(on: on) { resolve, fail in
 
             let request = URLRequest(url: url,
                                      cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,

--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -112,6 +112,7 @@ internal class Utils {
     }
 
     internal static func buildUrl(
+        on: DispatchQueue,
         _ url: String,
         _ token: String,
         connectOptions: ConnectOptions? = nil,
@@ -121,7 +122,7 @@ internal class Utils {
         forceSecure: Bool = false
     ) -> Promise<URL> {
 
-        Promise(on: .sdk) { () -> URL in
+        Promise(on: on) { () -> URL in
             // use default options if nil
             let connectOptions = connectOptions ?? ConnectOptions()
 
@@ -194,7 +195,8 @@ internal class Utils {
         }
     }
 
-    internal static func createDebounceFunc(wait: TimeInterval,
+    internal static func createDebounceFunc(on: DispatchQueue,
+                                            wait: TimeInterval,
                                             onCreateWorkItem: ((DispatchWorkItem) -> Void)? = nil,
                                             fnc: @escaping @convention(block) () -> Void) -> DebouncFunc {
         var workItem: DispatchWorkItem?
@@ -202,7 +204,7 @@ internal class Utils {
             workItem?.cancel()
             workItem = DispatchWorkItem { fnc() }
             onCreateWorkItem?(workItem!)
-            DispatchQueue.sdk.asyncAfter(deadline: .now() + wait, execute: workItem!)
+            on.asyncAfter(deadline: .now() + wait, execute: workItem!)
         }
     }
 

--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -112,7 +112,7 @@ internal class Utils {
     }
 
     internal static func buildUrl(
-        on: DispatchQueue,
+        on queue: DispatchQueue,
         _ url: String,
         _ token: String,
         connectOptions: ConnectOptions? = nil,
@@ -122,7 +122,7 @@ internal class Utils {
         forceSecure: Bool = false
     ) -> Promise<URL> {
 
-        Promise(on: on) { () -> URL in
+        Promise(on: queue) { () -> URL in
             // use default options if nil
             let connectOptions = connectOptions ?? ConnectOptions()
 
@@ -195,7 +195,7 @@ internal class Utils {
         }
     }
 
-    internal static func createDebounceFunc(on: DispatchQueue,
+    internal static func createDebounceFunc(on queue: DispatchQueue,
                                             wait: TimeInterval,
                                             onCreateWorkItem: ((DispatchWorkItem) -> Void)? = nil,
                                             fnc: @escaping @convention(block) () -> Void) -> DebouncFunc {
@@ -204,7 +204,7 @@ internal class Utils {
             workItem?.cancel()
             workItem = DispatchWorkItem { fnc() }
             onCreateWorkItem?(workItem!)
-            on.asyncAfter(deadline: .now() + wait, execute: workItem!)
+            queue.asyncAfter(deadline: .now() + wait, execute: workItem!)
         }
     }
 

--- a/Sources/LiveKit/SwiftUI/ObservableRoom.swift
+++ b/Sources/LiveKit/SwiftUI/ObservableRoom.swift
@@ -83,7 +83,7 @@ open class ObservableRoom: ObservableObject, RoomDelegate, Loggable {
             self.cameraTrackState = .busy(isPublishing: !self.cameraTrackState.isPublished)
         }
 
-        localParticipant.setCamera(enabled: !cameraTrackState.isPublished).then(on: .sdk) { publication in
+        localParticipant.setCamera(enabled: !cameraTrackState.isPublished).then(on: room.queue) { publication in
             DispatchQueue.main.async {
                 guard let publication = publication else {
                     self.cameraTrackState = .notPublished()
@@ -93,7 +93,7 @@ open class ObservableRoom: ObservableObject, RoomDelegate, Loggable {
                 self.cameraTrackState = .published(publication)
             }
             self.log("Successfully published camera")
-        }.catch(on: .sdk) { error in
+        }.catch(on: room.queue) { error in
             DispatchQueue.main.async {
                 self.cameraTrackState = .notPublished(error: error)
             }
@@ -117,7 +117,7 @@ open class ObservableRoom: ObservableObject, RoomDelegate, Loggable {
             self.screenShareTrackState = .busy(isPublishing: !self.screenShareTrackState.isPublished)
         }
 
-        localParticipant.setScreenShare(enabled: !screenShareTrackState.isPublished).then(on: .sdk) { publication in
+        localParticipant.setScreenShare(enabled: !screenShareTrackState.isPublished).then(on: room.queue) { publication in
             DispatchQueue.main.async {
                 guard let publication = publication else {
                     self.screenShareTrackState = .notPublished()
@@ -126,7 +126,7 @@ open class ObservableRoom: ObservableObject, RoomDelegate, Loggable {
 
                 self.screenShareTrackState = .published(publication)
             }
-        }.catch(on: .sdk) { error in
+        }.catch(on: room.queue) { error in
             DispatchQueue.main.async {
                 self.screenShareTrackState = .notPublished(error: error)
             }
@@ -149,7 +149,7 @@ open class ObservableRoom: ObservableObject, RoomDelegate, Loggable {
             self.microphoneTrackState = .busy(isPublishing: !self.microphoneTrackState.isPublished)
         }
 
-        localParticipant.setMicrophone(enabled: !microphoneTrackState.isPublished).then(on: .sdk) { publication in
+        localParticipant.setMicrophone(enabled: !microphoneTrackState.isPublished).then(on: room.queue) { publication in
             DispatchQueue.main.async {
                 guard let publication = publication else {
                     self.microphoneTrackState = .notPublished()
@@ -159,7 +159,7 @@ open class ObservableRoom: ObservableObject, RoomDelegate, Loggable {
                 self.microphoneTrackState = .published(publication)
             }
             self.log("Successfully published microphone")
-        }.catch(on: .sdk) { error in
+        }.catch(on: room.queue) { error in
             DispatchQueue.main.async {
                 self.microphoneTrackState = .notPublished(error: error)
             }

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -76,7 +76,7 @@ public class CameraCapturer: VideoCapturer {
 
     public override func startCapture() -> Promise<Bool> {
 
-        super.startCapture().then(on: .sdk) { didStart -> Promise<Bool> in
+        super.startCapture().then(on: queue) { didStart -> Promise<Bool> in
 
             guard didStart else {
                 // already started
@@ -170,7 +170,7 @@ public class CameraCapturer: VideoCapturer {
 
     public override func stopCapture() -> Promise<Bool> {
 
-        super.stopCapture().then(on: .sdk) { didStop -> Promise<Bool> in
+        super.stopCapture().then(on: queue) { didStop -> Promise<Bool> in
 
             guard didStop else {
                 // already stopped

--- a/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
@@ -31,14 +31,14 @@ public class InAppScreenCapturer: VideoCapturer {
 
     public override func startCapture() -> Promise<Bool> {
 
-        super.startCapture().then(on: .sdk) {didStart -> Promise<Bool> in
+        super.startCapture().then(on: queue) {didStart -> Promise<Bool> in
 
             guard didStart else {
                 // already started
                 return Promise(false)
             }
 
-            return Promise<Bool>(on: .sdk) { resolve, fail in
+            return Promise<Bool>(on: self.queue) { resolve, fail in
 
                 // TODO: force pixel format kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
                 RPScreenRecorder.shared().startCapture { sampleBuffer, type, _ in
@@ -72,14 +72,14 @@ public class InAppScreenCapturer: VideoCapturer {
 
     public override func stopCapture() -> Promise<Bool> {
 
-        super.stopCapture().then(on: .sdk) { didStop -> Promise<Bool> in
+        super.stopCapture().then(on: queue) { didStop -> Promise<Bool> in
 
             guard didStop else {
                 // already stopped
                 return Promise(false)
             }
 
-            return Promise<Bool>(on: .sdk) { resolve, fail in
+            return Promise<Bool>(on: self.queue) { resolve, fail in
 
                 RPScreenRecorder.shared().stopCapture { error in
                     if let error = error {

--- a/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
@@ -41,6 +41,8 @@ public extension VideoCapturerDelegate {
 // Intended to be a base class for video capturers
 public class VideoCapturer: MulticastDelegate<VideoCapturerDelegate>, VideoCapturerProtocol {
 
+    internal let queue = DispatchQueue(label: "LiveKitSDK.videoCapturer", qos: .default)
+
     /// Array of supported pixel formats that can be used to capture a frame.
     ///
     /// Usually the following formats are supported but it is recommended to confirm at run-time:
@@ -88,7 +90,7 @@ public class VideoCapturer: MulticastDelegate<VideoCapturerDelegate>, VideoCaptu
     // returns true if state updated
     public func startCapture() -> Promise<Bool> {
 
-        Promise(on: .sdk) { () -> Bool in
+        Promise(on: queue) { () -> Bool in
 
             guard self.captureState != .started else {
                 // already started
@@ -108,7 +110,7 @@ public class VideoCapturer: MulticastDelegate<VideoCapturerDelegate>, VideoCaptu
     // returns true if state updated
     public func stopCapture() -> Promise<Bool> {
 
-        Promise(on: .sdk) { () -> Bool in
+        Promise(on: queue) { () -> Bool in
 
             guard self.captureState != .stopped else {
                 // already stopped
@@ -127,7 +129,7 @@ public class VideoCapturer: MulticastDelegate<VideoCapturerDelegate>, VideoCaptu
     }
 
     public func restartCapture() -> Promise<Bool> {
-        stopCapture().then(on: .sdk) { _ -> Promise<Bool> in
+        stopCapture().then(on: queue) { _ -> Promise<Bool> in
             self.startCapture()
         }
     }

--- a/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
@@ -59,7 +59,7 @@ public class LocalAudioTrack: LocalTrack, AudioTrack {
 
     @discardableResult
     internal override func onPublish() -> Promise<Bool> {
-        super.onPublish().then(on: .sdk) { didPublish -> Bool in
+        super.onPublish().then(on: queue) { didPublish -> Bool in
             if didPublish {
                 AudioManager.shared.trackDidStart(.local)
             }
@@ -69,7 +69,7 @@ public class LocalAudioTrack: LocalTrack, AudioTrack {
 
     @discardableResult
     internal override func onUnpublish() -> Promise<Bool> {
-        super.onUnpublish().then(on: .sdk) { didUnpublish -> Bool in
+        super.onUnpublish().then(on: queue) { didUnpublish -> Bool in
             if didUnpublish {
                 AudioManager.shared.trackDidStop(.local)
             }

--- a/Sources/LiveKit/Track/Local/LocalTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalTrack.swift
@@ -32,9 +32,9 @@ public class LocalTrack: Track {
         // Already muted
         if muted { return Promise(()) }
 
-        return disable().then(on: .sdk) { _ in
+        return disable().then(on: queue) { _ in
             self.stop()
-        }.then(on: .sdk) { _ -> Void in
+        }.then(on: queue) { _ -> Void in
             self.set(muted: true, shouldSendSignal: true)
         }
     }
@@ -43,9 +43,9 @@ public class LocalTrack: Track {
         // Already un-muted
         if !muted { return Promise(()) }
 
-        return enable().then(on: .sdk) { _ in
+        return enable().then(on: queue) { _ in
             self.start()
-        }.then(on: .sdk) { _ -> Void in
+        }.then(on: queue) { _ -> Void in
             self.set(muted: false, shouldSendSignal: true)
         }
     }
@@ -53,7 +53,7 @@ public class LocalTrack: Track {
     // returns true if state updated
     internal func onPublish() -> Promise<Bool> {
 
-        Promise<Bool>(on: .sdk) { () -> Bool in
+        Promise<Bool>(on: queue) { () -> Bool in
 
             guard self.publishState != .published else {
                 // already published
@@ -68,7 +68,7 @@ public class LocalTrack: Track {
     // returns true if state updated
     internal func onUnpublish() -> Promise<Bool> {
 
-        Promise<Bool>(on: .sdk) { () -> Bool in
+        Promise<Bool>(on: queue) { () -> Bool in
 
             guard self.publishState != .unpublished else {
                 // already unpublished

--- a/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
@@ -42,14 +42,14 @@ public class LocalVideoTrack: LocalTrack, VideoTrack {
     }
 
     override public func start() -> Promise<Bool> {
-        super.start().then(on: .sdk) { didStart in
-            self.capturer.startCapture().then(on: .sdk) { _ in didStart }
+        super.start().then(on: queue) { didStart in
+            self.capturer.startCapture().then(on: self.queue) { _ in didStart }
         }
     }
 
     override public func stop() -> Promise<Bool> {
-        super.stop().then(on: .sdk) { didStop in
-            self.capturer.stopCapture().then(on: .sdk) { _ in didStop }
+        super.stop().then(on: queue) { didStop in
+            self.capturer.stopCapture().then(on: self.queue) { _ in didStop }
         }
     }
 }

--- a/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
@@ -30,7 +30,7 @@ class RemoteAudioTrack: RemoteTrack, AudioTrack {
     }
 
     override public func start() -> Promise<Bool> {
-        super.start().then(on: .sdk) { didStart -> Bool in
+        super.start().then(on: queue) { didStart -> Bool in
             if didStart {
                 AudioManager.shared.trackDidStart(.remote)
             }
@@ -39,7 +39,7 @@ class RemoteAudioTrack: RemoteTrack, AudioTrack {
     }
 
     override public func stop() -> Promise<Bool> {
-        super.stop().then(on: .sdk) { didStop -> Bool in
+        super.stop().then(on: queue) { didStop -> Bool in
             if didStop {
                 AudioManager.shared.trackDidStop(.remote)
             }

--- a/Sources/LiveKit/Track/Remote/RemoteTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteTrack.swift
@@ -19,14 +19,14 @@ import Promises
 public class RemoteTrack: Track {
 
     override public func start() -> Promise<Bool> {
-        super.start().then(on: .sdk) { didStart in
-            self.enable().then(on: .sdk) { _ in didStart }
+        super.start().then(on: queue) { didStart in
+            self.enable().then(on: self.queue) { _ in didStart }
         }
     }
 
     override public func stop() -> Promise<Bool> {
-        super.stop().then(on: .sdk) { didStop in
-            super.disable().then(on: .sdk) { _ in didStop }
+        super.stop().then(on: queue) { didStop in
+            super.disable().then(on: self.queue) { _ in didStop }
         }
     }
 }

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -19,6 +19,8 @@ import Promises
 
 public class Track: MulticastDelegate<TrackDelegate> {
 
+    internal let queue = DispatchQueue(label: "LiveKitSDK.track", qos: .default)
+
     public static let cameraName = "camera"
     public static let microphoneName = "microphone"
     public static let screenShareVideoName = "screen_share"
@@ -92,7 +94,7 @@ public class Track: MulticastDelegate<TrackDelegate> {
     // returns true if updated state
     public func start() -> Promise<Bool> {
 
-        Promise(on: .sdk) { () -> Bool in
+        Promise(on: queue) { () -> Bool in
 
             guard self.trackState != .started else {
                 // already started
@@ -107,7 +109,7 @@ public class Track: MulticastDelegate<TrackDelegate> {
     // returns true if updated state
     public func stop() -> Promise<Bool> {
 
-        Promise(on: .sdk) { () -> Bool in
+        Promise(on: queue) { () -> Bool in
 
             guard self.trackState != .stopped else {
                 // already stopped
@@ -121,7 +123,7 @@ public class Track: MulticastDelegate<TrackDelegate> {
 
     internal func enable() -> Promise<Bool> {
 
-        Promise(on: .sdk) { () -> Bool in
+        Promise(on: queue) { () -> Bool in
 
             guard !self.mediaTrack.isEnabled else {
                 // already enabled
@@ -135,7 +137,7 @@ public class Track: MulticastDelegate<TrackDelegate> {
 
     internal func disable() -> Promise<Bool> {
 
-        Promise(on: .sdk) { () -> Bool in
+        Promise(on: queue) { () -> Bool in
 
             guard self.mediaTrack.isEnabled else {
                 // already disabled


### PR DESCRIPTION
Using common static .sdk queue was a bad idea, queue gets too congested when multiple Room/Engine objects.
Concurrent Room connecting works well now.
