### PR TITLE
ObjC Support

### DIFF
--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -19,7 +19,8 @@ import Network
 import Promises
 import WebRTC
 
-@objc public class Room: NSObject, MulticastDelegateCapable, Loggable {
+@objc
+public class Room: NSObject, MulticastDelegateCapable, Loggable {
 
     // MARK: - MulticastDelegate
 
@@ -30,19 +31,30 @@ import WebRTC
 
     // MARK: - Public
 
-    @objc public var sid: Sid? { _state.sid }
-    @objc public var name: String? { _state.name }
-    @objc public var metadata: String? { _state.metadata }
-    @objc public var serverVersion: String? { _state.serverVersion }
-    @objc public var serverRegion: String? { _state.serverRegion }
+    @objc
+    public var sid: Sid? { _state.sid }
+
+    @objc
+    public var name: String? { _state.name }
+
+    @objc
+    public var metadata: String? { _state.metadata }
+
+    @objc
+    public var serverVersion: String? { _state.serverVersion }
+
+    @objc
+    public var serverRegion: String? { _state.serverRegion }
 
     public var localParticipant: LocalParticipant? { _state.localParticipant }
     public var remoteParticipants: [Sid: RemoteParticipant] { _state.remoteParticipants }
     public var activeSpeakers: [Participant] { _state.activeSpeakers }
 
     // expose engine's vars
-    @objc public var url: String? { engine._state.url }
-    @objc public var token: String? { engine._state.token }
+    @objc
+    public var url: String? { engine._state.url }
+    @objc
+    public var token: String? { engine._state.token }
 
     public var connectionState: ConnectionState { engine._state.connectionState }
     public var connectStopwatch: Stopwatch { engine._state.connectStopwatch }
@@ -73,7 +85,8 @@ import WebRTC
 
     // MARK: Objective-C Support
 
-    @objc public convenience override init() {
+    @objc
+    public convenience override init() {
 
         self.init(delegate: nil,
                   connectOptions: ConnectOptions(),
@@ -788,10 +801,11 @@ extension Room {
 
 extension Room {
 
-    @objc public func connect(url: String,
-                              token: String,
-                              connectOptions: ConnectOptions? = nil,
-                              roomOptions: RoomOptions? = nil) -> Promise<Room>.ObjCPromise<Room> {
+    @objc
+    public func connect(url: String,
+                        token: String,
+                        connectOptions: ConnectOptions? = nil,
+                        roomOptions: RoomOptions? = nil) -> Promise<Room>.ObjCPromise<Room> {
         connect(url,
                 token,
                 connectOptions: connectOptions,

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -53,14 +53,16 @@ public class Room: NSObject, MulticastDelegateCapable, Loggable {
     // expose engine's vars
     @objc
     public var url: String? { engine._state.url }
+
     @objc
     public var token: String? { engine._state.token }
 
     public var connectionState: ConnectionState { engine._state.connectionState }
-    public var connectStopwatch: Stopwatch { engine._state.connectStopwatch }
 
     @objc(connectionState)
     public var connectionStateObjC: ConnectionStateObjC { engine._state.connectionState.toObjCType() }
+
+    public var connectStopwatch: Stopwatch { engine._state.connectStopwatch }
 
     // MARK: - Internal
 

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -843,25 +843,3 @@ extension Room {
         delegates.notify(label: label, fnc)
     }
 }
-
-// MARK: - Objective-C Support
-
-extension Room {
-
-    @objc
-    public func connect(url: String,
-                        token: String,
-                        connectOptions: ConnectOptions? = nil,
-                        roomOptions: RoomOptions? = nil) -> Promise<Room>.ObjCPromise<Room> {
-        connect(url,
-                token,
-                connectOptions: connectOptions,
-                roomOptions: roomOptions).asObjCPromise()
-    }
-
-    @objc(disconnect)
-    @discardableResult
-    public func disconnectObjC() -> Promise<Void>.ObjCPromise<NSNull> {
-        disconnect().asObjCPromise()
-    }
-}

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -21,7 +21,7 @@ import WebRTC
 
 @objc public class Room: NSObject, MulticastDelegateCapable, Loggable {
 
-    // MARK: - Public
+    // MARK: - MulticastDelegate
 
     public typealias DelegateType = RoomDelegate
     public var delegates = MulticastDelegate<DelegateType>()

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -63,7 +63,9 @@ public class Room: NSObject, Loggable {
 
     public var connectionState: ConnectionState { engine._state.connectionState }
 
+    /// Only for Objective-C.
     @objc(connectionState)
+    @available(swift, obsoleted: 1.0)
     public var connectionStateObjC: ConnectionStateObjC { engine._state.connectionState.toObjCType() }
 
     public var connectStopwatch: Stopwatch { engine._state.connectStopwatch }

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -101,12 +101,13 @@ public class Room: NSObject, Loggable {
                   roomOptions: RoomOptions())
     }
 
-    public init(delegate: RoomDelegate? = nil,
-                connectOptions: ConnectOptions = ConnectOptions(),
-                roomOptions: RoomOptions = RoomOptions()) {
+    @objc
+    public init(delegate: RoomDelegateObjC? = nil,
+                connectOptions: ConnectOptions? = nil,
+                roomOptions: RoomOptions? = nil) {
 
-        self._state = StateSync(State(options: roomOptions))
-        self.engine = Engine(connectOptions: connectOptions)
+        self._state = StateSync(State(options: roomOptions ?? RoomOptions()))
+        self.engine = Engine(connectOptions: connectOptions ?? ConnectOptions())
         super.init()
 
         log()
@@ -119,7 +120,8 @@ public class Room: NSObject, Loggable {
         engine.signalClient.add(delegate: self)
 
         if let delegate = delegate {
-            add(delegate: delegate)
+            log("delegate: \(String(describing: delegate))")
+            delegates.add(delegate: delegate)
         }
 
         // listen to app states
@@ -855,5 +857,11 @@ extension Room {
                 token,
                 connectOptions: connectOptions,
                 roomOptions: roomOptions).asObjCPromise()
+    }
+
+    @objc(disconnect)
+    @discardableResult
+    public func disconnectObjC() -> Promise<Void>.ObjCPromise<NSNull> {
+        disconnect().asObjCPromise()
     }
 }

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -802,10 +802,12 @@ extension Room: AppStateDelegate {
 
 extension Room {
 
+    @objc
     public static var audioDeviceModule: RTCAudioDeviceModule {
         Engine.audioDeviceModule
     }
 
+    @objc
     public static var bypassVoiceProcessing: Bool {
         get { Engine.bypassVoiceProcessing }
         set { Engine.bypassVoiceProcessing = newValue }

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -19,25 +19,30 @@ import Network
 import Promises
 import WebRTC
 
-public class Room: MulticastDelegate<RoomDelegate> {
+@objc public class Room: NSObject, MulticastDelegateCapable, Loggable {
+
+    // MARK: - Public
+
+    public typealias DelegateType = RoomDelegate
+    public var delegates = MulticastDelegate<DelegateType>()
 
     internal let queue = DispatchQueue(label: "LiveKitSDK.room", qos: .default)
 
     // MARK: - Public
 
-    public var sid: Sid? { _state.sid }
-    public var name: String? { _state.name }
-    public var metadata: String? { _state.metadata }
-    public var serverVersion: String? { _state.serverVersion }
-    public var serverRegion: String? { _state.serverRegion }
+    @objc public var sid: Sid? { _state.sid }
+    @objc public var name: String? { _state.name }
+    @objc public var metadata: String? { _state.metadata }
+    @objc public var serverVersion: String? { _state.serverVersion }
+    @objc public var serverRegion: String? { _state.serverRegion }
 
     public var localParticipant: LocalParticipant? { _state.localParticipant }
     public var remoteParticipants: [Sid: RemoteParticipant] { _state.remoteParticipants }
     public var activeSpeakers: [Participant] { _state.activeSpeakers }
 
     // expose engine's vars
-    public var url: String? { engine._state.url }
-    public var token: String? { engine._state.token }
+    @objc public var url: String? { engine._state.url }
+    @objc public var token: String? { engine._state.token }
     public var connectionState: ConnectionState { engine._state.connectionState }
     public var connectStopwatch: Stopwatch { engine._state.connectStopwatch }
 
@@ -61,6 +66,15 @@ public class Room: MulticastDelegate<RoomDelegate> {
     }
 
     internal var _state: StateSync<State>
+
+    // MARK: Objective-C Support
+
+    @objc public convenience override init() {
+
+        self.init(delegate: nil,
+                  connectOptions: ConnectOptions(),
+                  roomOptions: RoomOptions())
+    }
 
     public init(delegate: RoomDelegate? = nil,
                 connectOptions: ConnectOptions = ConnectOptions(),
@@ -763,5 +777,20 @@ extension Room {
     public static var bypassVoiceProcessing: Bool {
         get { Engine.bypassVoiceProcessing }
         set { Engine.bypassVoiceProcessing = newValue }
+    }
+}
+
+// MARK: - Objective-C Support
+
+extension Room {
+
+    @objc public func connect(url: String,
+                              token: String,
+                              connectOptions: ConnectOptions? = nil,
+                              roomOptions: RoomOptions? = nil) -> Promise<Room>.ObjCPromise<Room> {
+        connect(url,
+                token,
+                connectOptions: connectOptions,
+                roomOptions: roomOptions).asObjCPromise()
     }
 }

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -43,8 +43,12 @@ import WebRTC
     // expose engine's vars
     @objc public var url: String? { engine._state.url }
     @objc public var token: String? { engine._state.token }
+
     public var connectionState: ConnectionState { engine._state.connectionState }
     public var connectStopwatch: Stopwatch { engine._state.connectStopwatch }
+
+    @objc(connectionState)
+    public var connectionStateObjC: ConnectionStateObjC { engine._state.connectionState.toObjCType() }
 
     // MARK: - Internal
 

--- a/Sources/LiveKit/Extensions/CustomStringConvertible.swift
+++ b/Sources/LiveKit/Extensions/CustomStringConvertible.swift
@@ -15,6 +15,7 @@
  */
 
 import Foundation
+import WebRTC
 
 extension TrackSettings: CustomStringConvertible {
 
@@ -78,5 +79,16 @@ extension Track {
 
     public override var description: String {
         "\(String(describing: type(of: self)))(sid: \(sid ?? "nil"), name: \(name), source: \(source))"
+    }
+}
+
+extension RTCRtpEncodingParameters {
+
+    public override var description: String {
+        "RTCRtpEncodingParameters(rid: \(rid ?? "nil"), "
+            + "active: \(isActive), "
+            + "scaleResolutionDownBy: \(String(describing: scaleResolutionDownBy)), "
+            + "maxBitrateBps: \(maxBitrateBps == nil ? "nil" : String(describing: maxBitrateBps)), "
+            + "maxFramerate: \(maxFramerate == nil ? "nil" : String(describing: maxFramerate)))"
     }
 }

--- a/Sources/LiveKit/Extensions/CustomStringConvertible.swift
+++ b/Sources/LiveKit/Extensions/CustomStringConvertible.swift
@@ -30,9 +30,9 @@ extension Livekit_VideoLayer: CustomStringConvertible {
     }
 }
 
-extension TrackPublication: CustomStringConvertible {
+extension TrackPublication {
 
-    public var description: String {
+    public override var description: String {
         "\(String(describing: type(of: self)))(sid: \(sid), kind: \(kind), source: \(source))"
     }
 }

--- a/Sources/LiveKit/LiveKit.swift
+++ b/Sources/LiveKit/LiveKit.swift
@@ -31,8 +31,10 @@ internal let logger = Logger(label: "LiveKitSDK")
 ///
 /// Download the [Multiplatform SwiftUI Example](https://github.com/livekit/multiplatform-swiftui-example)
 /// to try out the features.
-public class LiveKit {
+@objc
+public class LiveKit: NSObject {
 
+    @objc(sdkVersion)
     public static let version = "1.0.4"
 
     @available(*, deprecated, message: "Use Room.connect() instead, protocol v8 and higher do not support this method")
@@ -49,5 +51,14 @@ public class LiveKit {
                         roomOptions: roomOptions)
 
         return room.connect(url, token)
+    }
+
+    @objc
+    public static func setLoggerStandardOutput() {
+        LoggingSystem.bootstrap({
+            var logHandler = StreamLogHandler.standardOutput(label: $0)
+            logHandler.logLevel = .debug
+            return logHandler
+        })
     }
 }

--- a/Sources/LiveKit/ObjCSupport.swift
+++ b/Sources/LiveKit/ObjCSupport.swift
@@ -161,17 +161,41 @@ extension Track {
         stop().asObjCPromise()
     }
 
-    @objc(mute)
     @discardableResult
-    public func muteObjC() -> Promise<Void>.ObjCPromise<NSNull> {
+    internal func muteObjC() -> Promise<Void>.ObjCPromise<NSNull> {
 
-        mute().asObjCPromise()
+        _mute().asObjCPromise()
     }
 
-    @objc(unmute)
     @discardableResult
-    public func unmuteObjC() -> Promise<Void>.ObjCPromise<NSNull> {
+    internal func unmuteObjC() -> Promise<Void>.ObjCPromise<NSNull> {
 
-        unmute().asObjCPromise()
+        _unmute().asObjCPromise()
+    }
+}
+
+extension LocalAudioTrack {
+
+    public func mute() -> Promise<Void>.ObjCPromise<NSNull> {
+
+        super.muteObjC()
+    }
+
+    public func unmute() -> Promise<Void>.ObjCPromise<NSNull> {
+
+        super.unmuteObjC()
+    }
+}
+
+extension LocalVideoTrack {
+
+    public func mute() -> Promise<Void>.ObjCPromise<NSNull> {
+
+        super.muteObjC()
+    }
+
+    public func unmute() -> Promise<Void>.ObjCPromise<NSNull> {
+
+        super.unmuteObjC()
     }
 }

--- a/Sources/LiveKit/ObjCSupport.swift
+++ b/Sources/LiveKit/ObjCSupport.swift
@@ -42,7 +42,7 @@ extension ConnectionState {
 
 extension Room {
 
-    @objc
+    @objc(connectWithURL:token:connectOptions:roomOptions:)
     public func connect(url: String,
                         token: String,
                         connectOptions: ConnectOptions? = nil,
@@ -62,29 +62,57 @@ extension Room {
 
 extension LocalParticipant {
 
-    @objc
+    @objc(setCameraEnabled:)
     @discardableResult
-    public func setCamera(enabled: Bool) -> Promise<LocalTrackPublication?>.ObjCPromise<LocalTrackPublication> {
+    public func setCameraObjC(enabled: Bool) -> Promise<LocalTrackPublication?>.ObjCPromise<LocalTrackPublication> {
         setCamera(enabled: enabled).asObjCPromise()
     }
 
-    @objc
+    @objc(setMicrophoneEnabled:)
     @discardableResult
-    public func setMicrophone(enabled: Bool) -> Promise<LocalTrackPublication?>.ObjCPromise<LocalTrackPublication> {
+    public func setMicrophoneObjC(enabled: Bool) -> Promise<LocalTrackPublication?>.ObjCPromise<LocalTrackPublication> {
         setMicrophone(enabled: enabled).asObjCPromise()
+    }
+
+    @objc(setScreenShareEnabled:)
+    @discardableResult
+    public func setScreenShareObjC(enabled: Bool) -> Promise<LocalTrackPublication?>.ObjCPromise<LocalTrackPublication> {
+        setScreenShare(enabled: enabled).asObjCPromise()
+    }
+
+    @objc(publishVideoTrack:options:)
+    @discardableResult
+    public func publishVideoTrackObjC(track: LocalVideoTrack,
+                                      publishOptions: VideoPublishOptions? = nil) -> Promise<LocalTrackPublication>.ObjCPromise<LocalTrackPublication> {
+
+        publishVideoTrack(track: track, publishOptions: publishOptions).asObjCPromise()
+    }
+
+    @objc(publishAudioTrack:options:)
+    @discardableResult
+    public func publishAudioTrackObjC(track: LocalAudioTrack,
+                                      publishOptions: AudioPublishOptions? = nil) -> Promise<LocalTrackPublication>.ObjCPromise<LocalTrackPublication> {
+
+        publishAudioTrack(track: track, publishOptions: publishOptions).asObjCPromise()
+    }
+
+    @objc(unpublishPublication:)
+    @discardableResult
+    public func unpublishObjC(publication: LocalTrackPublication) -> Promise<Void>.ObjCPromise<NSNull> {
+        unpublish(publication: publication).asObjCPromise()
     }
 }
 
 extension CameraCapturer {
 
-    @objc
+    @objc(switchCameraPosition)
     @discardableResult
-    public func switchCameraPosition() -> Promise<Bool>.ObjCPromise<NSNumber> {
+    public func switchCameraPositionObjC() -> Promise<Bool>.ObjCPromise<NSNumber> {
         switchCameraPosition().asObjCPromise()
     }
 
-    @objc
-    public func setCameraPosition(_ position: AVCaptureDevice.Position) -> Promise<Bool>.ObjCPromise<NSNumber> {
+    @objc(setCameraPosition:)
+    public func setCameraPositionObjC(_ position: AVCaptureDevice.Position) -> Promise<Bool>.ObjCPromise<NSNumber> {
         setCameraPosition(position).asObjCPromise()
     }
 }

--- a/Sources/LiveKit/ObjCSupport.swift
+++ b/Sources/LiveKit/ObjCSupport.swift
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import Promises
+import WebRTC
+
+// MARK: - Objective-C Support
+
+@objc(ConnectionState)
+public enum ConnectionStateObjC: Int {
+    case disconnected
+    case connecting
+    case reconnecting
+    case connected
+}
+
+extension ConnectionState {
+
+    func toObjCType() -> ConnectionStateObjC {
+        switch self {
+        case .disconnected: return .disconnected
+        case .connecting: return .connecting
+        case .reconnecting: return .reconnecting
+        case .connected: return .connected
+        }
+    }
+}
+
+extension Room {
+
+    @objc
+    public func connect(url: String,
+                        token: String,
+                        connectOptions: ConnectOptions? = nil,
+                        roomOptions: RoomOptions? = nil) -> Promise<Room>.ObjCPromise<Room> {
+        connect(url,
+                token,
+                connectOptions: connectOptions,
+                roomOptions: roomOptions).asObjCPromise()
+    }
+
+    @objc(disconnect)
+    @discardableResult
+    public func disconnectObjC() -> Promise<Void>.ObjCPromise<NSNull> {
+        disconnect().asObjCPromise()
+    }
+}
+
+extension LocalParticipant {
+
+    @objc
+    @discardableResult
+    public func setCamera(enabled: Bool) -> Promise<LocalTrackPublication?>.ObjCPromise<LocalTrackPublication> {
+        setCamera(enabled: enabled).asObjCPromise()
+    }
+
+    @objc
+    @discardableResult
+    public func setMicrophone(enabled: Bool) -> Promise<LocalTrackPublication?>.ObjCPromise<LocalTrackPublication> {
+        setMicrophone(enabled: enabled).asObjCPromise()
+    }
+}
+
+extension CameraCapturer {
+
+    @objc
+    @discardableResult
+    public func switchCameraPosition() -> Promise<Bool>.ObjCPromise<NSNumber> {
+        switchCameraPosition().asObjCPromise()
+    }
+
+    @objc
+    public func setCameraPosition(_ position: AVCaptureDevice.Position) -> Promise<Bool>.ObjCPromise<NSNumber> {
+        setCameraPosition(position).asObjCPromise()
+    }
+}
+
+extension Track {
+
+    @objc(start)
+    @discardableResult
+    public func startObjC() -> Promise<Bool>.ObjCPromise<NSNumber> {
+        start().asObjCPromise()
+    }
+
+    @objc(stop)
+    @discardableResult
+    public func stopObjC() -> Promise<Bool>.ObjCPromise<NSNumber> {
+        stop().asObjCPromise()
+    }
+}

--- a/Sources/LiveKit/ObjCSupport.swift
+++ b/Sources/LiveKit/ObjCSupport.swift
@@ -43,10 +43,12 @@ extension ConnectionState {
 extension Room {
 
     @objc(connectWithURL:token:connectOptions:roomOptions:)
+    @discardableResult
     public func connect(url: String,
                         token: String,
                         connectOptions: ConnectOptions? = nil,
                         roomOptions: RoomOptions? = nil) -> Promise<Room>.ObjCPromise<Room> {
+
         connect(url,
                 token,
                 connectOptions: connectOptions,
@@ -56,6 +58,7 @@ extension Room {
     @objc(disconnect)
     @discardableResult
     public func disconnectObjC() -> Promise<Void>.ObjCPromise<NSNull> {
+
         disconnect().asObjCPromise()
     }
 }
@@ -65,18 +68,21 @@ extension LocalParticipant {
     @objc(setCameraEnabled:)
     @discardableResult
     public func setCameraObjC(enabled: Bool) -> Promise<LocalTrackPublication?>.ObjCPromise<LocalTrackPublication> {
+
         setCamera(enabled: enabled).asObjCPromise()
     }
 
     @objc(setMicrophoneEnabled:)
     @discardableResult
     public func setMicrophoneObjC(enabled: Bool) -> Promise<LocalTrackPublication?>.ObjCPromise<LocalTrackPublication> {
+
         setMicrophone(enabled: enabled).asObjCPromise()
     }
 
     @objc(setScreenShareEnabled:)
     @discardableResult
     public func setScreenShareObjC(enabled: Bool) -> Promise<LocalTrackPublication?>.ObjCPromise<LocalTrackPublication> {
+
         setScreenShare(enabled: enabled).asObjCPromise()
     }
 
@@ -99,7 +105,26 @@ extension LocalParticipant {
     @objc(unpublishPublication:)
     @discardableResult
     public func unpublishObjC(publication: LocalTrackPublication) -> Promise<Void>.ObjCPromise<NSNull> {
+
         unpublish(publication: publication).asObjCPromise()
+    }
+
+    @objc(publishData:reliability:destination:)
+    @discardableResult
+    public func publishDataObjC(data: Data,
+                                reliability: Reliability = .reliable,
+                                destination: [String] = []) -> Promise<Void>.ObjCPromise<NSNull> {
+
+        publishData(data: data, reliability: reliability, destination: destination).asObjCPromise()
+    }
+
+    @objc(setTrackSubscriptionPermissionsWithAllParticipantsAllowed:trackPermissions:)
+    @discardableResult
+    public func setTrackSubscriptionPermissionsObjC(allParticipantsAllowed: Bool,
+                                                    trackPermissions: [ParticipantTrackPermission] = []) -> Promise<Void>.ObjCPromise<NSNull> {
+
+        setTrackSubscriptionPermissions(allParticipantsAllowed: allParticipantsAllowed,
+                                        trackPermissions: trackPermissions).asObjCPromise()
     }
 }
 
@@ -108,11 +133,14 @@ extension CameraCapturer {
     @objc(switchCameraPosition)
     @discardableResult
     public func switchCameraPositionObjC() -> Promise<Bool>.ObjCPromise<NSNumber> {
+
         switchCameraPosition().asObjCPromise()
     }
 
     @objc(setCameraPosition:)
+    @discardableResult
     public func setCameraPositionObjC(_ position: AVCaptureDevice.Position) -> Promise<Bool>.ObjCPromise<NSNumber> {
+
         setCameraPosition(position).asObjCPromise()
     }
 }
@@ -122,12 +150,14 @@ extension Track {
     @objc(start)
     @discardableResult
     public func startObjC() -> Promise<Bool>.ObjCPromise<NSNumber> {
+
         start().asObjCPromise()
     }
 
     @objc(stop)
     @discardableResult
     public func stopObjC() -> Promise<Bool>.ObjCPromise<NSNumber> {
+
         stop().asObjCPromise()
     }
 }

--- a/Sources/LiveKit/ObjCSupport.swift
+++ b/Sources/LiveKit/ObjCSupport.swift
@@ -160,4 +160,18 @@ extension Track {
 
         stop().asObjCPromise()
     }
+
+    @objc(mute)
+    @discardableResult
+    public func muteObjC() -> Promise<Void>.ObjCPromise<NSNull> {
+
+        mute().asObjCPromise()
+    }
+
+    @objc(unmute)
+    @discardableResult
+    public func unmuteObjC() -> Promise<Void>.ObjCPromise<NSNull> {
+
+        unmute().asObjCPromise()
+    }
 }

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -491,19 +491,3 @@ extension LocalParticipant {
         return Promise(nil)
     }
 }
-
-// MARK: - Objective-C Support
-extension LocalParticipant {
-
-    @objc
-    @discardableResult
-    public func setCamera(enabled: Bool) -> Promise<LocalTrackPublication?>.ObjCPromise<LocalTrackPublication> {
-        setCamera(enabled: enabled).asObjCPromise()
-    }
-
-    @objc
-    @discardableResult
-    public func setMicrophone(enabled: Bool) -> Promise<LocalTrackPublication?>.ObjCPromise<LocalTrackPublication> {
-        setMicrophone(enabled: enabled).asObjCPromise()
-    }
-}

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -424,10 +424,12 @@ extension LocalParticipant {
 
 extension LocalParticipant {
 
+    @discardableResult
     public func setCamera(enabled: Bool) -> Promise<LocalTrackPublication?> {
         set(source: .camera, enabled: enabled)
     }
 
+    @discardableResult
     public func setMicrophone(enabled: Bool) -> Promise<LocalTrackPublication?> {
         set(source: .microphone, enabled: enabled)
     }
@@ -441,6 +443,7 @@ extension LocalParticipant {
     /// to capture other screens and windows. See ``MacOSScreenCapturer`` for details.
     ///
     /// For advanced usage, you can create a relevant ``LocalVideoTrack`` and call ``LocalParticipant/publishVideoTrack(track:publishOptions:)``.
+    @discardableResult
     public func setScreenShare(enabled: Bool) -> Promise<LocalTrackPublication?> {
         set(source: .screenShareVideo, enabled: enabled)
     }
@@ -486,5 +489,21 @@ extension LocalParticipant {
         }
 
         return Promise(nil)
+    }
+}
+
+// MARK: - Objective-C Support
+extension LocalParticipant {
+
+    @objc
+    @discardableResult
+    public func setCamera(enabled: Bool) -> Promise<LocalTrackPublication?>.ObjCPromise<LocalTrackPublication> {
+        setCamera(enabled: enabled).asObjCPromise()
+    }
+
+    @objc
+    @discardableResult
+    public func setMicrophone(enabled: Bool) -> Promise<LocalTrackPublication?>.ObjCPromise<LocalTrackPublication> {
+        setMicrophone(enabled: enabled).asObjCPromise()
     }
 }

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -18,7 +18,8 @@ import WebRTC
 import Promises
 import ReplayKit
 
-@objc public class LocalParticipant: Participant {
+@objc
+public class LocalParticipant: Participant {
 
     public var localAudioTracks: [LocalTrackPublication] { audioTracks.compactMap { $0 as? LocalTrackPublication } }
     public var localVideoTracks: [LocalTrackPublication] { videoTracks.compactMap { $0 as? LocalTrackPublication } }

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -18,7 +18,7 @@ import WebRTC
 import Promises
 import ReplayKit
 
-public class LocalParticipant: Participant {
+@objc public class LocalParticipant: Participant {
 
     public var localAudioTracks: [LocalTrackPublication] { audioTracks.compactMap { $0 as? LocalTrackPublication } }
     public var localVideoTracks: [LocalTrackPublication] { videoTracks.compactMap { $0 as? LocalTrackPublication } }

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -136,7 +136,7 @@ public class LocalParticipant: Participant {
         }.then(on: queue) { (transceiver, trackInfo) -> LocalTrackPublication in
 
             // store publishOptions used for this track
-            track.publishOptions = publishOptions
+            track._publishOptions = publishOptions
             track.transceiver = transceiver
 
             // prefer to maintainResolution for screen share

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -156,10 +156,10 @@ public class LocalParticipant: Participant {
 
             // notify didPublish
             self.notify(label: { "localParticipant.didPublish \(publication)" }) {
-                $0.localParticipant(self, didPublish: publication)
+                $0.localParticipant?(self, didPublish: publication)
             }
             self.room.notify(label: { "localParticipant.didPublish \(publication)" }) {
-                $0.room(self.room, localParticipant: self, didPublish: publication)
+                $0.room?(self.room, localParticipant: self, didPublish: publication)
             }
 
             self.log("[publish] success \(publication)", .info)
@@ -208,10 +208,10 @@ public class LocalParticipant: Participant {
                 guard _notify else { return }
                 // notify unpublish
                 self.notify(label: { "localParticipant.didUnpublish \(publication)" }) {
-                    $0.localParticipant(self, didUnpublish: publication)
+                    $0.localParticipant?(self, didUnpublish: publication)
                 }
                 self.room.notify(label: { "room.didUnpublish \(publication)" }) {
-                    $0.room(self.room, localParticipant: self, didUnpublish: publication)
+                    $0.room?(self.room, localParticipant: self, didUnpublish: publication)
                 }
             }
         }
@@ -374,10 +374,10 @@ public class LocalParticipant: Participant {
 
         if didUpdate {
             notify(label: { "participant.didUpdate permissions: \(newValue)" }) {
-                $0.participant(self, didUpdate: newValue)
+                $0.participant?(self, didUpdate: newValue)
             }
             room.notify(label: { "room.didUpdate permissions: \(newValue)" }) {
-                $0.room(self.room, participant: self, didUpdate: newValue)
+                $0.room?(self.room, participant: self, didUpdate: newValue)
             }
         }
 

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -21,14 +21,17 @@ import ReplayKit
 @objc
 public class LocalParticipant: Participant {
 
+    @objc
     public var localAudioTracks: [LocalTrackPublication] { audioTracks.compactMap { $0 as? LocalTrackPublication } }
+
+    @objc
     public var localVideoTracks: [LocalTrackPublication] { videoTracks.compactMap { $0 as? LocalTrackPublication } }
 
     private var allParticipantsAllowed: Bool = true
     private var trackPermissions: [ParticipantTrackPermission] = []
 
-    convenience init(from info: Livekit_ParticipantInfo,
-                     room: Room) {
+    internal convenience init(from info: Livekit_ParticipantInfo,
+                              room: Room) {
 
         self.init(sid: info.sid,
                   identity: info.identity,
@@ -38,8 +41,8 @@ public class LocalParticipant: Participant {
         updateFromInfo(info: info)
     }
 
-    public func getTrackPublication(sid: Sid) -> LocalTrackPublication? {
-        return tracks[sid] as? LocalTrackPublication
+    internal func getTrackPublication(sid: Sid) -> LocalTrackPublication? {
+        _state.tracks[sid] as? LocalTrackPublication
     }
 
     internal func publish(track: LocalTrack,

--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -18,7 +18,8 @@ import Foundation
 import WebRTC
 import Promises
 
-@objc public class Participant: NSObject, MulticastDelegateCapable, Loggable {
+@objc
+public class Participant: NSObject, MulticastDelegateCapable, Loggable {
 
     // MARK: - MulticastDelegate
 
@@ -27,15 +28,30 @@ import Promises
 
     internal let queue = DispatchQueue(label: "LiveKitSDK.participant", qos: .default)
 
-    @objc public let sid: Sid
-    @objc public var identity: String { _state.identity }
-    @objc public var name: String { _state.name }
-    @objc public var audioLevel: Float { _state.audioLevel }
-    @objc public var isSpeaking: Bool { _state.isSpeaking }
-    @objc public var metadata: String? { _state.metadata }
+    @objc
+    public let sid: Sid
+
+    @objc
+    public var identity: String { _state.identity }
+
+    @objc
+    public var name: String { _state.name }
+
+    @objc
+    public var audioLevel: Float { _state.audioLevel }
+
+    @objc
+    public var isSpeaking: Bool { _state.isSpeaking }
+
+    @objc
+    public var metadata: String? { _state.metadata }
+
     public var connectionQuality: ConnectionQuality { _state.connectionQuality }
     public var permissions: ParticipantPermissions { _state.permissions }
-    @objc public var joinedAt: Date? { _state.joinedAt }
+
+    @objc
+    public var joinedAt: Date? { _state.joinedAt }
+
     public var tracks: [String: TrackPublication] { _state.tracks }
 
     public var audioTracks: [TrackPublication] {

--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -46,18 +46,24 @@ public class Participant: NSObject, MulticastDelegateCapable, Loggable {
     @objc
     public var metadata: String? { _state.metadata }
 
+    @objc
     public var connectionQuality: ConnectionQuality { _state.connectionQuality }
+
+    @objc
     public var permissions: ParticipantPermissions { _state.permissions }
 
     @objc
     public var joinedAt: Date? { _state.joinedAt }
 
+    @objc
     public var tracks: [String: TrackPublication] { _state.tracks }
 
+    @objc
     public var audioTracks: [TrackPublication] {
         _state.tracks.values.filter { $0.kind == .audio }
     }
 
+    @objc
     public var videoTracks: [TrackPublication] {
         _state.tracks.values.filter { $0.kind == .video }
     }

--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -18,19 +18,24 @@ import Foundation
 import WebRTC
 import Promises
 
-public class Participant: MulticastDelegate<ParticipantDelegate> {
+@objc public class Participant: NSObject, MulticastDelegateCapable, Loggable {
+
+    // MARK: - MulticastDelegate
+
+    public typealias DelegateType = ParticipantDelegate
+    public var delegates = MulticastDelegate<DelegateType>()
 
     internal let queue = DispatchQueue(label: "LiveKitSDK.participant", qos: .default)
 
-    public let sid: Sid
-    public var identity: String { _state.identity }
-    public var name: String { _state.name }
-    public var audioLevel: Float { _state.audioLevel }
-    public var isSpeaking: Bool { _state.isSpeaking }
-    public var metadata: String? { _state.metadata }
+    @objc public let sid: Sid
+    @objc public var identity: String { _state.identity }
+    @objc public var name: String { _state.name }
+    @objc public var audioLevel: Float { _state.audioLevel }
+    @objc public var isSpeaking: Bool { _state.isSpeaking }
+    @objc public var metadata: String? { _state.metadata }
     public var connectionQuality: ConnectionQuality { _state.connectionQuality }
     public var permissions: ParticipantPermissions { _state.permissions }
-    public var joinedAt: Date? { _state.joinedAt }
+    @objc public var joinedAt: Date? { _state.joinedAt }
     public var tracks: [String: TrackPublication] { _state.tracks }
 
     public var audioTracks: [TrackPublication] {

--- a/Sources/LiveKit/Participant/RemoteParticipant.swift
+++ b/Sources/LiveKit/Participant/RemoteParticipant.swift
@@ -64,10 +64,10 @@ public class RemoteParticipant: Participant {
             for publication in newTrackPublications.values {
 
                 self.notify(label: { "participant.didPublish \(publication)" }) {
-                    $0.participant(self, didPublish: publication)
+                    $0.participant?(self, didPublish: publication)
                 }
                 self.room.notify(label: { "room.didPublish \(publication)" }) {
-                    $0.room(self.room, participant: self, didPublish: publication)
+                    $0.room?(self.room, participant: self, didPublish: publication)
                 }
             }
         }
@@ -90,10 +90,10 @@ public class RemoteParticipant: Participant {
             log("Could not subscribe to mediaTrack \(sid), unable to locate track publication. existing sids: (\(_state.tracks.keys.joined(separator: ", ")))", .error)
             let error = TrackError.state(message: "Could not find published track with sid: \(sid)")
             notify(label: { "participant.didFailToSubscribe trackSid: \(sid)" }) {
-                $0.participant(self, didFailToSubscribe: sid, error: error)
+                $0.participant?(self, didFailToSubscribe: sid, error: error)
             }
             room.notify(label: { "room.didFailToSubscribe trackSid: \(sid)" }) {
-                $0.room(self.room, participant: self, didFailToSubscribe: sid, error: error)
+                $0.room?(self.room, participant: self, didFailToSubscribe: sid, error: error)
             }
             return Promise(error)
         }
@@ -110,10 +110,10 @@ public class RemoteParticipant: Participant {
         default:
             let error = TrackError.type(message: "Unsupported type: \(rtcTrack.kind.description)")
             notify(label: { "participant.didFailToSubscribe trackSid: \(sid)" }) {
-                $0.participant(self, didFailToSubscribe: sid, error: error)
+                $0.participant?(self, didFailToSubscribe: sid, error: error)
             }
             room.notify(label: { "room.didFailToSubscribe trackSid: \(sid)" }) {
-                $0.room(self.room, participant: self, didFailToSubscribe: sid, error: error)
+                $0.room?(self.room, participant: self, didFailToSubscribe: sid, error: error)
             }
             return Promise(error)
         }
@@ -125,10 +125,10 @@ public class RemoteParticipant: Participant {
         addTrack(publication: publication)
         return track.start().then(on: queue) { _ -> Void in
             self.notify(label: { "participant.didSubscribe \(publication)" }) {
-                $0.participant(self, didSubscribe: publication, track: track)
+                $0.participant?(self, didSubscribe: publication, track: track)
             }
             self.room.notify(label: { "room.didSubscribe \(publication)" }) {
-                $0.room(self.room, participant: self, didSubscribe: publication, track: track)
+                $0.room?(self.room, participant: self, didSubscribe: publication, track: track)
             }
         }
     }
@@ -136,7 +136,7 @@ public class RemoteParticipant: Participant {
     internal override func cleanUp(notify _notify: Bool = true) -> Promise<Void> {
         super.cleanUp(notify: _notify).then(on: queue) {
             self.room.notify(label: { "room.participantDidLeave" }) {
-                $0.room(self.room, participantDidLeave: self)
+                $0.room?(self.room, participantDidLeave: self)
             }
         }
     }
@@ -157,10 +157,10 @@ public class RemoteParticipant: Participant {
                 guard let self = self, _notify else { return }
                 // notify unpublish
                 self.notify(label: { "participant.didUnpublish \(publication)" }) {
-                    $0.participant(self, didUnpublish: publication)
+                    $0.participant?(self, didUnpublish: publication)
                 }
                 self.room.notify(label: { "room.didUnpublish \(publication)" }) {
-                    $0.room(self.room, participant: self, didUnpublish: publication)
+                    $0.room?(self.room, participant: self, didUnpublish: publication)
                 }
             }
         }
@@ -178,10 +178,10 @@ public class RemoteParticipant: Participant {
             guard _notify else { return }
             // notify unsubscribe
             self.notify(label: { "participant.didUnsubscribe \(publication)" }) {
-                $0.participant(self, didUnsubscribe: publication, track: track)
+                $0.participant?(self, didUnsubscribe: publication, track: track)
             }
             self.room.notify(label: { "room.didUnsubscribe \(publication)" }) {
-                $0.room(self.room, participant: self, didUnsubscribe: publication, track: track)
+                $0.room?(self.room, participant: self, didUnsubscribe: publication, track: track)
             }
         }.then(on: queue) {
             notifyUnpublish()

--- a/Sources/LiveKit/Participant/RemoteParticipant.swift
+++ b/Sources/LiveKit/Participant/RemoteParticipant.swift
@@ -18,7 +18,7 @@ import Foundation
 import WebRTC
 import Promises
 
-public class RemoteParticipant: Participant {
+@objc public class RemoteParticipant: Participant {
 
     init(sid: Sid,
          info: Livekit_ParticipantInfo?,

--- a/Sources/LiveKit/Participant/RemoteParticipant.swift
+++ b/Sources/LiveKit/Participant/RemoteParticipant.swift
@@ -18,7 +18,8 @@ import Foundation
 import WebRTC
 import Promises
 
-@objc public class RemoteParticipant: Participant {
+@objc
+public class RemoteParticipant: Participant {
 
     init(sid: Sid,
          info: Livekit_ParticipantInfo?,

--- a/Sources/LiveKit/Participant/RemoteParticipant.swift
+++ b/Sources/LiveKit/Participant/RemoteParticipant.swift
@@ -21,9 +21,9 @@ import Promises
 @objc
 public class RemoteParticipant: Participant {
 
-    init(sid: Sid,
-         info: Livekit_ParticipantInfo?,
-         room: Room) {
+    internal init(sid: Sid,
+                  info: Livekit_ParticipantInfo?,
+                  room: Room) {
 
         super.init(sid: sid,
                    identity: info?.identity ?? "",
@@ -35,8 +35,8 @@ public class RemoteParticipant: Participant {
         }
     }
 
-    public func getTrackPublication(sid: Sid) -> RemoteTrackPublication? {
-        return _state.tracks[sid] as? RemoteTrackPublication
+    internal func getTrackPublication(sid: Sid) -> RemoteTrackPublication? {
+        _state.tracks[sid] as? RemoteTrackPublication
     }
 
     override func updateFromInfo(info: Livekit_ParticipantInfo) {
@@ -83,7 +83,7 @@ public class RemoteParticipant: Participant {
         }
     }
 
-    func addSubscribedMediaTrack(rtcTrack: RTCMediaStreamTrack, sid: Sid) -> Promise<Void> {
+    internal func addSubscribedMediaTrack(rtcTrack: RTCMediaStreamTrack, sid: Sid) -> Promise<Void> {
         var track: Track
 
         guard let publication = getTrackPublication(sid: sid) else {
@@ -133,7 +133,7 @@ public class RemoteParticipant: Participant {
         }
     }
 
-    override func cleanUp(notify _notify: Bool = true) -> Promise<Void> {
+    internal override func cleanUp(notify _notify: Bool = true) -> Promise<Void> {
         super.cleanUp(notify: _notify).then(on: queue) {
             self.room.notify(label: { "room.participantDidLeave" }) {
                 $0.room(self.room, participantDidLeave: self)

--- a/Sources/LiveKit/Protocols/ParticipantDelegate.swift
+++ b/Sources/LiveKit/Protocols/ParticipantDelegate.swift
@@ -48,57 +48,57 @@ public protocol ParticipantDelegate: AnyObject {
     /// or if the server has requested the participant to be muted.
     ///
     /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.
-    @objc(participant:didUpdatePublication:muted:) optional
+    @objc(participant:publication:didUpdateMuted:) optional
     func participant(_ participant: Participant, didUpdate publication: TrackPublication, muted: Bool)
 
     @objc(participant:didUpdatePermissions:) optional
     func participant(_ participant: Participant, didUpdate permissions: ParticipantPermissions)
 
     /// ``RemoteTrackPublication/streamState`` has updated for the ``RemoteParticipant``.
-    @objc optional
+    @objc(participant:publication:didUpdateStreamState:) optional
     func participant(_ participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, streamState: StreamState)
 
     /// ``RemoteTrackPublication/subscriptionAllowed`` has updated for the ``RemoteParticipant``.
-    @objc optional
+    @objc(participant:publication:didUpdateCanSubscribe:) optional
     func participant(_ participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, permission allowed: Bool)
 
     /// When a new ``RemoteTrackPublication`` is published to ``Room`` after the ``LocalParticipant`` has joined.
     ///
     /// This delegate method will not be called for tracks that are already published.
-    @objc optional
+    @objc(remoteParticipant:didPublish:) optional
     func participant(_ participant: RemoteParticipant, didPublish publication: RemoteTrackPublication)
 
     /// The ``RemoteParticipant`` has unpublished a ``RemoteTrackPublication``.
-    @objc optional
+    @objc(remoteParticipant:didUnpublish:) optional
     func participant(_ participant: RemoteParticipant, didUnpublish publication: RemoteTrackPublication)
 
     /// The ``LocalParticipant`` has published a ``LocalTrackPublication``.
-    @objc optional
+    @objc(localParticipant:didPublish:) optional
     func localParticipant(_ participant: LocalParticipant, didPublish publication: LocalTrackPublication)
 
     /// The ``LocalParticipant`` has unpublished a ``LocalTrackPublication``.
-    @objc optional
+    @objc(localParticipant:didUnpublish:) optional
     func localParticipant(_ participant: LocalParticipant, didUnpublish publication: LocalTrackPublication)
 
     /// The ``LocalParticipant`` has subscribed to a new ``RemoteTrackPublication``.
     ///
     /// This event will always fire as long as new tracks are ready for use.
-    @objc optional
+    @objc(participant:didSubscribe:track:) optional
     func participant(_ participant: RemoteParticipant, didSubscribe publication: RemoteTrackPublication, track: Track)
 
     /// Could not subscribe to a track.
     ///
     /// This is an error state, the subscription can be retried.
-    @objc optional
+    @objc(participant:didFailToSubscribeTrackWithSid:error:) optional
     func participant(_ participant: RemoteParticipant, didFailToSubscribe trackSid: String, error: Error)
 
     /// Unsubscribed from a ``RemoteTrackPublication`` and  is no longer available.
     ///
     /// Clients should listen to this event and handle cleanup.
-    @objc optional
+    @objc(participant:didUnsubscribePublication:track:) optional
     func participant(_ participant: RemoteParticipant, didUnsubscribe publication: RemoteTrackPublication, track: Track)
 
     /// Data was received from a ``RemoteParticipant``.
-    @objc optional
+    @objc(participant:didReceiveData:) optional
     func participant(_ participant: RemoteParticipant, didReceive data: Data)
 }

--- a/Sources/LiveKit/Protocols/ParticipantDelegate.swift
+++ b/Sources/LiveKit/Protocols/ParticipantDelegate.swift
@@ -24,18 +24,22 @@ import Foundation
 ///
 /// To ensure each participant's delegate is registered, you can look through ``Room/localParticipant`` and ``Room/remoteParticipants`` on connect
 /// and register it on new participants inside ``RoomDelegate/room(_:participantDidJoin:)-9bkm4``
+@objc
 public protocol ParticipantDelegate: AnyObject {
 
     /// A ``Participant``'s metadata has updated.
     /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.
+    @objc(participant:didUpdateMetadata:) optional
     func participant(_ participant: Participant, didUpdate metadata: String?)
 
     /// The isSpeaking status of a ``Participant`` has changed.
     /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.
+    @objc(participant:didUpdateSpeaking:) optional
     func participant(_ participant: Participant, didUpdate speaking: Bool)
 
     /// The connection quality of a ``Participant`` has updated.
     /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.
+    @objc(participant:didUpdateConnectionQuality:) optional
     func participant(_ participant: Participant, didUpdate connectionQuality: ConnectionQuality)
 
     /// `muted` state has updated for the ``Participant``'s ``TrackPublication``.
@@ -44,64 +48,57 @@ public protocol ParticipantDelegate: AnyObject {
     /// or if the server has requested the participant to be muted.
     ///
     /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.
+    @objc(participant:didUpdatePublication:muted:) optional
     func participant(_ participant: Participant, didUpdate publication: TrackPublication, muted: Bool)
 
+    @objc(participant:didUpdatePermissions:) optional
     func participant(_ participant: Participant, didUpdate permissions: ParticipantPermissions)
 
     /// ``RemoteTrackPublication/streamState`` has updated for the ``RemoteParticipant``.
+    @objc optional
     func participant(_ participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, streamState: StreamState)
 
     /// ``RemoteTrackPublication/subscriptionAllowed`` has updated for the ``RemoteParticipant``.
+    @objc optional
     func participant(_ participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, permission allowed: Bool)
 
     /// When a new ``RemoteTrackPublication`` is published to ``Room`` after the ``LocalParticipant`` has joined.
     ///
     /// This delegate method will not be called for tracks that are already published.
+    @objc optional
     func participant(_ participant: RemoteParticipant, didPublish publication: RemoteTrackPublication)
 
     /// The ``RemoteParticipant`` has unpublished a ``RemoteTrackPublication``.
+    @objc optional
     func participant(_ participant: RemoteParticipant, didUnpublish publication: RemoteTrackPublication)
 
     /// The ``LocalParticipant`` has published a ``LocalTrackPublication``.
+    @objc optional
     func localParticipant(_ participant: LocalParticipant, didPublish publication: LocalTrackPublication)
 
     /// The ``LocalParticipant`` has unpublished a ``LocalTrackPublication``.
+    @objc optional
     func localParticipant(_ participant: LocalParticipant, didUnpublish publication: LocalTrackPublication)
 
     /// The ``LocalParticipant`` has subscribed to a new ``RemoteTrackPublication``.
     ///
     /// This event will always fire as long as new tracks are ready for use.
+    @objc optional
     func participant(_ participant: RemoteParticipant, didSubscribe publication: RemoteTrackPublication, track: Track)
 
     /// Could not subscribe to a track.
     ///
     /// This is an error state, the subscription can be retried.
+    @objc optional
     func participant(_ participant: RemoteParticipant, didFailToSubscribe trackSid: String, error: Error)
 
     /// Unsubscribed from a ``RemoteTrackPublication`` and  is no longer available.
     ///
     /// Clients should listen to this event and handle cleanup.
+    @objc optional
     func participant(_ participant: RemoteParticipant, didUnsubscribe publication: RemoteTrackPublication, track: Track)
 
     /// Data was received from a ``RemoteParticipant``.
+    @objc optional
     func participant(_ participant: RemoteParticipant, didReceive data: Data)
-}
-
-/// Default implementation for ``ParticipantDelegate``
-public extension ParticipantDelegate {
-    func participant(_ participant: Participant, didUpdate metadata: String?) {}
-    func participant(_ participant: Participant, didUpdate speaking: Bool) {}
-    func participant(_ participant: Participant, didUpdate connectionQuality: ConnectionQuality) {}
-    func participant(_ participant: Participant, didUpdate publication: TrackPublication, muted: Bool) {}
-    func participant(_ participant: Participant, didUpdate permissions: ParticipantPermissions) {}
-    func participant(_ participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, streamState: StreamState) {}
-    func participant(_ participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, permission allowed: Bool) {}
-    func participant(_ participant: RemoteParticipant, didPublish publication: RemoteTrackPublication) {}
-    func participant(_ participant: RemoteParticipant, didUnpublish publication: RemoteTrackPublication) {}
-    func participant(_ participant: RemoteParticipant, didSubscribe publication: RemoteTrackPublication, track: Track) {}
-    func participant(_ participant: RemoteParticipant, didFailToSubscribe trackSid: String, error: Error) {}
-    func participant(_ participant: RemoteParticipant, didUnsubscribe publication: RemoteTrackPublication, track: Track) {}
-    func participant(_ participant: RemoteParticipant, didReceive data: Data) {}
-    func localParticipant(_ participant: LocalParticipant, didPublish publication: LocalTrackPublication) {}
-    func localParticipant(_ participant: LocalParticipant, didUnpublish publication: LocalTrackPublication) {}
 }

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -16,6 +16,10 @@
 
 import Foundation
 
+// @objc public protocol RoomDelegateObjC: AnyObject {
+//    @objc optional func room(_ room: Room, didUpdate connectionState: ConnectionStateObjC, oldValue: ConnectionStateObjC)
+// }
+
 /// ``RoomDelegate`` receives room events as well as ``Participant`` events.
 ///
 /// > Important: The thread which the delegate will be called on, is not guranteed to be the `main` thread.

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -18,8 +18,96 @@ import Foundation
 
 @objc
 public protocol RoomDelegateObjC: AnyObject {
-    @objc optional
+    @objc(room:didUpdateConnectionState:oldConnectionState:) optional
     func room(_ room: Room, didUpdate connectionState: ConnectionStateObjC, oldValue: ConnectionStateObjC)
+
+    /// Successfully connected to the room.
+    @objc optional
+    func room(_ room: Room, didConnect isReconnect: Bool)
+
+    /// Could not connect to the room.
+    @objc optional
+    func room(_ room: Room, didFailToConnect error: Error)
+
+    /// Client disconnected from the room unexpectedly.
+    @objc optional
+    func room(_ room: Room, didDisconnect error: Error?)
+
+    /// When a ``RemoteParticipant`` joins after the ``LocalParticipant``.
+    /// It will not emit events for participants that are already in the room.
+    @objc optional
+    func room(_ room: Room, participantDidJoin participant: RemoteParticipant)
+
+    /// When a ``RemoteParticipant`` leaves after the ``LocalParticipant`` has joined.
+    @objc optional
+    func room(_ room: Room, participantDidLeave participant: RemoteParticipant)
+
+    /// Active speakers changed.
+    ///
+    /// List of speakers are ordered by their ``Participant/audioLevel``, loudest speakers first.
+    /// This will include the ``LocalParticipant`` too.
+    @objc(room:didUpdateSpeakers:) optional
+    func room(_ room: Room, didUpdate speakers: [Participant])
+
+    /// ``Room``'s metadata has been updated.
+    @objc(room:didUpdateMetadata:) optional
+    func room(_ room: Room, didUpdate metadata: String?)
+
+    /// Same with ``ParticipantDelegate/participant(_:didUpdate:)-46iut``.
+    @objc(room:participant:didUpdateMetadata:) optional
+    func room(_ room: Room, participant: Participant, didUpdate metadata: String?)
+
+    /// Same with ``ParticipantDelegate/participant(_:didUpdate:)-7zxk1``.
+    @objc(room:participant:didUpdateConnectionQuality:) optional
+    func room(_ room: Room, participant: Participant, didUpdate connectionQuality: ConnectionQuality)
+
+    /// Same with ``ParticipantDelegate/participant(_:didUpdate:)-84m89``.
+    @objc(room:participant:publication:didUpdateMuted:) optional
+    func room(_ room: Room, participant: Participant, didUpdate publication: TrackPublication, muted: Bool)
+
+    @objc(room:participant:didUpdatePermissions:) optional
+    func room(_ room: Room, participant: Participant, didUpdate permissions: ParticipantPermissions)
+
+    /// Same with ``ParticipantDelegate/participant(_:didUpdate:streamState:)-1lu8t``.
+    @objc(room:participant:publication:didUpdateStreamState:) optional
+    func room(_ room: Room, participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, streamState: StreamState)
+
+    /// Same with ``ParticipantDelegate/participant(_:didPublish:)-60en3``.
+    @objc(room:participant:didPublishPublication:) optional
+    func room(_ room: Room, participant: RemoteParticipant, didPublish publication: RemoteTrackPublication)
+
+    /// Same with ``ParticipantDelegate/participant(_:didUnpublish:)-3bkga``.
+    @objc(room:participant:didUnpublishPublication:) optional
+    func room(_ room: Room, participant: RemoteParticipant, didUnpublish publication: RemoteTrackPublication)
+
+    /// Same with ``ParticipantDelegate/participant(_:didSubscribe:track:)-7mngl``.
+    @objc(room:participant:didSubscribePublication:track:) optional
+    func room(_ room: Room, participant: RemoteParticipant, didSubscribe publication: RemoteTrackPublication, track: Track)
+
+    /// Same with ``ParticipantDelegate/participant(_:didFailToSubscribe:error:)-10pn4``.
+    @objc optional
+    func room(_ room: Room, participant: RemoteParticipant, didFailToSubscribe trackSid: String, error: Error)
+
+    /// Same with ``ParticipantDelegate/participant(_:didUnsubscribe:track:)-3ksvp``.
+    @objc(room:publication:didUnsubscribePublication:track:) optional
+    func room(_ room: Room, participant: RemoteParticipant, didUnsubscribe publication: RemoteTrackPublication, track: Track)
+
+    /// Same with ``ParticipantDelegate/participant(_:didReceive:)-2t55a``
+    /// participant could be nil if data was sent by server api.
+    @objc(room:participant:didReceiveData:) optional
+    func room(_ room: Room, participant: RemoteParticipant?, didReceive data: Data)
+
+    /// Same with ``ParticipantDelegate/localParticipant(_:didPublish:)-90j2m``.
+    @objc(room:localParticipant:didPublishPublication:) optional
+    func room(_ room: Room, localParticipant: LocalParticipant, didPublish publication: LocalTrackPublication)
+
+    /// Same with ``ParticipantDelegate/participant(_:didUnpublish:)-3bkga``.
+    @objc(room:localParticipant:didUnpublishPublication:) optional
+    func room(_ room: Room, localParticipant: LocalParticipant, didUnpublish publication: LocalTrackPublication)
+
+    /// Same with ``ParticipantDelegate/participant(_:didUpdate:permission:)``.
+    @objc optional
+    func room(_ room: Room, participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, permission allowed: Bool)
 }
 
 /// ``RoomDelegate`` receives room events as well as ``Participant`` events.
@@ -37,100 +125,13 @@ public protocol RoomDelegateObjC: AnyObject {
 /// }
 /// ```
 /// See the source code of [Swift Example App](https://github.com/livekit/client-example-swift) for more examples.
-public protocol RoomDelegate: AnyObject {
-    /// Successfully connected to the room.
-    func room(_ room: Room, didConnect isReconnect: Bool)
-
-    /// Could not connect to the room.
-    func room(_ room: Room, didFailToConnect error: Error)
-
-    /// Client disconnected from the room unexpectedly.
-    func room(_ room: Room, didDisconnect error: Error?)
-
+public protocol RoomDelegate: RoomDelegateObjC {
     /// When the ``ConnectionState`` has updated.
     func room(_ room: Room, didUpdate connectionState: ConnectionState, oldValue: ConnectionState)
-
-    /// When a ``RemoteParticipant`` joins after the ``LocalParticipant``.
-    /// It will not emit events for participants that are already in the room.
-    func room(_ room: Room, participantDidJoin participant: RemoteParticipant)
-
-    /// When a ``RemoteParticipant`` leaves after the ``LocalParticipant`` has joined.
-    func room(_ room: Room, participantDidLeave participant: RemoteParticipant)
-
-    /// Active speakers changed.
-    ///
-    /// List of speakers are ordered by their ``Participant/audioLevel``, loudest speakers first.
-    /// This will include the ``LocalParticipant`` too.
-    func room(_ room: Room, didUpdate speakers: [Participant])
-
-    /// ``Room``'s metadata has been updated.
-    func room(_ room: Room, didUpdate metadata: String?)
-
-    /// Same with ``ParticipantDelegate/participant(_:didUpdate:)-46iut``.
-    func room(_ room: Room, participant: Participant, didUpdate metadata: String?)
-
-    /// Same with ``ParticipantDelegate/participant(_:didUpdate:)-7zxk1``.
-    func room(_ room: Room, participant: Participant, didUpdate connectionQuality: ConnectionQuality)
-
-    /// Same with ``ParticipantDelegate/participant(_:didUpdate:)-84m89``.
-    func room(_ room: Room, participant: Participant, didUpdate publication: TrackPublication, muted: Bool)
-
-    func room(_ room: Room, participant: Participant, didUpdate permissions: ParticipantPermissions)
-
-    /// Same with ``ParticipantDelegate/participant(_:didUpdate:streamState:)-1lu8t``.
-    func room(_ room: Room, participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, streamState: StreamState)
-
-    /// Same with ``ParticipantDelegate/participant(_:didPublish:)-60en3``.
-    func room(_ room: Room, participant: RemoteParticipant, didPublish publication: RemoteTrackPublication)
-
-    /// Same with ``ParticipantDelegate/participant(_:didUnpublish:)-3bkga``.
-    func room(_ room: Room, participant: RemoteParticipant, didUnpublish publication: RemoteTrackPublication)
-
-    /// Same with ``ParticipantDelegate/participant(_:didSubscribe:track:)-7mngl``.
-    func room(_ room: Room, participant: RemoteParticipant, didSubscribe publication: RemoteTrackPublication, track: Track)
-
-    /// Same with ``ParticipantDelegate/participant(_:didFailToSubscribe:error:)-10pn4``.
-    func room(_ room: Room, participant: RemoteParticipant, didFailToSubscribe trackSid: String, error: Error)
-
-    /// Same with ``ParticipantDelegate/participant(_:didUnsubscribe:track:)-3ksvp``.
-    func room(_ room: Room, participant: RemoteParticipant, didUnsubscribe publication: RemoteTrackPublication, track: Track)
-
-    /// Same with ``ParticipantDelegate/participant(_:didReceive:)-2t55a``
-    /// participant could be nil if data was sent by server api.
-    func room(_ room: Room, participant: RemoteParticipant?, didReceive data: Data)
-
-    /// Same with ``ParticipantDelegate/localParticipant(_:didPublish:)-90j2m``.
-    func room(_ room: Room, localParticipant: LocalParticipant, didPublish publication: LocalTrackPublication)
-
-    /// Same with ``ParticipantDelegate/participant(_:didUnpublish:)-3bkga``.
-    func room(_ room: Room, localParticipant: LocalParticipant, didUnpublish publication: LocalTrackPublication)
-
-    /// Same with ``ParticipantDelegate/participant(_:didUpdate:permission:)``.
-    func room(_ room: Room, participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, permission allowed: Bool)
 }
 
 /// Default implementation for ``RoomDelegate``
 public extension RoomDelegate {
-    func room(_ room: Room, didConnect isReconnect: Bool) {}
-    func room(_ room: Room, didFailToConnect error: Error) {}
-    func room(_ room: Room, didDisconnect error: Error?) {}
+
     func room(_ room: Room, didUpdate connectionState: ConnectionState, oldValue: ConnectionState) {}
-    func room(_ room: Room, participantDidJoin participant: RemoteParticipant) {}
-    func room(_ room: Room, participantDidLeave participant: RemoteParticipant) {}
-    func room(_ room: Room, didUpdate speakers: [Participant]) {}
-    func room(_ room: Room, didUpdate metadata: String?) {}
-    func room(_ room: Room, participant: Participant, didUpdate metadata: String?) {}
-    func room(_ room: Room, participant: Participant, didUpdate publication: TrackPublication, muted: Bool) {}
-    func room(_ room: Room, participant: Participant, didUpdate permissions: ParticipantPermissions) {}
-    func room(_ room: Room, participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, streamState: StreamState) {}
-    func room(_ room: Room, participant: Participant, didUpdate connectionQuality: ConnectionQuality) {}
-    func room(_ room: Room, participant: RemoteParticipant, didPublish publication: RemoteTrackPublication) {}
-    func room(_ room: Room, participant: RemoteParticipant, didUnpublish publication: RemoteTrackPublication) {}
-    func room(_ room: Room, participant: RemoteParticipant, didSubscribe publication: RemoteTrackPublication, track: Track) {}
-    func room(_ room: Room, participant: RemoteParticipant, didFailToSubscribe trackSid: String, error: Error) {}
-    func room(_ room: Room, participant: RemoteParticipant, didUnsubscribe publication: RemoteTrackPublication, track: Track) {}
-    func room(_ room: Room, participant: RemoteParticipant?, didReceive data: Data) {}
-    func room(_ room: Room, localParticipant: LocalParticipant, didPublish publication: LocalTrackPublication) {}
-    func room(_ room: Room, localParticipant: LocalParticipant, didUnpublish publication: LocalTrackPublication) {}
-    func room(_ room: Room, participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, permission allowed: Bool) {}
 }

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -16,6 +16,21 @@
 
 import Foundation
 
+/// ``RoomDelegate`` receives room events as well as ``Participant`` events.
+///
+/// > Important: The thread which the delegate will be called on, is not guranteed to be the `main` thread.
+/// If you will perform any UI update from the delegate, ensure the execution is from the `main` thread.
+///
+/// ## Example usage
+/// ```swift
+/// func room(_ room: Room, localParticipant: LocalParticipant, didPublish publication: LocalTrackPublication) {
+///   DispatchQueue.main.async {
+///     // update UI here
+///     self.localVideoView.isHidden = false
+///   }
+/// }
+/// ```
+/// See the source code of [Swift Example App](https://github.com/livekit/client-example-swift) for more examples.
 @objc
 public protocol RoomDelegateObjC: AnyObject {
 
@@ -111,21 +126,6 @@ public protocol RoomDelegateObjC: AnyObject {
     func room(_ room: Room, participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, permission allowed: Bool)
 }
 
-/// ``RoomDelegate`` receives room events as well as ``Participant`` events.
-///
-/// > Important: The thread which the delegate will be called on, is not guranteed to be the `main` thread.
-/// If you will perform any UI update from the delegate, ensure the execution is from the `main` thread.
-///
-/// ## Example usage
-/// ```swift
-/// func room(_ room: Room, localParticipant: LocalParticipant, didPublish publication: LocalTrackPublication) {
-///   DispatchQueue.main.async {
-///     // update UI here
-///     self.localVideoView.isHidden = false
-///   }
-/// }
-/// ```
-/// See the source code of [Swift Example App](https://github.com/livekit/client-example-swift) for more examples.
 public protocol RoomDelegate: RoomDelegateObjC {
     /// When the ``ConnectionState`` has updated.
     func room(_ room: Room, didUpdate connectionState: ConnectionState, oldValue: ConnectionState)

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -18,28 +18,29 @@ import Foundation
 
 @objc
 public protocol RoomDelegateObjC: AnyObject {
+
     @objc(room:didUpdateConnectionState:oldConnectionState:) optional
-    func room(_ room: Room, didUpdate connectionState: ConnectionStateObjC, oldValue: ConnectionStateObjC)
+    func room(_ room: Room, didUpdate connectionState: ConnectionStateObjC, oldValue oldConnectionState: ConnectionStateObjC)
 
     /// Successfully connected to the room.
-    @objc optional
+    @objc(room:didConnectIsReconnect:) optional
     func room(_ room: Room, didConnect isReconnect: Bool)
 
     /// Could not connect to the room.
-    @objc optional
+    @objc(room:didFailToConnectWithError:) optional
     func room(_ room: Room, didFailToConnect error: Error)
 
     /// Client disconnected from the room unexpectedly.
-    @objc optional
+    @objc(room:didDisconnectWithError:) optional
     func room(_ room: Room, didDisconnect error: Error?)
 
     /// When a ``RemoteParticipant`` joins after the ``LocalParticipant``.
     /// It will not emit events for participants that are already in the room.
-    @objc optional
+    @objc(room:participantDidJoin:) optional
     func room(_ room: Room, participantDidJoin participant: RemoteParticipant)
 
     /// When a ``RemoteParticipant`` leaves after the ``LocalParticipant`` has joined.
-    @objc optional
+    @objc(room:participantDidLeave:) optional
     func room(_ room: Room, participantDidLeave participant: RemoteParticipant)
 
     /// Active speakers changed.

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -16,9 +16,11 @@
 
 import Foundation
 
-// @objc public protocol RoomDelegateObjC: AnyObject {
-//    @objc optional func room(_ room: Room, didUpdate connectionState: ConnectionStateObjC, oldValue: ConnectionStateObjC)
-// }
+@objc
+public protocol RoomDelegateObjC: AnyObject {
+    @objc optional
+    func room(_ room: Room, didUpdate connectionState: ConnectionStateObjC, oldValue: ConnectionStateObjC)
+}
 
 /// ``RoomDelegate`` receives room events as well as ``Participant`` events.
 ///

--- a/Sources/LiveKit/Protocols/TrackDelegate.swift
+++ b/Sources/LiveKit/Protocols/TrackDelegate.swift
@@ -17,7 +17,8 @@
 import Foundation
 import WebRTC
 
-@objc public protocol TrackDelegate: AnyObject {
+@objc
+public protocol TrackDelegate: AnyObject {
     /// Dimensions of the video track has updated
     @objc(track:didUpdateDimensions:) optional
     func track(_ track: VideoTrack, didUpdate dimensions: Dimensions?)

--- a/Sources/LiveKit/Protocols/TrackDelegate.swift
+++ b/Sources/LiveKit/Protocols/TrackDelegate.swift
@@ -17,25 +17,24 @@
 import Foundation
 import WebRTC
 
-public protocol TrackDelegate: AnyObject {
+@objc public protocol TrackDelegate: AnyObject {
     /// Dimensions of the video track has updated
+    @objc(track:didUpdateDimensions:) optional
     func track(_ track: VideoTrack, didUpdate dimensions: Dimensions?)
+
     /// A ``VideoView`` was attached to the ``VideoTrack``
+    @objc optional
     func track(_ track: VideoTrack, didAttach videoView: VideoView)
+
     /// A ``VideoView`` was detached from the ``VideoTrack``
+    @objc optional
     func track(_ track: VideoTrack, didDetach videoView: VideoView)
+
     /// ``Track/muted`` has updated.
+    @objc(track:didUpdateMuted:shouldSendSignal:) optional
     func track(_ track: Track, didUpdate muted: Bool, shouldSendSignal: Bool)
+
     /// Statistics for the track has been generated.
+    @objc(track:didUpdateStats:) optional
     func track(_ track: Track, didUpdate stats: TrackStats)
-}
-
-// MARK: - Optional
-
-public extension TrackDelegate {
-    func track(_ track: VideoTrack, didUpdate dimensions: Dimensions?) {}
-    func track(_ track: VideoTrack, didAttach videoView: VideoView) {}
-    func track(_ track: VideoTrack, didDetach videoView: VideoView) {}
-    func track(_ track: Track, didUpdate muted: Bool, shouldSendSignal: Bool) {}
-    func track(_ track: Track, didUpdate stats: TrackStats) {}
 }

--- a/Sources/LiveKit/Protocols/VideoRenderer.swift
+++ b/Sources/LiveKit/Protocols/VideoRenderer.swift
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
+import Foundation
 import WebRTC
 
 @objc
-public protocol VideoTrack where Self: Track {
-
-    @objc(addVideoRenderer:)
-    func add(videoRenderer: VideoRenderer)
-
-    @objc(removeVideoRenderer:)
-    func remove(videoRenderer: VideoRenderer)
+public protocol VideoRenderer: RTCVideoRenderer {
+    /// Whether this ``VideoRenderer`` should be considered visible or not for AdaptiveStream.
+    /// This will be invoked on the .main thread.
+    @objc
+    var adaptiveStreamIsEnabled: Bool { get }
+    /// The size used for AdaptiveStream computation. Return .zero if size is unknown yet.
+    /// This will be invoked on the .main thread.
+    @objc
+    var adaptiveStreamSize: CGSize { get }
 }

--- a/Sources/LiveKit/Protocols/VideoViewDelegate.swift
+++ b/Sources/LiveKit/Protocols/VideoViewDelegate.swift
@@ -17,16 +17,12 @@
 import Foundation
 import WebRTC
 
+@objc
 public protocol VideoViewDelegate: AnyObject {
     /// Dimensions of the VideoView itself has updated
+    @objc(videoView:didUpdateSize:) optional
     func videoView(_ videoView: VideoView, didUpdate size: CGSize)
     /// VideoView updated the isRendering property
+    @objc(videoView:didUpdateIsRendering:) optional
     func videoView(_ videoView: VideoView, didUpdate isRendering: Bool)
-}
-
-// MARK: - Optional
-
-public extension VideoViewDelegate {
-    func videoView(_ videoView: VideoView, didUpdate size: CGSize) {}
-    func videoView(_ videoView: VideoView, didUpdate isRendering: Bool) {}
 }

--- a/Sources/LiveKit/Publications/LocalTrackPublication.swift
+++ b/Sources/LiveKit/Publications/LocalTrackPublication.swift
@@ -17,7 +17,8 @@
 import Foundation
 import Promises
 
-@objc public class LocalTrackPublication: TrackPublication {
+@objc
+public class LocalTrackPublication: TrackPublication {
 
     // indicates whether the track was suspended(muted) by the SDK
     internal var suspended: Bool = false

--- a/Sources/LiveKit/Publications/LocalTrackPublication.swift
+++ b/Sources/LiveKit/Publications/LocalTrackPublication.swift
@@ -36,7 +36,7 @@ public class LocalTrackPublication: TrackPublication {
             return Promise(InternalError.state(message: "track is nil or not a LocalTrack"))
         }
 
-        return track.mute()
+        return track._mute()
     }
 
     @discardableResult
@@ -46,7 +46,7 @@ public class LocalTrackPublication: TrackPublication {
             return Promise(InternalError.state(message: "track is nil or not a LocalTrack"))
         }
 
-        return track.unmute()
+        return track._unmute()
     }
 
     internal override func set(track newValue: Track?) -> Track? {

--- a/Sources/LiveKit/Publications/LocalTrackPublication.swift
+++ b/Sources/LiveKit/Publications/LocalTrackPublication.swift
@@ -17,7 +17,7 @@
 import Foundation
 import Promises
 
-public class LocalTrackPublication: TrackPublication {
+@objc public class LocalTrackPublication: TrackPublication {
 
     // indicates whether the track was suspended(muted) by the SDK
     internal var suspended: Bool = false

--- a/Sources/LiveKit/Publications/LocalTrackPublication.swift
+++ b/Sources/LiveKit/Publications/LocalTrackPublication.swift
@@ -49,7 +49,7 @@ public class LocalTrackPublication: TrackPublication {
         return track.unmute()
     }
 
-    override func set(track newValue: Track?) -> Track? {
+    internal override func set(track newValue: Track?) -> Track? {
         let oldValue = super.set(track: newValue)
 
         // listen for VideoCapturerDelegate

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -19,7 +19,7 @@ import CoreGraphics
 import Promises
 import WebRTC
 
-@objc public enum SubscriptionState: Int {
+@objc public enum SubscriptionState: Int, Codable {
     case subscribed
     case notAllowed
     case unsubscribed

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -25,7 +25,7 @@ import WebRTC
     case unsubscribed
 }
 
-public class RemoteTrackPublication: TrackPublication {
+@objc public class RemoteTrackPublication: TrackPublication {
 
     public var subscriptionAllowed: Bool { _state.subscriptionAllowed }
     public var enabled: Bool { _state.trackSettings.enabled }

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -43,7 +43,7 @@ public class RemoteTrackPublication: TrackPublication {
     // this must be on .main queue
     private var asTimer = DispatchQueueTimer(timeInterval: 0.3, queue: .main)
 
-    override internal init(info: Livekit_TrackInfo,
+    internal override init(info: Livekit_TrackInfo,
                            track: Track? = nil,
                            participant: Participant) {
 
@@ -64,7 +64,7 @@ public class RemoteTrackPublication: TrackPublication {
         set(metadataMuted: info.muted)
     }
 
-    override public var subscribed: Bool {
+    public override var subscribed: Bool {
         if !subscriptionAllowed { return false }
         return preferSubscribed != false && super.subscribed
     }
@@ -150,10 +150,10 @@ public class RemoteTrackPublication: TrackPublication {
 
             if let oldValue = oldValue, newValue == nil, let participant = participant as? RemoteParticipant {
                 participant.notify(label: { "participant.didUnsubscribe \(self)" }) {
-                    $0.participant(participant, didUnsubscribe: self, track: oldValue)
+                    $0.participant?(participant, didUnsubscribe: self, track: oldValue)
                 }
                 participant.room.notify(label: { "room.didUnsubscribe \(self)" }) {
-                    $0.room(participant.room, participant: participant, didUnsubscribe: self, track: oldValue)
+                    $0.room?(participant.room, participant: participant, didUnsubscribe: self, track: oldValue)
                 }
             }
         }
@@ -201,10 +201,10 @@ internal extension RemoteTrackPublication {
         // if track exists, track will emit the following events
         if track == nil {
             participant.notify(label: { "participant.didUpdate muted: \(newValue)" }) {
-                $0.participant(participant, didUpdate: self, muted: newValue)
+                $0.participant?(participant, didUpdate: self, muted: newValue)
             }
             participant.room.notify(label: { "room.didUpdate muted: \(newValue)" }) {
-                $0.room(participant.room, participant: participant, didUpdate: self, muted: newValue)
+                $0.room?(participant.room, participant: participant, didUpdate: self, muted: newValue)
             }
         }
     }
@@ -215,10 +215,10 @@ internal extension RemoteTrackPublication {
 
         guard let participant = self.participant as? RemoteParticipant else { return }
         participant.notify(label: { "participant.didUpdate permission: \(newValue)" }) {
-            $0.participant(participant, didUpdate: self, permission: newValue)
+            $0.participant?(participant, didUpdate: self, permission: newValue)
         }
         participant.room.notify(label: { "room.didUpdate permission: \(newValue)" }) {
-            $0.room(participant.room, participant: participant, didUpdate: self, permission: newValue)
+            $0.room?(participant.room, participant: participant, didUpdate: self, permission: newValue)
         }
     }
 }

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -19,7 +19,7 @@ import CoreGraphics
 import Promises
 import WebRTC
 
-public enum SubscriptionState {
+@objc public enum SubscriptionState: Int {
     case subscribed
     case notAllowed
     case unsubscribed

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -19,13 +19,15 @@ import CoreGraphics
 import Promises
 import WebRTC
 
-@objc public enum SubscriptionState: Int, Codable {
+@objc
+public enum SubscriptionState: Int, Codable {
     case subscribed
     case notAllowed
     case unsubscribed
 }
 
-@objc public class RemoteTrackPublication: TrackPublication {
+@objc
+public class RemoteTrackPublication: TrackPublication {
 
     public var subscriptionAllowed: Bool { _state.subscriptionAllowed }
     public var enabled: Bool { _state.trackSettings.enabled }

--- a/Sources/LiveKit/Publications/TrackPublication.swift
+++ b/Sources/LiveKit/Publications/TrackPublication.swift
@@ -18,7 +18,7 @@ import Foundation
 import CoreGraphics
 import Promises
 
-public class TrackPublication: TrackDelegate, Loggable {
+@objc public class TrackPublication: NSObject, TrackDelegate, Loggable {
 
     internal let queue = DispatchQueue(label: "LiveKitSDK.publication", qos: .default)
 
@@ -73,6 +73,9 @@ public class TrackPublication: TrackDelegate, Loggable {
         self.kind = info.type.toLKType()
         self.source = info.source.toLKType()
         self.participant = participant
+
+        super.init()
+
         self.set(track: track)
         updateFromInfo(info: info)
 
@@ -173,7 +176,7 @@ public class TrackPublication: TrackDelegate, Loggable {
 
 // MARK: - Equatable
 
-extension TrackPublication: Equatable {
+extension TrackPublication {
     // objects are considered equal if sids are the same
     public static func == (lhs: TrackPublication, rhs: TrackPublication) -> Bool {
         lhs.sid == rhs.sid

--- a/Sources/LiveKit/Publications/TrackPublication.swift
+++ b/Sources/LiveKit/Publications/TrackPublication.swift
@@ -18,7 +18,8 @@ import Foundation
 import CoreGraphics
 import Promises
 
-@objc public class TrackPublication: NSObject, TrackDelegate, Loggable {
+@objc
+public class TrackPublication: NSObject, TrackDelegate, Loggable {
 
     internal let queue = DispatchQueue(label: "LiveKitSDK.publication", qos: .default)
 

--- a/Sources/LiveKit/Publications/TrackPublication.swift
+++ b/Sources/LiveKit/Publications/TrackPublication.swift
@@ -23,20 +23,39 @@ public class TrackPublication: NSObject, TrackDelegate, Loggable {
 
     internal let queue = DispatchQueue(label: "LiveKitSDK.publication", qos: .default)
 
+    @objc
     public let sid: Sid
+
+    @objc
     public let kind: Track.Kind
+
+    @objc
     public let source: Track.Source
 
+    @objc
     public var name: String { _state.name }
+
+    @objc
     public var track: Track? { _state.track }
+
+    @objc
     public var muted: Bool { track?._state.muted ?? false }
+
+    @objc
     public var streamState: StreamState { _state.streamState }
 
     /// video-only
+    @objc
     public var dimensions: Dimensions? { _state.dimensions }
+
+    @objc
     public var simulcasted: Bool { _state.simulcasted }
+
     /// MIME type of the ``Track``.
+    @objc
     public var mimeType: String { _state.mimeType }
+
+    @objc
     public var subscribed: Bool { _state.track != nil }
 
     // MARK: - Internal
@@ -91,10 +110,10 @@ public class TrackPublication: NSObject, TrackDelegate, Loggable {
             if state.streamState != oldState.streamState {
                 if let participant = self.participant as? RemoteParticipant, let trackPublication = self as? RemoteTrackPublication {
                     participant.notify(label: { "participant.didUpdate \(trackPublication) streamState: \(state.streamState)" }) {
-                        $0.participant(participant, didUpdate: trackPublication, streamState: state.streamState)
+                        $0.participant?(participant, didUpdate: trackPublication, streamState: state.streamState)
                     }
                     participant.room.notify(label: { "room.didUpdate \(trackPublication) streamState: \(state.streamState)" }) {
-                        $0.room(participant.room, participant: participant, didUpdate: trackPublication, streamState: state.streamState)
+                        $0.room?(participant.room, participant: participant, didUpdate: trackPublication, streamState: state.streamState)
                     }
                 }
             }
@@ -166,10 +185,10 @@ public class TrackPublication: NSObject, TrackDelegate, Loggable {
             .recover(on: queue) { self.log("Failed to stop all tracks, error: \($0)") }
             .then(on: queue) {
                 participant.notify {
-                    $0.participant(participant, didUpdate: self, muted: muted)
+                    $0.participant?(participant, didUpdate: self, muted: muted)
                 }
                 participant.room.notify {
-                    $0.room(participant.room, participant: participant, didUpdate: self, muted: self.muted)
+                    $0.room?(participant.room, participant: participant, didUpdate: self, muted: self.muted)
                 }
             }
     }

--- a/Sources/LiveKit/Publications/TrackPublication.swift
+++ b/Sources/LiveKit/Publications/TrackPublication.swift
@@ -192,13 +192,17 @@ public class TrackPublication: NSObject, TrackDelegate, Loggable {
                 }
             }
     }
-}
 
-// MARK: - Equatable
+    // MARK: - Equal
 
-extension TrackPublication {
-    // objects are considered equal if sids are the same
-    public static func == (lhs: TrackPublication, rhs: TrackPublication) -> Bool {
-        lhs.sid == rhs.sid
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return self.sid == other.sid
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(sid)
+        return hasher.finalize()
     }
 }

--- a/Sources/LiveKit/Support/DisplayLink.swift
+++ b/Sources/LiveKit/Support/DisplayLink.swift
@@ -66,7 +66,8 @@ internal class iOSDisplayLink: DisplayLink {
 
         var callback: ((DisplayLinkFrame) -> Void)?
 
-        @objc dynamic func frame(_ _displayLink: CADisplayLink) {
+        @objc
+        dynamic func frame(_ _displayLink: CADisplayLink) {
 
             let frame = DisplayLinkFrame(
                 timestamp: _displayLink.timestamp,

--- a/Sources/LiveKit/Support/MulticastDelegate.swift
+++ b/Sources/LiveKit/Support/MulticastDelegate.swift
@@ -113,27 +113,3 @@ public class MulticastDelegate<T>: NSObject, Loggable {
         }
     }
 }
-
-public protocol MulticastDelegateCapable {
-    associatedtype DelegateType
-    var delegates: MulticastDelegate<DelegateType> { get }
-    func add(delegate: DelegateType)
-    func remove(delegate: DelegateType)
-    func notify(label: (() -> String)?, _ fnc: @escaping (DelegateType) -> Void)
-}
-
-public extension MulticastDelegateCapable {
-
-    func add(delegate: DelegateType) {
-        delegates.add(delegate: delegate)
-    }
-
-    func remove(delegate: DelegateType) {
-        delegates.remove(delegate: delegate)
-    }
-
-    func notify(label: (() -> String)? = nil,
-                _ fnc: @escaping (DelegateType) -> Void) {
-        delegates.notify(label: label, fnc)
-    }
-}

--- a/Sources/LiveKit/Support/MulticastDelegate.swift
+++ b/Sources/LiveKit/Support/MulticastDelegate.swift
@@ -122,18 +122,18 @@ public protocol MulticastDelegateCapable {
     func notify(label: (() -> String)?, _ fnc: @escaping (DelegateType) -> Void)
 }
 
-extension MulticastDelegateCapable {
+public extension MulticastDelegateCapable {
 
-    public func add(delegate: DelegateType) {
+    func add(delegate: DelegateType) {
         delegates.add(delegate: delegate)
     }
 
-    public func remove(delegate: DelegateType) {
+    func remove(delegate: DelegateType) {
         delegates.remove(delegate: delegate)
     }
 
-    public func notify(label: (() -> String)? = nil,
-                       _ fnc: @escaping (DelegateType) -> Void) {
+    func notify(label: (() -> String)? = nil,
+                _ fnc: @escaping (DelegateType) -> Void) {
         delegates.notify(label: label, fnc)
     }
 }

--- a/Sources/LiveKit/Track/AudioTrack.swift
+++ b/Sources/LiveKit/Track/AudioTrack.swift
@@ -16,7 +16,7 @@
 
 import WebRTC
 
-public protocol AudioTrack: Track {
+@objc public class AudioTrack: Track {
 
 }
 

--- a/Sources/LiveKit/Track/AudioTrack.swift
+++ b/Sources/LiveKit/Track/AudioTrack.swift
@@ -17,7 +17,7 @@
 import WebRTC
 
 @objc
-public class AudioTrack: Track {
+public protocol AudioTrack where Self: Track {
 
 }
 

--- a/Sources/LiveKit/Track/AudioTrack.swift
+++ b/Sources/LiveKit/Track/AudioTrack.swift
@@ -16,7 +16,8 @@
 
 import WebRTC
 
-@objc public class AudioTrack: Track {
+@objc
+public class AudioTrack: Track {
 
 }
 

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -194,6 +194,7 @@ public class CameraCapturer: VideoCapturer {
 
 extension LocalVideoTrack {
 
+    @objc
     public static func createCameraTrack(name: String = Track.cameraName,
                                          options: CameraCaptureOptions = CameraCaptureOptions()) -> LocalVideoTrack {
         let videoSource = Engine.createVideoSource(forScreenShare: false)

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -23,11 +23,13 @@ public class CameraCapturer: VideoCapturer {
 
     private let capturer: RTCCameraVideoCapturer
 
+    @objc
     public static func captureDevices() -> [AVCaptureDevice] {
         DispatchQueue.webRTC.sync { RTCCameraVideoCapturer.captureDevices() }
     }
 
     /// Checks whether both front and back capturing devices exist, and can be switched.
+    @objc
     public static func canSwitchPosition() -> Bool {
         let devices = captureDevices()
         return devices.contains(where: { $0.position == .front }) &&
@@ -35,6 +37,7 @@ public class CameraCapturer: VideoCapturer {
     }
 
     /// Current device used for capturing
+    @objc
     public private(set) var device: AVCaptureDevice?
 
     /// Current position of the device
@@ -42,6 +45,7 @@ public class CameraCapturer: VideoCapturer {
         device?.position
     }
 
+    @objc
     public var options: CameraCaptureOptions
 
     init(delegate: RTCVideoCapturerDelegate, options: CameraCaptureOptions) {
@@ -195,12 +199,18 @@ public class CameraCapturer: VideoCapturer {
 extension LocalVideoTrack {
 
     @objc
-    public static func createCameraTrack(name: String = Track.cameraName,
-                                         options: CameraCaptureOptions = CameraCaptureOptions()) -> LocalVideoTrack {
+    public static func createCameraTrack() -> LocalVideoTrack {
+        createCameraTrack(name: nil, options: nil)
+    }
+
+    @objc
+    public static func createCameraTrack(name: String? = nil,
+                                         options: CameraCaptureOptions? = nil) -> LocalVideoTrack {
+
         let videoSource = Engine.createVideoSource(forScreenShare: false)
-        let capturer = CameraCapturer(delegate: videoSource, options: options)
+        let capturer = CameraCapturer(delegate: videoSource, options: options ?? CameraCaptureOptions())
         return LocalVideoTrack(
-            name: name,
+            name: name ?? Track.cameraName,
             source: .camera,
             capturer: capturer,
             videoSource: videoSource
@@ -250,5 +260,21 @@ extension AVCaptureDevice.Format {
             // merge previous element
             result = merge(range: previous, with: current)
         }
+    }
+}
+
+// MARK: - Objective-C Support
+
+extension CameraCapturer {
+
+    @objc
+    @discardableResult
+    public func switchCameraPosition() -> Promise<Bool>.ObjCPromise<NSNumber> {
+        switchCameraPosition().asObjCPromise()
+    }
+
+    @objc
+    public func setCameraPosition(_ position: AVCaptureDevice.Position) -> Promise<Bool>.ObjCPromise<NSNumber> {
+        setCameraPosition(position).asObjCPromise()
     }
 }

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -97,7 +97,7 @@ public class CameraCapturer: VideoCapturer {
             // list of all formats in order of dimensions size
             let formats = DispatchQueue.webRTC.sync { RTCCameraVideoCapturer.supportedFormats(for: device) }
             // create an array of sorted touples by dimensions size
-            let sortedFormats = formats.map({ (format: $0, dimensions: CMVideoFormatDescriptionGetDimensions($0.formatDescription)) })
+            let sortedFormats = formats.map({ (format: $0, dimensions: Dimensions(from: CMVideoFormatDescriptionGetDimensions($0.formatDescription))) })
                 .sorted { $0.dimensions.area < $1.dimensions.area }
 
             // default to the smallest

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -262,19 +262,3 @@ extension AVCaptureDevice.Format {
         }
     }
 }
-
-// MARK: - Objective-C Support
-
-extension CameraCapturer {
-
-    @objc
-    @discardableResult
-    public func switchCameraPosition() -> Promise<Bool>.ObjCPromise<NSNumber> {
-        switchCameraPosition().asObjCPromise()
-    }
-
-    @objc
-    public func setCameraPosition(_ position: AVCaptureDevice.Position) -> Promise<Bool>.ObjCPromise<NSNumber> {
-        setCameraPosition(position).asObjCPromise()
-    }
-}

--- a/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
@@ -19,7 +19,7 @@ import WebRTC
 import Promises
 
 @objc
-public class LocalAudioTrack: AudioTrack, LocalTrack {
+public class LocalAudioTrack: Track, LocalTrack, AudioTrack {
 
     internal init(name: String,
                   source: Track.Source,

--- a/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
@@ -18,7 +18,7 @@ import Foundation
 import WebRTC
 import Promises
 
-public class LocalAudioTrack: LocalTrack, AudioTrack {
+@objc public class LocalAudioTrack: LocalTrack, AudioTrack {
 
     internal init(name: String,
                   source: Track.Source,

--- a/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
@@ -18,7 +18,8 @@ import Foundation
 import WebRTC
 import Promises
 
-@objc public class LocalAudioTrack: AudioTrack, LocalTrack {
+@objc
+public class LocalAudioTrack: AudioTrack, LocalTrack {
 
     internal init(name: String,
                   source: Track.Source,

--- a/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
@@ -18,7 +18,7 @@ import Foundation
 import WebRTC
 import Promises
 
-@objc public class LocalAudioTrack: LocalTrack, AudioTrack {
+@objc public class LocalAudioTrack: AudioTrack, LocalTrack {
 
     internal init(name: String,
                   source: Track.Source,

--- a/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
@@ -78,3 +78,10 @@ public class LocalAudioTrack: Track, LocalTrack, AudioTrack {
         }
     }
 }
+
+extension LocalAudioTrack {
+
+    public var publishOptions: PublishOptions? { super._publishOptions }
+
+    public var publishState: Track.PublishState { super._publishState }
+}

--- a/Sources/LiveKit/Track/Local/LocalTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalTrack.swift
@@ -17,6 +17,7 @@
 import Foundation
 import Promises
 
-@objc public protocol LocalTrack where Self: Track {
+@objc
+public protocol LocalTrack where Self: Track {
 
 }

--- a/Sources/LiveKit/Track/Local/LocalTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalTrack.swift
@@ -14,69 +14,9 @@
  * limitations under the License.
  */
 
+import Foundation
 import Promises
 
-public class LocalTrack: Track {
+@objc public protocol LocalTrack where Self: Track {
 
-    public enum PublishState {
-        case unpublished
-        case published
-    }
-
-    public private(set) var publishState: PublishState = .unpublished
-
-    /// ``publishOptions`` used for this track if already published.
-    public internal(set) var publishOptions: PublishOptions?
-
-    public func mute() -> Promise<Void> {
-        // Already muted
-        if muted { return Promise(()) }
-
-        return disable().then(on: queue) { _ in
-            self.stop()
-        }.then(on: queue) { _ -> Void in
-            self.set(muted: true, shouldSendSignal: true)
-        }
-    }
-
-    public func unmute() -> Promise<Void> {
-        // Already un-muted
-        if !muted { return Promise(()) }
-
-        return enable().then(on: queue) { _ in
-            self.start()
-        }.then(on: queue) { _ -> Void in
-            self.set(muted: false, shouldSendSignal: true)
-        }
-    }
-
-    // returns true if state updated
-    internal func onPublish() -> Promise<Bool> {
-
-        Promise<Bool>(on: queue) { () -> Bool in
-
-            guard self.publishState != .published else {
-                // already published
-                return false
-            }
-
-            self.publishState = .published
-            return true
-        }
-    }
-
-    // returns true if state updated
-    internal func onUnpublish() -> Promise<Bool> {
-
-        Promise<Bool>(on: queue) { () -> Bool in
-
-            guard self.publishState != .unpublished else {
-                // already unpublished
-                return false
-            }
-
-            self.publishState = .unpublished
-            return true
-        }
-    }
 }

--- a/Sources/LiveKit/Track/Local/LocalTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalTrack.swift
@@ -20,4 +20,17 @@ import Promises
 @objc
 public protocol LocalTrack where Self: Track {
 
+    @objc(publishOptions)
+    var publishOptions: PublishOptions? { get }
+
+    @objc(publishState)
+    var publishState: PublishState { get }
+
+    @objc(mute)
+    @discardableResult
+    func mute() -> Promise<Void>.ObjCPromise<NSNull>
+
+    @objc(unmute)
+    @discardableResult
+    func unmute() -> Promise<Void>.ObjCPromise<NSNull>
 }

--- a/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
@@ -20,7 +20,7 @@ import Promises
 import ReplayKit
 
 @objc
-public class LocalVideoTrack: VideoTrack, LocalTrack {
+public class LocalVideoTrack: Track, LocalTrack, VideoTrack {
 
     @objc
     public internal(set) var capturer: VideoCapturer
@@ -58,13 +58,14 @@ public class LocalVideoTrack: VideoTrack, LocalTrack {
     }
 }
 
-extension RTCRtpEncodingParameters {
-    open override var description: String {
-        return "RTCRtpEncodingParameters(rid: \(rid ?? "nil"), "
-            + "active: \(isActive), "
-            + "scaleResolutionDownBy: \(String(describing: scaleResolutionDownBy)), "
-            + "maxBitrateBps: \(maxBitrateBps == nil ? "nil" : String(describing: maxBitrateBps)), "
-            + "maxFramerate: \(maxFramerate == nil ? "nil" : String(describing: maxFramerate)))"
+extension LocalVideoTrack {
+
+    public func add(videoRenderer: VideoRenderer) {
+        super._add(videoRenderer: videoRenderer)
+    }
+
+    public func remove(videoRenderer: VideoRenderer) {
+        super._remove(videoRenderer: videoRenderer)
     }
 }
 

--- a/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
@@ -19,7 +19,8 @@ import WebRTC
 import Promises
 import ReplayKit
 
-@objc public class LocalVideoTrack: VideoTrack, LocalTrack {
+@objc
+public class LocalVideoTrack: VideoTrack, LocalTrack {
 
     public internal(set) var capturer: VideoCapturer
     public internal(set) var videoSource: RTCVideoSource

--- a/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
@@ -19,7 +19,7 @@ import WebRTC
 import Promises
 import ReplayKit
 
-public class LocalVideoTrack: LocalTrack, VideoTrack {
+@objc public class LocalVideoTrack: LocalTrack, VideoTrack {
 
     public internal(set) var capturer: VideoCapturer
     public internal(set) var videoSource: RTCVideoSource

--- a/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
@@ -82,3 +82,10 @@ extension LocalVideoTrack {
         return capturer.restartCapture()
     }
 }
+
+extension LocalVideoTrack {
+
+    public var publishOptions: PublishOptions? { super._publishOptions }
+
+    public var publishState: Track.PublishState { super._publishState }
+}

--- a/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
@@ -19,7 +19,7 @@ import WebRTC
 import Promises
 import ReplayKit
 
-@objc public class LocalVideoTrack: LocalTrack, VideoTrack {
+@objc public class LocalVideoTrack: VideoTrack, LocalTrack {
 
     public internal(set) var capturer: VideoCapturer
     public internal(set) var videoSource: RTCVideoSource

--- a/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
@@ -22,7 +22,10 @@ import ReplayKit
 @objc
 public class LocalVideoTrack: VideoTrack, LocalTrack {
 
+    @objc
     public internal(set) var capturer: VideoCapturer
+
+    @objc
     public internal(set) var videoSource: RTCVideoSource
 
     internal init(name: String,

--- a/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
@@ -17,7 +17,8 @@
 import WebRTC
 import Promises
 
-@objc class RemoteAudioTrack: AudioTrack, RemoteTrack {
+@objc
+class RemoteAudioTrack: AudioTrack, RemoteTrack {
 
     init(name: String,
          source: Track.Source,

--- a/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
@@ -17,7 +17,7 @@
 import WebRTC
 import Promises
 
-@objc class RemoteAudioTrack: RemoteTrack, AudioTrack {
+@objc class RemoteAudioTrack: AudioTrack, RemoteTrack {
 
     init(name: String,
          source: Track.Source,

--- a/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
@@ -17,7 +17,7 @@
 import WebRTC
 import Promises
 
-class RemoteAudioTrack: RemoteTrack, AudioTrack {
+@objc class RemoteAudioTrack: RemoteTrack, AudioTrack {
 
     init(name: String,
          source: Track.Source,

--- a/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
@@ -18,7 +18,7 @@ import WebRTC
 import Promises
 
 @objc
-class RemoteAudioTrack: AudioTrack, RemoteTrack {
+class RemoteAudioTrack: Track, RemoteTrack, AudioTrack {
 
     init(name: String,
          source: Track.Source,

--- a/Sources/LiveKit/Track/Remote/RemoteTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteTrack.swift
@@ -14,19 +14,9 @@
  * limitations under the License.
  */
 
+import Foundation
 import Promises
 
-public class RemoteTrack: Track {
+@objc public protocol RemoteTrack where Self: Track {
 
-    override public func start() -> Promise<Bool> {
-        super.start().then(on: queue) { didStart in
-            self.enable().then(on: self.queue) { _ in didStart }
-        }
-    }
-
-    override public func stop() -> Promise<Bool> {
-        super.stop().then(on: queue) { didStop in
-            super.disable().then(on: self.queue) { _ in didStop }
-        }
-    }
 }

--- a/Sources/LiveKit/Track/Remote/RemoteTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteTrack.swift
@@ -17,6 +17,7 @@
 import Foundation
 import Promises
 
-@objc public protocol RemoteTrack where Self: Track {
+@objc
+public protocol RemoteTrack where Self: Track {
 
 }

--- a/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
@@ -18,7 +18,7 @@ import WebRTC
 import Promises
 
 @objc
-class RemoteVideoTrack: VideoTrack, RemoteTrack {
+class RemoteVideoTrack: Track, RemoteTrack, VideoTrack {
 
     init(name: String,
          source: Track.Source,
@@ -28,5 +28,16 @@ class RemoteVideoTrack: VideoTrack, RemoteTrack {
                    kind: .video,
                    source: source,
                    track: track)
+    }
+}
+
+extension RemoteVideoTrack {
+
+    public func add(videoRenderer: VideoRenderer) {
+        super._add(videoRenderer: videoRenderer)
+    }
+
+    public func remove(videoRenderer: VideoRenderer) {
+        super._remove(videoRenderer: videoRenderer)
     }
 }

--- a/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
@@ -17,7 +17,8 @@
 import WebRTC
 import Promises
 
-@objc class RemoteVideoTrack: VideoTrack, RemoteTrack {
+@objc
+class RemoteVideoTrack: VideoTrack, RemoteTrack {
 
     init(name: String,
          source: Track.Source,

--- a/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
@@ -17,7 +17,7 @@
 import WebRTC
 import Promises
 
-class RemoteVideoTrack: RemoteTrack, VideoTrack {
+@objc class RemoteVideoTrack: RemoteTrack, VideoTrack {
 
     init(name: String,
          source: Track.Source,

--- a/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
@@ -17,7 +17,7 @@
 import WebRTC
 import Promises
 
-@objc class RemoteVideoTrack: RemoteTrack, VideoTrack {
+@objc class RemoteVideoTrack: VideoTrack, RemoteTrack {
 
     init(name: String,
          source: Track.Source,

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -344,20 +344,3 @@ extension Track {
         delegates.notify(label: label, fnc)
     }
 }
-
-// MARK: - Objective-C Support
-
-extension Track {
-
-    @objc(start)
-    @discardableResult
-    public func startObjC() -> Promise<Bool>.ObjCPromise<NSNumber> {
-        start().asObjCPromise()
-    }
-
-    @objc(stop)
-    @discardableResult
-    public func stopObjC() -> Promise<Bool>.ObjCPromise<NSNumber> {
-        stop().asObjCPromise()
-    }
-}

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -261,6 +261,7 @@ internal extension Track {
     // returns true when value is updated
     @discardableResult
     func set(dimensions newValue: Dimensions?) -> Bool {
+
         guard _state.dimensions != newValue else { return false }
 
         _state.mutate { $0.dimensions = newValue }

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -26,9 +26,16 @@ public class Track: NSObject, Loggable {
 
     internal let queue = DispatchQueue(label: "LiveKitSDK.track", qos: .default)
 
+    @objc
     public static let cameraName = "camera"
+
+    @objc
     public static let microphoneName = "microphone"
+
+    @objc
     public static let screenShareVideoName = "screen_share"
+
+    @objc
     public static let screenShareAudioName = "screen_share_audio"
 
     @objc(TrackKind)

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -17,7 +17,8 @@
 import WebRTC
 import Promises
 
-@objc public class Track: NSObject, Loggable {
+@objc
+public class Track: NSObject, Loggable {
 
     // MARK: - MulticastDelegate
 
@@ -52,7 +53,8 @@ import Promises
         case screenShareAudio
     }
 
-    @objc public enum PublishState: Int {
+    @objc
+    public enum PublishState: Int {
         case unpublished
         case published
     }
@@ -64,20 +66,28 @@ import Promises
     /// Only for ``LocalTrack``s.
     public internal(set) var publishOptions: PublishOptions?
 
-    @objc public let kind: Track.Kind
-    @objc public let source: Track.Source
-    @objc public let name: String
+    @objc
+    public let kind: Track.Kind
+    @objc
+    public let source: Track.Source
+    @objc
+    public let name: String
 
-    @objc public var sid: Sid? { _state.sid }
-    @objc public var muted: Bool { _state.muted }
-    @objc public var stats: TrackStats? { _state.stats }
+    @objc
+    public var sid: Sid? { _state.sid }
+    @objc
+    public var muted: Bool { _state.muted }
+    @objc
+    public var stats: TrackStats? { _state.stats }
 
     /// Dimensions of the video (only if video track)
-    @objc public var dimensions: Dimensions? { _state.dimensions }
+    @objc
+    public var dimensions: Dimensions? { _state.dimensions }
 
     /// The last video frame received for this track
     public var videoFrame: RTCVideoFrame? { _state.videoFrame }
-    @objc public var trackState: TrackState { _state.trackState }
+    @objc
+    public var trackState: TrackState { _state.trackState }
 
     // MARK: - Internal
 

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -60,30 +60,36 @@ public class Track: NSObject, Loggable {
         case screenShareAudio
     }
 
-    @objc
+    @objc(PublishState)
     public enum PublishState: Int {
         case unpublished
         case published
     }
 
     /// Only for ``LocalTrack``s.
+    @objc
     public private(set) var publishState: PublishState = .unpublished
 
     /// ``publishOptions`` used for this track if already published.
     /// Only for ``LocalTrack``s.
+    @objc
     public internal(set) var publishOptions: PublishOptions?
 
     @objc
     public let kind: Track.Kind
+
     @objc
     public let source: Track.Source
+
     @objc
     public let name: String
 
     @objc
     public var sid: Sid? { _state.sid }
+
     @objc
     public var muted: Bool { _state.muted }
+
     @objc
     public var stats: TrackStats? { _state.stats }
 
@@ -93,6 +99,7 @@ public class Track: NSObject, Loggable {
 
     /// The last video frame received for this track
     public var videoFrame: RTCVideoFrame? { _state.videoFrame }
+
     @objc
     public var trackState: TrackState { _state.trackState }
 
@@ -221,8 +228,10 @@ public class Track: NSObject, Loggable {
 
     // returns true if state updated
     internal func onPublish() -> Promise<Bool> {
+        // LocalTrack only
+        guard self is LocalTrack else { return Promise(false) }
 
-        Promise<Bool>(on: queue) { () -> Bool in
+        return Promise<Bool>(on: queue) { () -> Bool in
 
             guard self.publishState != .published else {
                 // already published
@@ -236,8 +245,10 @@ public class Track: NSObject, Loggable {
 
     // returns true if state updated
     internal func onUnpublish() -> Promise<Bool> {
+        // LocalTrack only
+        guard self is LocalTrack else { return Promise(false) }
 
-        Promise<Bool>(on: queue) { () -> Bool in
+        return Promise<Bool>(on: queue) { () -> Bool in
 
             guard self.publishState != .unpublished else {
                 // already unpublished
@@ -303,8 +314,8 @@ extension Track {
 extension Track {
 
     public func mute() -> Promise<Void> {
-        // Already muted
-        if muted { return Promise(()) }
+        // LocalTrack only, already muted
+        guard self is LocalTrack, !muted else { return Promise(()) }
 
         return disable().then(on: queue) { _ in
             self.stop()
@@ -314,8 +325,8 @@ extension Track {
     }
 
     public func unmute() -> Promise<Void> {
-        // Already un-muted
-        if !muted { return Promise(()) }
+        // LocalTrack only, already un-muted
+        guard self is LocalTrack, muted else { return Promise(()) }
 
         return enable().then(on: queue) { _ in
             self.start()

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -329,8 +329,8 @@ extension Track {
 
 extension Track {
 
-    @objc
-    public func start() -> Promise<Bool>.ObjCPromise<NSNumber> {
+    @objc(start)
+    public func startObjC() -> Promise<Bool>.ObjCPromise<NSNumber> {
         start().asObjCPromise()
     }
 }

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -290,24 +290,6 @@ extension Track {
     }
 }
 
-// MARK: - MulticastDelegate
-
-extension Track {
-
-    func add(delegate: TrackDelegate) {
-        delegates.add(delegate: delegate)
-    }
-
-    func remove(delegate: TrackDelegate) {
-        delegates.remove(delegate: delegate)
-    }
-
-    func notify(label: (() -> String)? = nil,
-                _ fnc: @escaping (TrackDelegate) -> Void) {
-        delegates.notify(label: label, fnc)
-    }
-}
-
 // MARK: - Local
 
 extension Track {
@@ -332,6 +314,26 @@ extension Track {
         }.then(on: queue) { _ -> Void in
             self.set(muted: false, shouldSendSignal: true)
         }
+    }
+}
+
+// MARK: - MulticastDelegate
+
+extension Track {
+
+    @objc(addDelegate:)
+    public func add(delegate: TrackDelegate) {
+        delegates.add(delegate: delegate)
+    }
+
+    @objc(removeDelegate:)
+    public func remove(delegate: TrackDelegate) {
+        delegates.remove(delegate: delegate)
+    }
+
+    internal func notify(label: (() -> String)? = nil,
+                         _ fnc: @escaping (TrackDelegate) -> Void) {
+        delegates.notify(label: label, fnc)
     }
 }
 

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -67,13 +67,11 @@ public class Track: NSObject, Loggable {
     }
 
     /// Only for ``LocalTrack``s.
-    @objc
-    public private(set) var publishState: PublishState = .unpublished
+    internal private(set) var _publishState: PublishState = .unpublished
 
     /// ``publishOptions`` used for this track if already published.
     /// Only for ``LocalTrack``s.
-    @objc
-    public internal(set) var publishOptions: PublishOptions?
+    internal var _publishOptions: PublishOptions?
 
     @objc
     public let kind: Track.Kind
@@ -233,12 +231,12 @@ public class Track: NSObject, Loggable {
 
         return Promise<Bool>(on: queue) { () -> Bool in
 
-            guard self.publishState != .published else {
+            guard self._publishState != .published else {
                 // already published
                 return false
             }
 
-            self.publishState = .published
+            self._publishState = .published
             return true
         }
     }
@@ -250,12 +248,12 @@ public class Track: NSObject, Loggable {
 
         return Promise<Bool>(on: queue) { () -> Bool in
 
-            guard self.publishState != .unpublished else {
+            guard self._publishState != .unpublished else {
                 // already unpublished
                 return false
             }
 
-            self.publishState = .unpublished
+            self._publishState = .unpublished
             return true
         }
     }

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -330,7 +330,14 @@ extension Track {
 extension Track {
 
     @objc(start)
+    @discardableResult
     public func startObjC() -> Promise<Bool>.ObjCPromise<NSNumber> {
         start().asObjCPromise()
+    }
+
+    @objc(stop)
+    @discardableResult
+    public func stopObjC() -> Promise<Bool>.ObjCPromise<NSNumber> {
+        stop().asObjCPromise()
     }
 }

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -30,18 +30,21 @@ import Promises
     public static let screenShareVideoName = "screen_share"
     public static let screenShareAudioName = "screen_share_audio"
 
-    public enum Kind {
+    @objc(TrackKind)
+    public enum Kind: Int, Codable {
         case audio
         case video
         case none
     }
 
-    public enum TrackState {
+    @objc(TrackState)
+    public enum TrackState: Int, Codable {
         case stopped
         case started
     }
 
-    public enum Source {
+    @objc(TrackSource)
+    public enum Source: Int, Codable {
         case unknown
         case camera
         case microphone
@@ -61,20 +64,20 @@ import Promises
     /// Only for ``LocalTrack``s.
     public internal(set) var publishOptions: PublishOptions?
 
-    public let kind: Track.Kind
-    public let source: Track.Source
+    @objc public let kind: Track.Kind
+    @objc public let source: Track.Source
     @objc public let name: String
 
     @objc public var sid: Sid? { _state.sid }
-    public var muted: Bool { _state.muted }
-    public var stats: TrackStats? { _state.stats }
+    @objc public var muted: Bool { _state.muted }
+    @objc public var stats: TrackStats? { _state.stats }
 
     /// Dimensions of the video (only if video track)
-    public var dimensions: Dimensions? { _state.dimensions }
+    @objc public var dimensions: Dimensions? { _state.dimensions }
 
     /// The last video frame received for this track
     public var videoFrame: RTCVideoFrame? { _state.videoFrame }
-    public var trackState: TrackState { _state.trackState }
+    @objc public var trackState: TrackState { _state.trackState }
 
     // MARK: - Internal
 
@@ -106,16 +109,6 @@ import Promises
     deinit {
         log("sid: \(String(describing: sid))")
     }
-
-    //    override public func start() -> Promise<Bool> {
-    //        super.start().then(on: queue) { didStart in
-    //            self.enable().then(on: self.queue) { _ in didStart }
-    //        }
-    //    }
-    //
-    //    override public func stop() -> Promise<Bool> {
-    //        super.stop()
-    //    }
 
     // returns true if updated state
     public func start() -> Promise<Bool> {
@@ -329,5 +322,15 @@ extension Track {
         }.then(on: queue) { _ -> Void in
             self.set(muted: false, shouldSendSignal: true)
         }
+    }
+}
+
+// MARK: - Objective-C Support
+
+extension Track {
+
+    @objc
+    public func start() -> Promise<Bool>.ObjCPromise<NSNumber> {
+        start().asObjCPromise()
     }
 }

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -17,7 +17,11 @@
 import WebRTC
 import Promises
 
-public class Track: MulticastDelegate<TrackDelegate> {
+@objc public class Track: NSObject, Loggable {
+
+    // MARK: - MulticastDelegate
+
+    private var delegates = MulticastDelegate<TrackDelegate>()
 
     internal let queue = DispatchQueue(label: "LiveKitSDK.track", qos: .default)
 
@@ -213,5 +217,23 @@ extension Track {
     @available(*, deprecated, renamed: "trackState")
     public var state: TrackState {
         self._state.trackState
+    }
+}
+
+// MARK: - MulticastDelegate
+
+extension Track {
+
+    func add(delegate: TrackDelegate) {
+        delegates.add(delegate: delegate)
+    }
+
+    func remove(delegate: TrackDelegate) {
+        delegates.remove(delegate: delegate)
+    }
+
+    func notify(label: (() -> String)? = nil,
+                _ fnc: @escaping (TrackDelegate) -> Void) {
+        delegates.notify(label: label, fnc)
     }
 }

--- a/Sources/LiveKit/Track/VideoTrack.swift
+++ b/Sources/LiveKit/Track/VideoTrack.swift
@@ -16,7 +16,7 @@
 
 import WebRTC
 
-public protocol VideoTrack: Track {
+@objc public class VideoTrack: Track {
 
 }
 
@@ -29,7 +29,7 @@ public protocol VideoTrack: Track {
     var adaptiveStreamSize: CGSize { get }
 }
 
-extension VideoTrack {
+@objc extension VideoTrack {
 
     public func add(videoRenderer: VideoRenderer) {
 

--- a/Sources/LiveKit/Track/VideoTrack.swift
+++ b/Sources/LiveKit/Track/VideoTrack.swift
@@ -16,21 +16,26 @@
 
 import WebRTC
 
-@objc public class VideoTrack: Track {
+@objc
+public class VideoTrack: Track {
 
 }
 
-@objc public protocol VideoRenderer: RTCVideoRenderer {
+@objc
+public protocol VideoRenderer: RTCVideoRenderer {
     /// Whether this ``VideoRenderer`` should be considered visible or not for AdaptiveStream.
     /// This will be invoked on the .main thread.
+    @objc
     var adaptiveStreamIsEnabled: Bool { get }
     /// The size used for AdaptiveStream computation. Return .zero if size is unknown yet.
     /// This will be invoked on the .main thread.
+    @objc
     var adaptiveStreamSize: CGSize { get }
 }
 
-@objc extension VideoTrack {
+extension VideoTrack {
 
+    @objc
     public func add(videoRenderer: VideoRenderer) {
 
         guard let videoTrack = self.mediaTrack as? RTCVideoTrack else {
@@ -45,6 +50,7 @@ import WebRTC
         videoTrack.add(videoRenderer)
     }
 
+    @objc
     public func remove(videoRenderer: VideoRenderer) {
 
         guard let videoTrack = self.mediaTrack as? RTCVideoTrack else {

--- a/Sources/LiveKit/Types/ConnectionQuality.swift
+++ b/Sources/LiveKit/Types/ConnectionQuality.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-public enum ConnectionQuality {
+@objc public enum ConnectionQuality: Int {
     case unknown
     case poor
     case good

--- a/Sources/LiveKit/Types/ConnectionQuality.swift
+++ b/Sources/LiveKit/Types/ConnectionQuality.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-@objc public enum ConnectionQuality: Int {
+@objc
+public enum ConnectionQuality: Int {
     case unknown
     case poor
     case good

--- a/Sources/LiveKit/Types/ConnectionState.swift
+++ b/Sources/LiveKit/Types/ConnectionState.swift
@@ -101,3 +101,25 @@ protocol ReconnectableState {
     var reconnectMode: ReconnectMode? { get }
     var connectionState: ConnectionState { get }
 }
+
+// MARK: - Objective-C Support
+
+@objc(ConnectionState)
+public enum ConnectionStateObjC: Int {
+    case disconnected
+    case connecting
+    case reconnecting
+    case connected
+}
+
+extension ConnectionState {
+
+    func toObjCType() -> ConnectionStateObjC {
+        switch self {
+        case .disconnected: return .disconnected
+        case .connecting: return .connecting
+        case .reconnecting: return .reconnecting
+        case .connected: return .connected
+        }
+    }
+}

--- a/Sources/LiveKit/Types/ConnectionState.swift
+++ b/Sources/LiveKit/Types/ConnectionState.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-public enum ReconnectMode {
+@objc public enum ReconnectMode: Int {
     case quick
     case full
 }

--- a/Sources/LiveKit/Types/ConnectionState.swift
+++ b/Sources/LiveKit/Types/ConnectionState.swift
@@ -102,25 +102,3 @@ protocol ReconnectableState {
     var reconnectMode: ReconnectMode? { get }
     var connectionState: ConnectionState { get }
 }
-
-// MARK: - Objective-C Support
-
-@objc(ConnectionState)
-public enum ConnectionStateObjC: Int {
-    case disconnected
-    case connecting
-    case reconnecting
-    case connected
-}
-
-extension ConnectionState {
-
-    func toObjCType() -> ConnectionStateObjC {
-        switch self {
-        case .disconnected: return .disconnected
-        case .connecting: return .connecting
-        case .reconnecting: return .reconnecting
-        case .connected: return .connected
-        }
-    }
-}

--- a/Sources/LiveKit/Types/ConnectionState.swift
+++ b/Sources/LiveKit/Types/ConnectionState.swift
@@ -16,7 +16,8 @@
 
 import Foundation
 
-@objc public enum ReconnectMode: Int {
+@objc
+public enum ReconnectMode: Int {
     case quick
     case full
 }

--- a/Sources/LiveKit/Types/Dimensions.swift
+++ b/Sources/LiveKit/Types/Dimensions.swift
@@ -18,16 +18,20 @@ import Foundation
 import CoreMedia
 import WebRTC
 
-@objc public class Dimensions: NSObject {
+@objc
+public class Dimensions: NSObject {
 
     public static func == (lhs: Dimensions, rhs: Dimensions) -> Bool {
         lhs.width == rhs.width && lhs.height == rhs.height
     }
 
-    @objc public let width: Int32
-    @objc public let height: Int32
+    @objc
+    public let width: Int32
+    @objc
+    public let height: Int32
 
-    @objc public init(width: Int32, height: Int32) {
+    @objc
+    public init(width: Int32, height: Int32) {
         self.width = width
         self.height = height
     }

--- a/Sources/LiveKit/Types/Dimensions.swift
+++ b/Sources/LiveKit/Types/Dimensions.swift
@@ -21,10 +21,6 @@ import WebRTC
 @objc
 public class Dimensions: NSObject {
 
-    public static func == (lhs: Dimensions, rhs: Dimensions) -> Bool {
-        lhs.width == rhs.width && lhs.height == rhs.height
-    }
-
     @objc
     public let width: Int32
 
@@ -40,6 +36,20 @@ public class Dimensions: NSObject {
     public init(from dimensions: CMVideoDimensions) {
         self.width = dimensions.width
         self.height = dimensions.height
+    }
+
+    // MARK: - Equal
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return self.width == other.width && self.height == other.height
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(width)
+        hasher.combine(height)
+        return hasher.finalize()
     }
 }
 

--- a/Sources/LiveKit/Types/Dimensions.swift
+++ b/Sources/LiveKit/Types/Dimensions.swift
@@ -27,6 +27,7 @@ public class Dimensions: NSObject {
 
     @objc
     public let width: Int32
+
     @objc
     public let height: Int32
 
@@ -185,28 +186,45 @@ extension Dimensions {
 
 // MARK: - Presets
 
+@objc
 public extension Dimensions {
 
     // 16:9 aspect ratio presets
     static let h90_169 = Dimensions(width: 160, height: 90)
+
     static let h180_169 = Dimensions(width: 320, height: 180)
+
     static let h216_169 = Dimensions(width: 384, height: 216)
+
     static let h360_169 = Dimensions(width: 640, height: 360)
+
     static let h540_169 = Dimensions(width: 960, height: 540)
+
     static let h720_169 = Dimensions(width: 1_280, height: 720)
+
     static let h1080_169 = Dimensions(width: 1_920, height: 1_080)
+
     static let h1440_169 = Dimensions(width: 2_560, height: 1_440)
+
     static let h2160_169 = Dimensions(width: 3_840, height: 2_160)
 
     // 4:3 aspect ratio presets
     static let h120_43 = Dimensions(width: 160, height: 120)
+
     static let h180_43 = Dimensions(width: 240, height: 180)
+
     static let h240_43 = Dimensions(width: 320, height: 240)
+
     static let h360_43 = Dimensions(width: 480, height: 360)
+
     static let h480_43 = Dimensions(width: 640, height: 480)
+
     static let h540_43 = Dimensions(width: 720, height: 540)
+
     static let h720_43 = Dimensions(width: 960, height: 720)
+
     static let h1080_43 = Dimensions(width: 1_440, height: 1_080)
+
     static let h1440_43 = Dimensions(width: 1_920, height: 1_440)
 }
 

--- a/Sources/LiveKit/Types/Dimensions.swift
+++ b/Sources/LiveKit/Types/Dimensions.swift
@@ -18,8 +18,25 @@ import Foundation
 import CoreMedia
 import WebRTC
 
-// use CMVideoDimensions instead of defining our own struct
-public typealias Dimensions = CMVideoDimensions
+@objc public class Dimensions: NSObject {
+
+    public static func == (lhs: Dimensions, rhs: Dimensions) -> Bool {
+        lhs.width == rhs.width && lhs.height == rhs.height
+    }
+
+    @objc public let width: Int32
+    @objc public let height: Int32
+
+    @objc public init(width: Int32, height: Int32) {
+        self.width = width
+        self.height = height
+    }
+
+    public init(from dimensions: CMVideoDimensions) {
+        self.width = dimensions.width
+        self.height = dimensions.height
+    }
+}
 
 // MARK: - Static constants
 
@@ -30,15 +47,6 @@ extension Dimensions {
 
     internal static let renderSafeSize: Int32 = 8
     internal static let encodeSafeSize: Int32 = 16
-}
-
-// MARK: - Equatable
-
-extension Dimensions: Equatable {
-
-    public static func == (lhs: Dimensions, rhs: Dimensions) -> Bool {
-        lhs.width == rhs.width && lhs.height == rhs.height
-    }
 }
 
 // this may cause ambiguity to comparison

--- a/Sources/LiveKit/Types/Options/CaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/CaptureOptions.swift
@@ -31,13 +31,9 @@ public protocol VideoCaptureOptions: CaptureOptions {
 @objc
 public class CameraCaptureOptions: NSObject, VideoCaptureOptions {
 
-    public static func == (lhs: CameraCaptureOptions, rhs: CameraCaptureOptions) -> Bool {
-        // TODO: Implement
-        fatalError("Not implemented")
-    }
-
     @objc
     public let position: AVCaptureDevice.Position
+
     @objc
     public let preferredFormat: AVCaptureDevice.Format?
 
@@ -79,20 +75,36 @@ public class CameraCaptureOptions: NSObject, VideoCaptureOptions {
                              dimensions: dimensions ?? self.dimensions,
                              fps: fps ?? self.fps)
     }
+
+    // MARK: - Equal
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return self.position == other.position &&
+            self.preferredFormat == other.preferredFormat &&
+            self.dimensions == other.dimensions &&
+            self.fps == other.fps
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(position)
+        hasher.combine(preferredFormat)
+        hasher.combine(dimensions)
+        hasher.combine(fps)
+        return hasher.finalize()
+    }
 }
 
 @objc
 public class ScreenShareCaptureOptions: NSObject, VideoCaptureOptions {
 
-    public static func == (lhs: ScreenShareCaptureOptions, rhs: ScreenShareCaptureOptions) -> Bool {
-        // TODO: Implement
-        fatalError("Not implemented")
-    }
-
     @objc
     public let dimensions: Dimensions
+
     @objc
     public let fps: Int
+
     @objc
     public let useBroadcastExtension: Bool
 
@@ -104,18 +116,31 @@ public class ScreenShareCaptureOptions: NSObject, VideoCaptureOptions {
         self.fps = fps
         self.useBroadcastExtension = useBroadcastExtension
     }
+
+    // MARK: - Equal
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return self.dimensions == other.dimensions &&
+            self.fps == other.fps &&
+            self.useBroadcastExtension == other.useBroadcastExtension
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(dimensions)
+        hasher.combine(fps)
+        hasher.combine(useBroadcastExtension)
+        return hasher.finalize()
+    }
 }
 
 @objc
 public class BufferCaptureOptions: NSObject, VideoCaptureOptions {
 
-    public static func == (lhs: BufferCaptureOptions, rhs: BufferCaptureOptions) -> Bool {
-        // TODO: Implement
-        fatalError("Not implemented")
-    }
-
     @objc
     public let dimensions: Dimensions
+
     @objc
     public let fps: Int
 
@@ -129,28 +154,44 @@ public class BufferCaptureOptions: NSObject, VideoCaptureOptions {
         self.dimensions = options.dimensions
         self.fps = options.fps
     }
+
+    // MARK: - Equal
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return self.dimensions == other.dimensions &&
+            self.fps == other.fps
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(dimensions)
+        hasher.combine(fps)
+        return hasher.finalize()
+    }
 }
 
 @objc
 public class AudioCaptureOptions: NSObject, CaptureOptions {
 
-    public static func == (lhs: AudioCaptureOptions, rhs: AudioCaptureOptions) -> Bool {
-        // TODO: Implement
-        fatalError("Not implemented")
-    }
-
     @objc
     public let echoCancellation: Bool
+
     @objc
     public let noiseSuppression: Bool
+
     @objc
     public let autoGainControl: Bool
+
     @objc
     public let typingNoiseDetection: Bool
+
     @objc
     public let highpassFilter: Bool
+
     @objc
     public let experimentalNoiseSuppression: Bool = false
+
     @objc
     public let experimentalAutoGainControl: Bool = false
 
@@ -159,10 +200,36 @@ public class AudioCaptureOptions: NSObject, CaptureOptions {
                 autoGainControl: Bool = true,
                 typingNoiseDetection: Bool = true,
                 highpassFilter: Bool = true) {
+
         self.echoCancellation = echoCancellation
         self.noiseSuppression = noiseSuppression
         self.autoGainControl = autoGainControl
         self.typingNoiseDetection = typingNoiseDetection
         self.highpassFilter = highpassFilter
+    }
+
+    // MARK: - Equal
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return self.echoCancellation == other.echoCancellation &&
+            self.noiseSuppression == other.noiseSuppression &&
+            self.autoGainControl == other.autoGainControl &&
+            self.typingNoiseDetection == other.typingNoiseDetection &&
+            self.highpassFilter == other.highpassFilter &&
+            self.experimentalNoiseSuppression == other.experimentalNoiseSuppression &&
+            self.experimentalAutoGainControl == other.experimentalAutoGainControl
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(echoCancellation)
+        hasher.combine(noiseSuppression)
+        hasher.combine(autoGainControl)
+        hasher.combine(typingNoiseDetection)
+        hasher.combine(highpassFilter)
+        hasher.combine(experimentalNoiseSuppression)
+        hasher.combine(experimentalAutoGainControl)
+        return hasher.finalize()
     }
 }

--- a/Sources/LiveKit/Types/Options/CaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/CaptureOptions.swift
@@ -42,6 +42,15 @@ import WebRTC
     /// preferred fps to use for capturing, the SDK may override with a recommended value.
     @objc public let fps: Int
 
+    @objc
+    public override init() {
+        self.position = .front
+        self.preferredFormat = nil
+        self.dimensions = .h720_169
+        self.fps = 30
+    }
+
+    @objc
     public init(position: AVCaptureDevice.Position = .front,
                 preferredFormat: AVCaptureDevice.Format? = nil,
                 dimensions: Dimensions = .h720_169,

--- a/Sources/LiveKit/Types/Options/CaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/CaptureOptions.swift
@@ -17,30 +17,37 @@
 import Foundation
 import WebRTC
 
-@objc public protocol CaptureOptions {
+@objc
+public protocol CaptureOptions {
 
 }
 
-@objc public protocol VideoCaptureOptions: CaptureOptions {
+@objc
+public protocol VideoCaptureOptions: CaptureOptions {
     var dimensions: Dimensions { get }
     var fps: Int { get }
 }
 
-@objc public class CameraCaptureOptions: NSObject, VideoCaptureOptions {
+@objc
+public class CameraCaptureOptions: NSObject, VideoCaptureOptions {
 
     public static func == (lhs: CameraCaptureOptions, rhs: CameraCaptureOptions) -> Bool {
         // TODO: Implement
         fatalError("Not implemented")
     }
 
-    @objc public let position: AVCaptureDevice.Position
-    @objc public let preferredFormat: AVCaptureDevice.Format?
+    @objc
+    public let position: AVCaptureDevice.Position
+    @objc
+    public let preferredFormat: AVCaptureDevice.Format?
 
     /// preferred dimensions for capturing, the SDK may override with a recommended value.
-    @objc public let dimensions: Dimensions
+    @objc
+    public let dimensions: Dimensions
 
     /// preferred fps to use for capturing, the SDK may override with a recommended value.
-    @objc public let fps: Int
+    @objc
+    public let fps: Int
 
     @objc
     public override init() {
@@ -74,16 +81,20 @@ import WebRTC
     }
 }
 
-@objc public class ScreenShareCaptureOptions: NSObject, VideoCaptureOptions {
+@objc
+public class ScreenShareCaptureOptions: NSObject, VideoCaptureOptions {
 
     public static func == (lhs: ScreenShareCaptureOptions, rhs: ScreenShareCaptureOptions) -> Bool {
         // TODO: Implement
         fatalError("Not implemented")
     }
 
-    @objc public let dimensions: Dimensions
-    @objc public let fps: Int
-    @objc public let useBroadcastExtension: Bool
+    @objc
+    public let dimensions: Dimensions
+    @objc
+    public let fps: Int
+    @objc
+    public let useBroadcastExtension: Bool
 
     public init(dimensions: Dimensions = .h1080_169,
                 fps: Int = 30,
@@ -95,15 +106,18 @@ import WebRTC
     }
 }
 
-@objc public class BufferCaptureOptions: NSObject, VideoCaptureOptions {
+@objc
+public class BufferCaptureOptions: NSObject, VideoCaptureOptions {
 
     public static func == (lhs: BufferCaptureOptions, rhs: BufferCaptureOptions) -> Bool {
         // TODO: Implement
         fatalError("Not implemented")
     }
 
-    @objc public let dimensions: Dimensions
-    @objc public let fps: Int
+    @objc
+    public let dimensions: Dimensions
+    @objc
+    public let fps: Int
 
     public init(dimensions: Dimensions = .h1080_169,
                 fps: Int = 30) {
@@ -117,20 +131,28 @@ import WebRTC
     }
 }
 
-@objc public class AudioCaptureOptions: NSObject, CaptureOptions {
+@objc
+public class AudioCaptureOptions: NSObject, CaptureOptions {
 
     public static func == (lhs: AudioCaptureOptions, rhs: AudioCaptureOptions) -> Bool {
         // TODO: Implement
         fatalError("Not implemented")
     }
 
-    @objc public let echoCancellation: Bool
-    @objc public let noiseSuppression: Bool
-    @objc public let autoGainControl: Bool
-    @objc public let typingNoiseDetection: Bool
-    @objc public let highpassFilter: Bool
-    @objc public let experimentalNoiseSuppression: Bool = false
-    @objc public let experimentalAutoGainControl: Bool = false
+    @objc
+    public let echoCancellation: Bool
+    @objc
+    public let noiseSuppression: Bool
+    @objc
+    public let autoGainControl: Bool
+    @objc
+    public let typingNoiseDetection: Bool
+    @objc
+    public let highpassFilter: Bool
+    @objc
+    public let experimentalNoiseSuppression: Bool = false
+    @objc
+    public let experimentalAutoGainControl: Bool = false
 
     public init(echoCancellation: Bool = true,
                 noiseSuppression: Bool = false,

--- a/Sources/LiveKit/Types/Options/CaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/CaptureOptions.swift
@@ -17,25 +17,30 @@
 import Foundation
 import WebRTC
 
-public protocol CaptureOptions {
+@objc public protocol CaptureOptions {
 
 }
 
-public protocol VideoCaptureOptions: CaptureOptions {
+@objc public protocol VideoCaptureOptions: CaptureOptions {
     var dimensions: Dimensions { get }
     var fps: Int { get }
 }
 
-public struct CameraCaptureOptions: VideoCaptureOptions, Equatable {
+@objc public class CameraCaptureOptions: NSObject, VideoCaptureOptions {
 
-    public let position: AVCaptureDevice.Position
-    public let preferredFormat: AVCaptureDevice.Format?
+    public static func == (lhs: CameraCaptureOptions, rhs: CameraCaptureOptions) -> Bool {
+        // TODO: Implement
+        fatalError("Not implemented")
+    }
+
+    @objc public let position: AVCaptureDevice.Position
+    @objc public let preferredFormat: AVCaptureDevice.Format?
 
     /// preferred dimensions for capturing, the SDK may override with a recommended value.
-    public let dimensions: Dimensions
+    @objc public let dimensions: Dimensions
 
     /// preferred fps to use for capturing, the SDK may override with a recommended value.
-    public let fps: Int
+    @objc public let fps: Int
 
     public init(position: AVCaptureDevice.Position = .front,
                 preferredFormat: AVCaptureDevice.Format? = nil,
@@ -60,26 +65,36 @@ public struct CameraCaptureOptions: VideoCaptureOptions, Equatable {
     }
 }
 
-public struct ScreenShareCaptureOptions: VideoCaptureOptions, Equatable {
+@objc public class ScreenShareCaptureOptions: NSObject, VideoCaptureOptions {
 
-    public let dimensions: Dimensions
-    public let fps: Int
-    public let useBroadcastExtension: Bool
+    public static func == (lhs: ScreenShareCaptureOptions, rhs: ScreenShareCaptureOptions) -> Bool {
+        // TODO: Implement
+        fatalError("Not implemented")
+    }
+
+    @objc public let dimensions: Dimensions
+    @objc public let fps: Int
+    @objc public let useBroadcastExtension: Bool
 
     public init(dimensions: Dimensions = .h1080_169,
                 fps: Int = 30,
-                useBroadcastExtension: Bool = false
-    ) {
+                useBroadcastExtension: Bool = false) {
+
         self.dimensions = dimensions
         self.fps = fps
         self.useBroadcastExtension = useBroadcastExtension
     }
 }
 
-public struct BufferCaptureOptions: VideoCaptureOptions, Equatable {
+@objc public class BufferCaptureOptions: NSObject, VideoCaptureOptions {
 
-    public let dimensions: Dimensions
-    public let fps: Int
+    public static func == (lhs: BufferCaptureOptions, rhs: BufferCaptureOptions) -> Bool {
+        // TODO: Implement
+        fatalError("Not implemented")
+    }
+
+    @objc public let dimensions: Dimensions
+    @objc public let fps: Int
 
     public init(dimensions: Dimensions = .h1080_169,
                 fps: Int = 30) {
@@ -93,15 +108,20 @@ public struct BufferCaptureOptions: VideoCaptureOptions, Equatable {
     }
 }
 
-public struct AudioCaptureOptions: CaptureOptions, Equatable {
+@objc public class AudioCaptureOptions: NSObject, CaptureOptions {
 
-    public let echoCancellation: Bool
-    public let noiseSuppression: Bool
-    public let autoGainControl: Bool
-    public let typingNoiseDetection: Bool
-    public let highpassFilter: Bool
-    public let experimentalNoiseSuppression: Bool = false
-    public let experimentalAutoGainControl: Bool = false
+    public static func == (lhs: AudioCaptureOptions, rhs: AudioCaptureOptions) -> Bool {
+        // TODO: Implement
+        fatalError("Not implemented")
+    }
+
+    @objc public let echoCancellation: Bool
+    @objc public let noiseSuppression: Bool
+    @objc public let autoGainControl: Bool
+    @objc public let typingNoiseDetection: Bool
+    @objc public let highpassFilter: Bool
+    @objc public let experimentalNoiseSuppression: Bool = false
+    @objc public let experimentalAutoGainControl: Bool = false
 
     public init(echoCancellation: Bool = true,
                 noiseSuppression: Bool = false,

--- a/Sources/LiveKit/Types/Options/ConnectOptions.swift
+++ b/Sources/LiveKit/Types/Options/ConnectOptions.swift
@@ -21,26 +21,22 @@ import WebRTC
 @objc
 public class ConnectOptions: NSObject {
 
-    public static func == (lhs: ConnectOptions, rhs: ConnectOptions) -> Bool {
-        lhs.autoSubscribe == rhs.autoSubscribe &&
-            lhs.rtcConfiguration == rhs.rtcConfiguration &&
-            lhs.protocolVersion == rhs.protocolVersion  &&
-            lhs.publishOnlyMode == rhs.publishOnlyMode
-    }
-
     /// Automatically subscribe to ``RemoteParticipant``'s tracks.
     /// Defaults to true.
     @objc
     public let autoSubscribe: Bool
+
     @objc
     public let rtcConfiguration: RTCConfiguration
-    /// LiveKit server protocol version to use. Generally, it's not recommended to change this.
-    @objc
-    public let protocolVersion: ProtocolVersion
+
     /// Providing a string will make the connection publish-only, suitable for iOS Broadcast Upload Extensions.
     /// The string can be used to identify the publisher.
     @objc
     public let publishOnlyMode: String?
+
+    /// LiveKit server protocol version to use. Generally, it's not recommended to change this.
+    @objc
+    public let protocolVersion: ProtocolVersion
 
     @objc
     public override init() {
@@ -60,6 +56,25 @@ public class ConnectOptions: NSObject {
         self.rtcConfiguration = rtcConfiguration ?? .liveKitDefault()
         self.publishOnlyMode = publishOnlyMode
         self.protocolVersion = protocolVersion
+    }
+
+    // MARK: - Equal
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return self.autoSubscribe == other.autoSubscribe &&
+            self.rtcConfiguration == other.rtcConfiguration &&
+            self.publishOnlyMode == other.publishOnlyMode &&
+            self.protocolVersion == other.protocolVersion
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(autoSubscribe)
+        hasher.combine(rtcConfiguration)
+        hasher.combine(publishOnlyMode)
+        hasher.combine(protocolVersion)
+        return hasher.finalize()
     }
 }
 

--- a/Sources/LiveKit/Types/Options/ConnectOptions.swift
+++ b/Sources/LiveKit/Types/Options/ConnectOptions.swift
@@ -18,7 +18,8 @@ import Foundation
 import WebRTC
 
 /// Options used when establishing a connection.
-@objc public class ConnectOptions: NSObject {
+@objc
+public class ConnectOptions: NSObject {
 
     public static func == (lhs: ConnectOptions, rhs: ConnectOptions) -> Bool {
         lhs.autoSubscribe == rhs.autoSubscribe &&
@@ -29,25 +30,31 @@ import WebRTC
 
     /// Automatically subscribe to ``RemoteParticipant``'s tracks.
     /// Defaults to true.
-    @objc public let autoSubscribe: Bool
-    @objc public let rtcConfiguration: RTCConfiguration
+    @objc
+    public let autoSubscribe: Bool
+    @objc
+    public let rtcConfiguration: RTCConfiguration
     /// LiveKit server protocol version to use. Generally, it's not recommended to change this.
-    @objc public let protocolVersion: ProtocolVersion
+    @objc
+    public let protocolVersion: ProtocolVersion
     /// Providing a string will make the connection publish-only, suitable for iOS Broadcast Upload Extensions.
     /// The string can be used to identify the publisher.
-    @objc public let publishOnlyMode: String?
+    @objc
+    public let publishOnlyMode: String?
 
-    @objc public override init() {
+    @objc
+    public override init() {
         self.autoSubscribe = true
         self.rtcConfiguration = .liveKitDefault()
         self.publishOnlyMode = nil
         self.protocolVersion = .v8
     }
 
-    @objc public init(autoSubscribe: Bool = true,
-                      rtcConfiguration: RTCConfiguration? = nil,
-                      publishOnlyMode: String? = nil,
-                      protocolVersion: ProtocolVersion = .v8) {
+    @objc
+    public init(autoSubscribe: Bool = true,
+                rtcConfiguration: RTCConfiguration? = nil,
+                publishOnlyMode: String? = nil,
+                protocolVersion: ProtocolVersion = .v8) {
 
         self.autoSubscribe = autoSubscribe
         self.rtcConfiguration = rtcConfiguration ?? .liveKitDefault()

--- a/Sources/LiveKit/Types/Options/ConnectOptions.swift
+++ b/Sources/LiveKit/Types/Options/ConnectOptions.swift
@@ -18,25 +18,39 @@ import Foundation
 import WebRTC
 
 /// Options used when establishing a connection.
-public struct ConnectOptions: Equatable {
+@objc public class ConnectOptions: NSObject {
+
+    public static func == (lhs: ConnectOptions, rhs: ConnectOptions) -> Bool {
+        lhs.autoSubscribe == rhs.autoSubscribe &&
+            lhs.rtcConfiguration == rhs.rtcConfiguration &&
+            lhs.protocolVersion == rhs.protocolVersion  &&
+            lhs.publishOnlyMode == rhs.publishOnlyMode
+    }
 
     /// Automatically subscribe to ``RemoteParticipant``'s tracks.
     /// Defaults to true.
-    public let autoSubscribe: Bool
-    public let rtcConfiguration: RTCConfiguration
+    @objc public let autoSubscribe: Bool
+    @objc public let rtcConfiguration: RTCConfiguration
     /// LiveKit server protocol version to use. Generally, it's not recommended to change this.
-    public let protocolVersion: ProtocolVersion
+    @objc public let protocolVersion: ProtocolVersion
     /// Providing a string will make the connection publish-only, suitable for iOS Broadcast Upload Extensions.
     /// The string can be used to identify the publisher.
-    public let publishOnlyMode: String?
+    @objc public let publishOnlyMode: String?
 
-    public init(autoSubscribe: Bool = true,
-                rtcConfiguration: RTCConfiguration = .liveKitDefault(),
-                publishOnlyMode: String? = nil,
-                protocolVersion: ProtocolVersion = .v8) {
+    @objc public override init() {
+        self.autoSubscribe = true
+        self.rtcConfiguration = .liveKitDefault()
+        self.publishOnlyMode = nil
+        self.protocolVersion = .v8
+    }
+
+    @objc public init(autoSubscribe: Bool = true,
+                      rtcConfiguration: RTCConfiguration? = nil,
+                      publishOnlyMode: String? = nil,
+                      protocolVersion: ProtocolVersion = .v8) {
 
         self.autoSubscribe = autoSubscribe
-        self.rtcConfiguration = rtcConfiguration
+        self.rtcConfiguration = rtcConfiguration ?? .liveKitDefault()
         self.publishOnlyMode = publishOnlyMode
         self.protocolVersion = protocolVersion
     }

--- a/Sources/LiveKit/Types/Options/PublishOptions.swift
+++ b/Sources/LiveKit/Types/Options/PublishOptions.swift
@@ -16,28 +16,36 @@
 
 import Foundation
 
-@objc public protocol PublishOptions {
+@objc
+public protocol PublishOptions {
     var name: String? { get }
 }
 
-@objc public class VideoPublishOptions: NSObject, PublishOptions {
+@objc
+public class VideoPublishOptions: NSObject, PublishOptions {
 
     public static func == (lhs: VideoPublishOptions, rhs: VideoPublishOptions) -> Bool {
         // TODO: Implement
         fatalError("Not implemented")
     }
 
-    @objc public let name: String?
+    @objc
+    public let name: String?
     /// preferred encoding parameters
-    @objc public let encoding: VideoEncoding?
+    @objc
+    public let encoding: VideoEncoding?
     /// encoding parameters for for screen share
-    @objc public let screenShareEncoding: VideoEncoding?
+    @objc
+    public let screenShareEncoding: VideoEncoding?
     /// true to enable simulcasting, publishes three tracks at different sizes
-    @objc public let simulcast: Bool
+    @objc
+    public let simulcast: Bool
 
-    @objc public let simulcastLayers: [VideoParameters]
+    @objc
+    public let simulcastLayers: [VideoParameters]
 
-    @objc public let screenShareSimulcastLayers: [VideoParameters]
+    @objc
+    public let screenShareSimulcastLayers: [VideoParameters]
 
     public init(name: String? = nil,
                 encoding: VideoEncoding? = nil,
@@ -55,16 +63,19 @@ import Foundation
     }
 }
 
-@objc public class AudioPublishOptions: NSObject, PublishOptions {
+@objc
+public class AudioPublishOptions: NSObject, PublishOptions {
 
     public static func == (lhs: AudioPublishOptions, rhs: AudioPublishOptions) -> Bool {
         // TODO: Implement
         fatalError("Not implemented")
     }
 
-    @objc public let name: String?
+    @objc
+    public let name: String?
     public let bitrate: Int?
-    @objc public let dtx: Bool
+    @objc
+    public let dtx: Bool
 
     public init(name: String? = nil,
                 bitrate: Int? = nil,
@@ -76,14 +87,16 @@ import Foundation
     }
 }
 
-@objc public class DataPublishOptions: NSObject, PublishOptions {
+@objc
+public class DataPublishOptions: NSObject, PublishOptions {
 
     public static func == (lhs: DataPublishOptions, rhs: DataPublishOptions) -> Bool {
         // TODO: Implement
         fatalError("Not implemented")
     }
 
-    @objc public let name: String?
+    @objc
+    public let name: String?
 
     public init(name: String? = nil) {
 

--- a/Sources/LiveKit/Types/Options/PublishOptions.swift
+++ b/Sources/LiveKit/Types/Options/PublishOptions.swift
@@ -24,19 +24,17 @@ public protocol PublishOptions {
 @objc
 public class VideoPublishOptions: NSObject, PublishOptions {
 
-    public static func == (lhs: VideoPublishOptions, rhs: VideoPublishOptions) -> Bool {
-        // TODO: Implement
-        fatalError("Not implemented")
-    }
-
     @objc
     public let name: String?
+
     /// preferred encoding parameters
     @objc
     public let encoding: VideoEncoding?
+
     /// encoding parameters for for screen share
     @objc
     public let screenShareEncoding: VideoEncoding?
+
     /// true to enable simulcasting, publishes three tracks at different sizes
     @objc
     public let simulcast: Bool
@@ -61,19 +59,39 @@ public class VideoPublishOptions: NSObject, PublishOptions {
         self.simulcastLayers = simulcastLayers
         self.screenShareSimulcastLayers = screenShareSimulcastLayers
     }
+
+    // MARK: - Equal
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return self.name == other.name &&
+            self.encoding == other.encoding &&
+            self.screenShareEncoding == other.screenShareEncoding &&
+            self.simulcast == other.simulcast &&
+            self.simulcastLayers == other.simulcastLayers &&
+            self.screenShareSimulcastLayers == other.screenShareSimulcastLayers
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(name)
+        hasher.combine(encoding)
+        hasher.combine(screenShareEncoding)
+        hasher.combine(simulcast)
+        hasher.combine(simulcastLayers)
+        hasher.combine(screenShareSimulcastLayers)
+        return hasher.finalize()
+    }
 }
 
 @objc
 public class AudioPublishOptions: NSObject, PublishOptions {
 
-    public static func == (lhs: AudioPublishOptions, rhs: AudioPublishOptions) -> Bool {
-        // TODO: Implement
-        fatalError("Not implemented")
-    }
-
     @objc
     public let name: String?
+
     public let bitrate: Int?
+
     @objc
     public let dtx: Bool
 
@@ -85,15 +103,27 @@ public class AudioPublishOptions: NSObject, PublishOptions {
         self.bitrate = bitrate
         self.dtx = dtx
     }
+
+    // MARK: - Equal
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return self.name == other.name &&
+            self.bitrate == other.bitrate &&
+            self.dtx == other.dtx
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(name)
+        hasher.combine(bitrate)
+        hasher.combine(dtx)
+        return hasher.finalize()
+    }
 }
 
 @objc
 public class DataPublishOptions: NSObject, PublishOptions {
-
-    public static func == (lhs: DataPublishOptions, rhs: DataPublishOptions) -> Bool {
-        // TODO: Implement
-        fatalError("Not implemented")
-    }
 
     @objc
     public let name: String?
@@ -101,5 +131,18 @@ public class DataPublishOptions: NSObject, PublishOptions {
     public init(name: String? = nil) {
 
         self.name = name
+    }
+
+    // MARK: - Equal
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return self.name == other.name
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(name)
+        return hasher.finalize()
     }
 }

--- a/Sources/LiveKit/Types/Options/PublishOptions.swift
+++ b/Sources/LiveKit/Types/Options/PublishOptions.swift
@@ -16,23 +16,28 @@
 
 import Foundation
 
-public protocol PublishOptions {
+@objc public protocol PublishOptions {
     var name: String? { get }
 }
 
-public struct VideoPublishOptions: PublishOptions, Equatable {
+@objc public class VideoPublishOptions: NSObject, PublishOptions {
 
-    public let name: String?
+    public static func == (lhs: VideoPublishOptions, rhs: VideoPublishOptions) -> Bool {
+        // TODO: Implement
+        fatalError("Not implemented")
+    }
+
+    @objc public let name: String?
     /// preferred encoding parameters
-    public let encoding: VideoEncoding?
+    @objc public let encoding: VideoEncoding?
     /// encoding parameters for for screen share
-    public let screenShareEncoding: VideoEncoding?
+    @objc public let screenShareEncoding: VideoEncoding?
     /// true to enable simulcasting, publishes three tracks at different sizes
-    public let simulcast: Bool
+    @objc public let simulcast: Bool
 
-    public let simulcastLayers: [VideoParameters]
+    @objc public let simulcastLayers: [VideoParameters]
 
-    public let screenShareSimulcastLayers: [VideoParameters]
+    @objc public let screenShareSimulcastLayers: [VideoParameters]
 
     public init(name: String? = nil,
                 encoding: VideoEncoding? = nil,
@@ -50,11 +55,16 @@ public struct VideoPublishOptions: PublishOptions, Equatable {
     }
 }
 
-public struct AudioPublishOptions: PublishOptions, Equatable {
+@objc public class AudioPublishOptions: NSObject, PublishOptions {
 
-    public let name: String?
+    public static func == (lhs: AudioPublishOptions, rhs: AudioPublishOptions) -> Bool {
+        // TODO: Implement
+        fatalError("Not implemented")
+    }
+
+    @objc public let name: String?
     public let bitrate: Int?
-    public let dtx: Bool
+    @objc public let dtx: Bool
 
     public init(name: String? = nil,
                 bitrate: Int? = nil,
@@ -66,9 +76,14 @@ public struct AudioPublishOptions: PublishOptions, Equatable {
     }
 }
 
-public struct DataPublishOptions: PublishOptions, Equatable {
+@objc public class DataPublishOptions: NSObject, PublishOptions {
 
-    public let name: String?
+    public static func == (lhs: DataPublishOptions, rhs: DataPublishOptions) -> Bool {
+        // TODO: Implement
+        fatalError("Not implemented")
+    }
+
+    @objc public let name: String?
 
     public init(name: String? = nil) {
 

--- a/Sources/LiveKit/Types/Options/RoomOptions.swift
+++ b/Sources/LiveKit/Types/Options/RoomOptions.swift
@@ -16,15 +16,21 @@
 
 import Foundation
 
-public struct RoomOptions: Equatable {
-    // default options for capturing
-    public let defaultCameraCaptureOptions: CameraCaptureOptions
-    public let defaultScreenShareCaptureOptions: ScreenShareCaptureOptions
+@objc public class RoomOptions: NSObject {
 
-    public let defaultAudioCaptureOptions: AudioCaptureOptions
+    public static func == (lhs: RoomOptions, rhs: RoomOptions) -> Bool {
+        // TODO: Implement
+        fatalError("Not implemented")
+    }
+
+    // default options for capturing
+    @objc public let defaultCameraCaptureOptions: CameraCaptureOptions
+    @objc public let defaultScreenShareCaptureOptions: ScreenShareCaptureOptions
+
+    @objc public let defaultAudioCaptureOptions: AudioCaptureOptions
     // default options for publishing
-    public let defaultVideoPublishOptions: VideoPublishOptions
-    public let defaultAudioPublishOptions: AudioPublishOptions
+    @objc public let defaultVideoPublishOptions: VideoPublishOptions
+    @objc public let defaultAudioPublishOptions: AudioPublishOptions
 
     /// AdaptiveStream lets LiveKit automatically manage quality of subscribed
     /// video tracks to optimize for bandwidth and CPU.
@@ -34,23 +40,23 @@ public struct RoomOptions: Equatable {
     /// When none of the video elements are visible, it'll temporarily pause
     /// the data flow until they are visible again.
     ///
-    public let adaptiveStream: Bool
+    @objc public let adaptiveStream: Bool
 
     /// Dynamically pauses video layers that are not being consumed by any subscribers,
     /// significantly reducing publishing CPU and bandwidth usage.
     ///
-    public let dynacast: Bool
+    @objc public let dynacast: Bool
 
-    public let stopLocalTrackOnUnpublish: Bool
+    @objc public let stopLocalTrackOnUnpublish: Bool
 
     /// Automatically suspend(mute) video tracks when the app enters background and
     /// resume(unmute) when the app enters foreground again.
-    public let suspendLocalVideoTracksInBackground: Bool
+    @objc public let suspendLocalVideoTracksInBackground: Bool
 
     /// **Experimental**
     /// Report ``TrackStats`` every second to ``TrackDelegate`` for each local and remote tracks.
     /// This may consume slightly more CPU resources.
-    public let reportStats: Bool
+    @objc public let reportStats: Bool
 
     public init(defaultCameraCaptureOptions: CameraCaptureOptions = CameraCaptureOptions(),
                 defaultScreenShareCaptureOptions: ScreenShareCaptureOptions = ScreenShareCaptureOptions(),

--- a/Sources/LiveKit/Types/Options/RoomOptions.swift
+++ b/Sources/LiveKit/Types/Options/RoomOptions.swift
@@ -16,7 +16,8 @@
 
 import Foundation
 
-@objc public class RoomOptions: NSObject {
+@objc
+public class RoomOptions: NSObject {
 
     public static func == (lhs: RoomOptions, rhs: RoomOptions) -> Bool {
         // TODO: Implement
@@ -24,13 +25,18 @@ import Foundation
     }
 
     // default options for capturing
-    @objc public let defaultCameraCaptureOptions: CameraCaptureOptions
-    @objc public let defaultScreenShareCaptureOptions: ScreenShareCaptureOptions
+    @objc
+    public let defaultCameraCaptureOptions: CameraCaptureOptions
+    @objc
+    public let defaultScreenShareCaptureOptions: ScreenShareCaptureOptions
 
-    @objc public let defaultAudioCaptureOptions: AudioCaptureOptions
+    @objc
+    public let defaultAudioCaptureOptions: AudioCaptureOptions
     // default options for publishing
-    @objc public let defaultVideoPublishOptions: VideoPublishOptions
-    @objc public let defaultAudioPublishOptions: AudioPublishOptions
+    @objc
+    public let defaultVideoPublishOptions: VideoPublishOptions
+    @objc
+    public let defaultAudioPublishOptions: AudioPublishOptions
 
     /// AdaptiveStream lets LiveKit automatically manage quality of subscribed
     /// video tracks to optimize for bandwidth and CPU.
@@ -40,23 +46,28 @@ import Foundation
     /// When none of the video elements are visible, it'll temporarily pause
     /// the data flow until they are visible again.
     ///
-    @objc public let adaptiveStream: Bool
+    @objc
+    public let adaptiveStream: Bool
 
     /// Dynamically pauses video layers that are not being consumed by any subscribers,
     /// significantly reducing publishing CPU and bandwidth usage.
     ///
-    @objc public let dynacast: Bool
+    @objc
+    public let dynacast: Bool
 
-    @objc public let stopLocalTrackOnUnpublish: Bool
+    @objc
+    public let stopLocalTrackOnUnpublish: Bool
 
     /// Automatically suspend(mute) video tracks when the app enters background and
     /// resume(unmute) when the app enters foreground again.
-    @objc public let suspendLocalVideoTracksInBackground: Bool
+    @objc
+    public let suspendLocalVideoTracksInBackground: Bool
 
     /// **Experimental**
     /// Report ``TrackStats`` every second to ``TrackDelegate`` for each local and remote tracks.
     /// This may consume slightly more CPU resources.
-    @objc public let reportStats: Bool
+    @objc
+    public let reportStats: Bool
 
     public init(defaultCameraCaptureOptions: CameraCaptureOptions = CameraCaptureOptions(),
                 defaultScreenShareCaptureOptions: ScreenShareCaptureOptions = ScreenShareCaptureOptions(),

--- a/Sources/LiveKit/Types/Options/RoomOptions.swift
+++ b/Sources/LiveKit/Types/Options/RoomOptions.swift
@@ -19,22 +19,20 @@ import Foundation
 @objc
 public class RoomOptions: NSObject {
 
-    public static func == (lhs: RoomOptions, rhs: RoomOptions) -> Bool {
-        // TODO: Implement
-        fatalError("Not implemented")
-    }
-
     // default options for capturing
     @objc
     public let defaultCameraCaptureOptions: CameraCaptureOptions
+
     @objc
     public let defaultScreenShareCaptureOptions: ScreenShareCaptureOptions
 
     @objc
     public let defaultAudioCaptureOptions: AudioCaptureOptions
+
     // default options for publishing
     @objc
     public let defaultVideoPublishOptions: VideoPublishOptions
+
     @objc
     public let defaultAudioPublishOptions: AudioPublishOptions
 
@@ -90,5 +88,36 @@ public class RoomOptions: NSObject {
         self.stopLocalTrackOnUnpublish = stopLocalTrackOnUnpublish
         self.suspendLocalVideoTracksInBackground = suspendLocalVideoTracksInBackground
         self.reportStats = reportStats
+    }
+
+    // MARK: - Equal
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return self.defaultCameraCaptureOptions == other.defaultCameraCaptureOptions &&
+            self.defaultScreenShareCaptureOptions == other.defaultScreenShareCaptureOptions &&
+            self.defaultAudioCaptureOptions == other.defaultAudioCaptureOptions &&
+            self.defaultVideoPublishOptions == other.defaultVideoPublishOptions &&
+            self.defaultAudioPublishOptions == other.defaultAudioPublishOptions &&
+            self.adaptiveStream == other.adaptiveStream &&
+            self.dynacast == other.dynacast &&
+            self.stopLocalTrackOnUnpublish == other.stopLocalTrackOnUnpublish &&
+            self.suspendLocalVideoTracksInBackground == other.suspendLocalVideoTracksInBackground &&
+            self.reportStats == other.reportStats
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(defaultCameraCaptureOptions)
+        hasher.combine(defaultScreenShareCaptureOptions)
+        hasher.combine(defaultAudioCaptureOptions)
+        hasher.combine(defaultVideoPublishOptions)
+        hasher.combine(defaultAudioPublishOptions)
+        hasher.combine(adaptiveStream)
+        hasher.combine(dynacast)
+        hasher.combine(stopLocalTrackOnUnpublish)
+        hasher.combine(suspendLocalVideoTracksInBackground)
+        hasher.combine(reportStats)
+        return hasher.finalize()
     }
 }

--- a/Sources/LiveKit/Types/Other.swift
+++ b/Sources/LiveKit/Types/Other.swift
@@ -25,7 +25,8 @@ public typealias Sid = String
 // wait: resolves when wait is complete or rejects when timeout
 internal typealias WaitPromises<T> = (listen: Promise<Void>, wait: () -> Promise<T>)
 
-@objc public enum Reliability: Int {
+@objc
+public enum Reliability: Int {
     case reliable
     case lossy
 }

--- a/Sources/LiveKit/Types/Other.swift
+++ b/Sources/LiveKit/Types/Other.swift
@@ -25,7 +25,7 @@ public typealias Sid = String
 // wait: resolves when wait is complete or rejects when timeout
 internal typealias WaitPromises<T> = (listen: Promise<Void>, wait: () -> Promise<T>)
 
-public enum Reliability {
+@objc public enum Reliability: Int {
     case reliable
     case lossy
 }

--- a/Sources/LiveKit/Types/ParticipantPermissions.swift
+++ b/Sources/LiveKit/Types/ParticipantPermissions.swift
@@ -20,21 +20,30 @@ import Foundation
 public class ParticipantPermissions: NSObject {
 
     /// ``Participant`` can subscribe to tracks in the room
+    @objc
     public let canSubscribe: Bool
+
     /// ``Participant`` can publish new tracks to room
+    @objc
     public let canPublish: Bool
+
     /// ``Participant`` can publish data
+    @objc
     public let canPublishData: Bool
+
     /// ``Participant`` is hidden to others
+    @objc
     public let hidden: Bool
+
     /// Indicates it's a recorder instance
+    @objc
     public let recorder: Bool
 
-    public init(canSubscribe: Bool = false,
-                canPublish: Bool = false,
-                canPublishData: Bool = false,
-                hidden: Bool = false,
-                recorder: Bool = false) {
+    internal init(canSubscribe: Bool = false,
+                  canPublish: Bool = false,
+                  canPublishData: Bool = false,
+                  hidden: Bool = false,
+                  recorder: Bool = false) {
 
         self.canSubscribe = canSubscribe
         self.canPublish = canPublish

--- a/Sources/LiveKit/Types/ParticipantPermissions.swift
+++ b/Sources/LiveKit/Types/ParticipantPermissions.swift
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-public struct ParticipantPermissions: Equatable {
+import Foundation
+
+@objc public class ParticipantPermissions: NSObject {
 
     /// ``Participant`` can subscribe to tracks in the room
     public let canSubscribe: Bool

--- a/Sources/LiveKit/Types/ParticipantPermissions.swift
+++ b/Sources/LiveKit/Types/ParticipantPermissions.swift
@@ -52,12 +52,25 @@ public class ParticipantPermissions: NSObject {
         self.recorder = recorder
     }
 
-    public static func == (lhs: ParticipantPermissions, rhs: ParticipantPermissions) -> Bool {
-        return lhs.canSubscribe == rhs.canSubscribe &&
-            lhs.canPublish == rhs.canPublish &&
-            lhs.canPublishData == rhs.canPublishData &&
-            lhs.hidden == rhs.hidden &&
-            lhs.recorder == rhs.recorder
+    // MARK: - Equal
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return self.canSubscribe == other.canSubscribe &&
+            self.canPublish == other.canPublish &&
+            self.canPublishData == other.canPublishData &&
+            self.hidden == other.hidden &&
+            self.recorder == other.recorder
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(canSubscribe)
+        hasher.combine(canPublish)
+        hasher.combine(canPublishData)
+        hasher.combine(hidden)
+        hasher.combine(recorder)
+        return hasher.finalize()
     }
 }
 

--- a/Sources/LiveKit/Types/ParticipantPermissions.swift
+++ b/Sources/LiveKit/Types/ParticipantPermissions.swift
@@ -16,7 +16,8 @@
 
 import Foundation
 
-@objc public class ParticipantPermissions: NSObject {
+@objc
+public class ParticipantPermissions: NSObject {
 
     /// ``Participant`` can subscribe to tracks in the room
     public let canSubscribe: Bool

--- a/Sources/LiveKit/Types/ParticipantTrackPermission.swift
+++ b/Sources/LiveKit/Types/ParticipantTrackPermission.swift
@@ -16,27 +16,33 @@
 
 import Foundation
 
-public struct ParticipantTrackPermission {
+@objc
+public class ParticipantTrackPermission: NSObject {
     /**
      * The participant id this permission applies to.
      */
-    let participantSid: String
+    @objc
+    public let participantSid: String
 
     /**
      * If set to true, the target participant can subscribe to all tracks from the local participant.
      *
      * Takes precedence over ``allowedTrackSids``.
      */
+    @objc
     let allTracksAllowed: Bool
 
     /**
      * The list of track ids that the target participant can subscribe to.
      */
+    @objc
     let allowedTrackSids: [String]
 
+    @objc
     public init(participantSid: String,
                 allTracksAllowed: Bool,
                 allowedTrackSids: [String] = [String]()) {
+
         self.participantSid = participantSid
         self.allTracksAllowed = allTracksAllowed
         self.allowedTrackSids = allowedTrackSids
@@ -44,6 +50,7 @@ public struct ParticipantTrackPermission {
 }
 
 extension ParticipantTrackPermission {
+
     func toPBType() -> Livekit_TrackPermission {
         return Livekit_TrackPermission.with {
             $0.participantSid = self.participantSid

--- a/Sources/LiveKit/Types/ProtocolVersion.swift
+++ b/Sources/LiveKit/Types/ProtocolVersion.swift
@@ -16,7 +16,8 @@
 
 import Foundation
 
-@objc public enum ProtocolVersion: Int {
+@objc
+public enum ProtocolVersion: Int {
     case v2 = 2
     case v3 = 3
     case v4 = 4

--- a/Sources/LiveKit/Types/ProtocolVersion.swift
+++ b/Sources/LiveKit/Types/ProtocolVersion.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-public enum ProtocolVersion: Int, RawRepresentable {
+@objc public enum ProtocolVersion: Int {
     case v2 = 2
     case v3 = 3
     case v4 = 4

--- a/Sources/LiveKit/Types/TrackStats.swift
+++ b/Sources/LiveKit/Types/TrackStats.swift
@@ -52,7 +52,18 @@ public extension TrackStats {
     }
 }
 
-public struct TrackStats: Equatable {
+@objc public class TrackStats: NSObject {
+
+    public static func == (lhs: TrackStats, rhs: TrackStats) -> Bool {
+        lhs.created == rhs.created &&
+            lhs.ssrc == rhs.ssrc &&
+            lhs.trackId == rhs.trackId  &&
+            lhs.bytesSent == rhs.bytesSent &&
+            lhs.bytesReceived == rhs.bytesReceived &&
+            lhs.codecName == rhs.codecName &&
+            lhs.bpsSent == rhs.bpsSent &&
+            lhs.bpsReceived == rhs.bpsReceived
+    }
 
     static let keyTypeSSRC = "ssrc"
     static let keyTrackId = "googTrackId"
@@ -64,10 +75,10 @@ public struct TrackStats: Equatable {
     static let keyCodecName = "googCodecName"
 
     // date and time of this stats created
-    let created = Date()
+    public let created = Date()
 
-    let ssrc: String
-    let trackId: String
+    public let ssrc: String
+    public let trackId: String
 
     // TODO: add more values
     public let bytesSent: Int

--- a/Sources/LiveKit/Types/TrackStats.swift
+++ b/Sources/LiveKit/Types/TrackStats.swift
@@ -52,7 +52,8 @@ public extension TrackStats {
     }
 }
 
-@objc public class TrackStats: NSObject {
+@objc
+public class TrackStats: NSObject {
 
     public static func == (lhs: TrackStats, rhs: TrackStats) -> Bool {
         lhs.created == rhs.created &&

--- a/Sources/LiveKit/Types/TrackStats.swift
+++ b/Sources/LiveKit/Types/TrackStats.swift
@@ -55,15 +55,31 @@ public extension TrackStats {
 @objc
 public class TrackStats: NSObject {
 
-    public static func == (lhs: TrackStats, rhs: TrackStats) -> Bool {
-        lhs.created == rhs.created &&
-            lhs.ssrc == rhs.ssrc &&
-            lhs.trackId == rhs.trackId  &&
-            lhs.bytesSent == rhs.bytesSent &&
-            lhs.bytesReceived == rhs.bytesReceived &&
-            lhs.codecName == rhs.codecName &&
-            lhs.bpsSent == rhs.bpsSent &&
-            lhs.bpsReceived == rhs.bpsReceived
+    // MARK: - Equal
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return  self.created == other.created &&
+            self.ssrc == other.ssrc &&
+            self.trackId == other.trackId  &&
+            self.bytesSent == other.bytesSent &&
+            self.bytesReceived == other.bytesReceived &&
+            self.codecName == other.codecName &&
+            self.bpsSent == other.bpsSent &&
+            self.bpsReceived == other.bpsReceived
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(created)
+        hasher.combine(ssrc)
+        hasher.combine(trackId)
+        hasher.combine(bytesSent)
+        hasher.combine(bytesReceived)
+        hasher.combine(codecName)
+        hasher.combine(bpsSent)
+        hasher.combine(bpsReceived)
+        return hasher.finalize()
     }
 
     static let keyTypeSSRC = "ssrc"

--- a/Sources/LiveKit/Types/TrackStreamState.swift
+++ b/Sources/LiveKit/Types/TrackStreamState.swift
@@ -16,7 +16,8 @@
 
 import WebRTC
 
-@objc public enum StreamState: Int {
+@objc
+public enum StreamState: Int {
     case paused
     case active
 }

--- a/Sources/LiveKit/Types/TrackStreamState.swift
+++ b/Sources/LiveKit/Types/TrackStreamState.swift
@@ -16,7 +16,7 @@
 
 import WebRTC
 
-public enum StreamState {
+@objc public enum StreamState: Int {
     case paused
     case active
 }

--- a/Sources/LiveKit/Types/VideoEncoding.swift
+++ b/Sources/LiveKit/Types/VideoEncoding.swift
@@ -17,7 +17,8 @@
 import Foundation
 import WebRTC
 
-@objc public class VideoEncoding: NSObject {
+@objc
+public class VideoEncoding: NSObject {
 
     public static func == (lhs: VideoEncoding, rhs: VideoEncoding) -> Bool {
         // TODO: Implement

--- a/Sources/LiveKit/Types/VideoEncoding.swift
+++ b/Sources/LiveKit/Types/VideoEncoding.swift
@@ -25,9 +25,13 @@ public class VideoEncoding: NSObject {
         fatalError("Not implemented")
     }
 
+    @objc
     public var maxBitrate: Int
+
+    @objc
     public var maxFps: Int
 
+    @objc
     public init(maxBitrate: Int, maxFps: Int) {
         self.maxBitrate = maxBitrate
         self.maxFps = maxFps

--- a/Sources/LiveKit/Types/VideoEncoding.swift
+++ b/Sources/LiveKit/Types/VideoEncoding.swift
@@ -20,11 +20,6 @@ import WebRTC
 @objc
 public class VideoEncoding: NSObject {
 
-    public static func == (lhs: VideoEncoding, rhs: VideoEncoding) -> Bool {
-        // TODO: Implement
-        fatalError("Not implemented")
-    }
-
     @objc
     public var maxBitrate: Int
 
@@ -35,6 +30,21 @@ public class VideoEncoding: NSObject {
     public init(maxBitrate: Int, maxFps: Int) {
         self.maxBitrate = maxBitrate
         self.maxFps = maxFps
+    }
+
+    // MARK: - Equal
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return self.maxBitrate == other.maxBitrate &&
+            self.maxFps == other.maxFps
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(maxBitrate)
+        hasher.combine(maxFps)
+        return hasher.finalize()
     }
 }
 

--- a/Sources/LiveKit/Types/VideoEncoding.swift
+++ b/Sources/LiveKit/Types/VideoEncoding.swift
@@ -17,7 +17,13 @@
 import Foundation
 import WebRTC
 
-public struct VideoEncoding: Equatable {
+@objc public class VideoEncoding: NSObject {
+
+    public static func == (lhs: VideoEncoding, rhs: VideoEncoding) -> Bool {
+        // TODO: Implement
+        fatalError("Not implemented")
+    }
+
     public var maxBitrate: Int
     public var maxFps: Int
 

--- a/Sources/LiveKit/Types/VideoParameters.swift
+++ b/Sources/LiveKit/Types/VideoParameters.swift
@@ -43,7 +43,8 @@ extension Collection where Element == VideoParameters {
     }
 }
 
-@objc public class VideoParameters: NSObject {
+@objc
+public class VideoParameters: NSObject {
 
     public static func == (lhs: VideoParameters, rhs: VideoParameters) -> Bool {
         lhs.dimensions == rhs.dimensions &&

--- a/Sources/LiveKit/Types/VideoParameters.swift
+++ b/Sources/LiveKit/Types/VideoParameters.swift
@@ -43,7 +43,12 @@ extension Collection where Element == VideoParameters {
     }
 }
 
-public struct VideoParameters: Equatable {
+@objc public class VideoParameters: NSObject {
+
+    public static func == (lhs: VideoParameters, rhs: VideoParameters) -> Bool {
+        lhs.dimensions == rhs.dimensions &&
+            lhs.encoding == rhs.encoding
+    }
 
     public let dimensions: Dimensions
     public let encoding: VideoEncoding
@@ -265,11 +270,6 @@ extension VideoParameters: Comparable {
         }
 
         return lhs.dimensions.area < rhs.dimensions.area
-    }
-
-    public static func == (lhs: VideoParameters, rhs: VideoParameters) -> Bool {
-        lhs.dimensions == rhs.dimensions &&
-            lhs.encoding == rhs.encoding
     }
 }
 

--- a/Sources/LiveKit/Types/VideoParameters.swift
+++ b/Sources/LiveKit/Types/VideoParameters.swift
@@ -46,11 +46,6 @@ extension Collection where Element == VideoParameters {
 @objc
 public class VideoParameters: NSObject {
 
-    public static func == (lhs: VideoParameters, rhs: VideoParameters) -> Bool {
-        lhs.dimensions == rhs.dimensions &&
-            lhs.encoding == rhs.encoding
-    }
-
     @objc
     public let dimensions: Dimensions
 
@@ -61,6 +56,21 @@ public class VideoParameters: NSObject {
     public init(dimensions: Dimensions, encoding: VideoEncoding) {
         self.dimensions = dimensions
         self.encoding = encoding
+    }
+
+    // MARK: - Equal
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return self.dimensions == other.dimensions &&
+            self.encoding == other.encoding
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(dimensions)
+        hasher.combine(encoding)
+        return hasher.finalize()
     }
 }
 

--- a/Sources/LiveKit/Types/VideoParameters.swift
+++ b/Sources/LiveKit/Types/VideoParameters.swift
@@ -51,9 +51,13 @@ public class VideoParameters: NSObject {
             lhs.encoding == rhs.encoding
     }
 
+    @objc
     public let dimensions: Dimensions
+
+    @objc
     public let encoding: VideoEncoding
 
+    @objc
     public init(dimensions: Dimensions, encoding: VideoEncoding) {
         self.dimensions = dimensions
         self.encoding = encoding
@@ -96,9 +100,10 @@ internal extension VideoParameters {
 
 // MARK: - Presets
 
-public extension VideoParameters {
+@objc
+extension VideoParameters {
 
-    static let presets43 = [
+    internal static let presets43 = [
         presetH120_43,
         presetH180_43,
         presetH240_43,
@@ -110,7 +115,7 @@ public extension VideoParameters {
         presetH1440_43
     ]
 
-    static let presets169 = [
+    internal static let presets169 = [
         presetH90_169,
         presetH180_169,
         presetH216_169,
@@ -122,7 +127,7 @@ public extension VideoParameters {
         presetH2160_169
     ]
 
-    static let presetsScreenShare = [
+    internal static let presetsScreenShare = [
         presetScreenShareH360FPS3,
         presetScreenShareH720FPS5,
         presetScreenShareH720FPS15,
@@ -130,133 +135,130 @@ public extension VideoParameters {
         presetScreenShareH1080FPS30
     ]
 
-    static let defaultSimulcastPresets169 = [
+    internal static let defaultSimulcastPresets169 = [
         presetH180_169,
         presetH360_169
     ]
 
-    static let defaultSimulcastPresets43 = [
+    internal static let defaultSimulcastPresets43 = [
         presetH180_43,
         presetH360_43
     ]
 
     // 16:9 aspect ratio
-
-    static let presetH90_169 = VideoParameters(
+    public static let presetH90_169 = VideoParameters(
         dimensions: .h90_169,
         encoding: VideoEncoding(maxBitrate: 60_000, maxFps: 15)
     )
 
-    static let presetH180_169 = VideoParameters(
+    public static let presetH180_169 = VideoParameters(
         dimensions: .h180_169,
         encoding: VideoEncoding(maxBitrate: 120_000, maxFps: 15)
     )
 
-    static let presetH216_169 = VideoParameters(
+    public static let presetH216_169 = VideoParameters(
         dimensions: .h216_169,
         encoding: VideoEncoding(maxBitrate: 180_000, maxFps: 15)
     )
 
-    static let presetH360_169 = VideoParameters(
+    public static let presetH360_169 = VideoParameters(
         dimensions: .h360_169,
         encoding: VideoEncoding(maxBitrate: 300_000, maxFps: 20)
     )
 
-    static let presetH540_169 = VideoParameters(
+    public static let presetH540_169 = VideoParameters(
         dimensions: .h540_169,
         encoding: VideoEncoding(maxBitrate: 600_000, maxFps: 25)
     )
 
-    static let presetH720_169 = VideoParameters(
+    public static let presetH720_169 = VideoParameters(
         dimensions: .h720_169,
         encoding: VideoEncoding(maxBitrate: 2_000_000, maxFps: 30)
     )
 
-    static let presetH1080_169 = VideoParameters(
+    public static let presetH1080_169 = VideoParameters(
         dimensions: .h1080_169,
         encoding: VideoEncoding(maxBitrate: 3_000_000, maxFps: 30)
     )
 
-    static let presetH1440_169 = VideoParameters(
+    public static let presetH1440_169 = VideoParameters(
         dimensions: .h1440_169,
         encoding: VideoEncoding(maxBitrate: 5_000_000, maxFps: 30)
     )
 
-    static let presetH2160_169 = VideoParameters(
+    public static let presetH2160_169 = VideoParameters(
         dimensions: .h2160_169,
         encoding: VideoEncoding(maxBitrate: 8_000_000, maxFps: 30)
     )
 
     // 4:3 aspect ratio
-
-    static let presetH120_43 = VideoParameters(
+    public static let presetH120_43 = VideoParameters(
         dimensions: .h120_43,
         encoding: VideoEncoding(maxBitrate: 80_000, maxFps: 15)
     )
 
-    static let presetH180_43 = VideoParameters(
+    public static let presetH180_43 = VideoParameters(
         dimensions: .h180_43,
         encoding: VideoEncoding(maxBitrate: 100_000, maxFps: 15)
     )
 
-    static let presetH240_43 = VideoParameters(
+    public static let presetH240_43 = VideoParameters(
         dimensions: .h240_43,
         encoding: VideoEncoding(maxBitrate: 150_000, maxFps: 15)
     )
 
-    static let presetH360_43 = VideoParameters(
+    public static let presetH360_43 = VideoParameters(
         dimensions: .h360_43,
         encoding: VideoEncoding(maxBitrate: 225_000, maxFps: 20)
     )
 
-    static let presetH480_43 = VideoParameters(
+    public static let presetH480_43 = VideoParameters(
         dimensions: .h480_43,
         encoding: VideoEncoding(maxBitrate: 300_000, maxFps: 20)
     )
 
-    static let presetH540_43 = VideoParameters(
+    public static let presetH540_43 = VideoParameters(
         dimensions: .h540_43,
         encoding: VideoEncoding(maxBitrate: 450_000, maxFps: 25)
     )
 
-    static let presetH720_43 = VideoParameters(
+    public static let presetH720_43 = VideoParameters(
         dimensions: .h720_43,
         encoding: VideoEncoding(maxBitrate: 1_500_000, maxFps: 30)
     )
 
-    static let presetH1080_43 = VideoParameters(
+    public static let presetH1080_43 = VideoParameters(
         dimensions: .h1080_43,
         encoding: VideoEncoding(maxBitrate: 2_500_000, maxFps: 30)
     )
 
-    static let presetH1440_43 = VideoParameters(
+    public static let presetH1440_43 = VideoParameters(
         dimensions: .h1440_43,
         encoding: VideoEncoding(maxBitrate: 3_500_000, maxFps: 30)
     )
 
     // Screen share
-
-    static let presetScreenShareH360FPS3 = VideoParameters(
+    public static let presetScreenShareH360FPS3 = VideoParameters(
         dimensions: .h360_169,
         encoding: VideoEncoding(maxBitrate: 200_000, maxFps: 3)
     )
 
-    static let presetScreenShareH720FPS5 = VideoParameters(
+    public static let presetScreenShareH720FPS5 = VideoParameters(
         dimensions: .h720_169,
         encoding: VideoEncoding(maxBitrate: 400_000, maxFps: 5)
     )
 
-    static let presetScreenShareH720FPS15 = VideoParameters(
+    public static let presetScreenShareH720FPS15 = VideoParameters(
         dimensions: .h720_169,
         encoding: VideoEncoding(maxBitrate: 1_000_000, maxFps: 15)
     )
 
-    static let presetScreenShareH1080FPS15 = VideoParameters(
+    public static let presetScreenShareH1080FPS15 = VideoParameters(
         dimensions: .h1080_169,
         encoding: VideoEncoding(maxBitrate: 1_500_000, maxFps: 15)
     )
 
-    static let presetScreenShareH1080FPS30 = VideoParameters(
+    public static let presetScreenShareH1080FPS30 = VideoParameters(
         dimensions: .h1080_169,
         encoding: VideoEncoding(maxBitrate: 3_000_000, maxFps: 30)
     )

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -21,7 +21,8 @@ import MetalKit
 /// A ``NativeViewType`` that conforms to ``RTCVideoRenderer``.
 public typealias NativeRendererView = NativeViewType & RTCVideoRenderer
 
-@objc public class VideoView: NativeView, MulticastDelegateCapable, Loggable {
+@objc
+public class VideoView: NativeView, MulticastDelegateCapable, Loggable {
 
     // MARK: - Static
 
@@ -34,14 +35,16 @@ public typealias NativeRendererView = NativeViewType & RTCVideoRenderer
     public var delegates = MulticastDelegate<DelegateType>()
 
     /// Specifies how to render the video withing the ``VideoView``'s bounds.
-    @objc public enum LayoutMode: Int, Codable {
+    @objc
+    public enum LayoutMode: Int, Codable {
         /// Video will be fully visible within the ``VideoView``.
         case fit
         /// Video will fully cover up the ``VideoView``.
         case fill
     }
 
-    @objc public enum MirrorMode: Int, Codable {
+    @objc
+    public enum MirrorMode: Int, Codable {
         /// Will mirror if the track is a front facing camera track.
         case auto
         case off
@@ -49,13 +52,15 @@ public typealias NativeRendererView = NativeViewType & RTCVideoRenderer
     }
 
     /// ``LayoutMode-swift.enum`` of the ``VideoView``.
-    @objc public var layoutMode: LayoutMode {
+    @objc
+    public var layoutMode: LayoutMode {
         get { _state.layoutMode }
         set { _state.mutate { $0.layoutMode = newValue } }
     }
 
     /// Flips the video horizontally, useful for local VideoViews.
-    @objc public var mirrorMode: MirrorMode {
+    @objc
+    public var mirrorMode: MirrorMode {
         get { _state.mirrorMode }
         set { _state.mutate { $0.mirrorMode = newValue } }
     }
@@ -86,12 +91,14 @@ public typealias NativeRendererView = NativeViewType & RTCVideoRenderer
     }
 
     /// If set to false, rendering will be paused temporarily. Useful for performance optimizations with UICollectionViewCell etc.
-    @objc public var isEnabled: Bool {
+    @objc
+    public var isEnabled: Bool {
         get { _state.isEnabled }
         set { _state.mutate { $0.isEnabled = newValue } }
     }
 
-    @objc public override var isHidden: Bool {
+    @objc
+    public override var isHidden: Bool {
         get { _state.isHidden }
         set {
             _state.mutate { $0.isHidden = newValue }
@@ -99,13 +106,17 @@ public typealias NativeRendererView = NativeViewType & RTCVideoRenderer
         }
     }
 
-    @objc public var debugMode: Bool {
+    @objc
+    public var debugMode: Bool {
         get { _state.debugMode }
         set { _state.mutate { $0.debugMode = newValue } }
     }
 
-    @objc public var isRendering: Bool { _state.isRendering }
-    @objc public var didRenderFirstFrame: Bool { _state.didRenderFirstFrame }
+    @objc
+    public var isRendering: Bool { _state.isRendering }
+
+    @objc
+    public var didRenderFirstFrame: Bool { _state.didRenderFirstFrame }
 
     // MARK: - Internal
 

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -22,7 +22,7 @@ import MetalKit
 public typealias NativeRendererView = NativeViewType & RTCVideoRenderer
 
 @objc
-public class VideoView: NativeView, MulticastDelegateCapable, Loggable {
+public class VideoView: NativeView, Loggable {
 
     // MARK: - Static
 
@@ -31,8 +31,7 @@ public class VideoView: NativeView, MulticastDelegateCapable, Loggable {
 
     // MARK: - MulticastDelegate
 
-    public typealias DelegateType = VideoViewDelegate
-    public var delegates = MulticastDelegate<DelegateType>()
+    private var delegates = MulticastDelegate<VideoViewDelegate>()
 
     /// Specifies how to render the video withing the ``VideoView``'s bounds.
     @objc
@@ -245,14 +244,14 @@ public class VideoView: NativeView, MulticastDelegateCapable, Loggable {
                 }
 
                 self.notify(label: { "videoView.didUpdate isRendering: \(state.isRendering)" }) {
-                    $0.videoView(self, didUpdate: state.isRendering)
+                    $0.videoView?(self, didUpdate: state.isRendering)
                 }
             }
 
             // viewSize updated
             if state.viewSize != oldState.viewSize {
                 self.notify(label: { "videoView.didUpdate viewSize: \(state.viewSize)" }) {
-                    $0.videoView(self, didUpdate: state.viewSize)
+                    $0.videoView?(self, didUpdate: state.viewSize)
                 }
             }
 
@@ -573,6 +572,26 @@ internal extension VideoView {
         guard let track1 = track1, let track2 = track2 else { return false }
         // use isEqual
         return track1.isEqual(track2)
+    }
+}
+
+// MARK: - MulticastDelegate
+
+extension VideoView {
+
+    @objc(addDelegate:)
+    public func add(delegate: VideoViewDelegate) {
+        delegates.add(delegate: delegate)
+    }
+
+    @objc(removeDelegate:)
+    public func remove(delegate: VideoViewDelegate) {
+        delegates.remove(delegate: delegate)
+    }
+
+    internal func notify(label: (() -> String)? = nil,
+                         _ fnc: @escaping (VideoViewDelegate) -> Void) {
+        delegates.notify(label: label, fnc)
     }
 }
 

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -34,14 +34,14 @@ public typealias NativeRendererView = NativeViewType & RTCVideoRenderer
     public var delegates = MulticastDelegate<DelegateType>()
 
     /// Specifies how to render the video withing the ``VideoView``'s bounds.
-    @objc public enum LayoutMode: Int {
+    @objc public enum LayoutMode: Int, Codable {
         /// Video will be fully visible within the ``VideoView``.
         case fit
         /// Video will fully cover up the ``VideoView``.
         case fill
     }
 
-    @objc public enum MirrorMode: Int {
+    @objc public enum MirrorMode: Int, Codable {
         /// Will mirror if the track is a front facing camera track.
         case auto
         case off
@@ -189,7 +189,7 @@ public typealias NativeRendererView = NativeViewType & RTCVideoRenderer
                         // notify detach
                         track.notify(label: { "track.didDetach videoView: \(self)" }) { [weak self, weak track] (delegate) -> Void in
                             guard let self = self, let track = track else { return }
-                            delegate.track(track, didDetach: self)
+                            delegate.track?(track, didDetach: self)
                         }
                     }
 
@@ -215,7 +215,7 @@ public typealias NativeRendererView = NativeViewType & RTCVideoRenderer
                         // notify attach
                         track.notify(label: { "track.didAttach videoView: \(self)" }) { [weak self, weak track] (delegate) -> Void in
                             guard let self = self, let track = track else { return }
-                            delegate.track(track, didAttach: self)
+                            delegate.track?(track, didAttach: self)
                         }
                     }
                 }

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -28,7 +28,7 @@ public typealias NativeRendererView = NativeViewType & RTCVideoRenderer
     private static let mirrorTransform = CATransform3DMakeScale(-1.0, 1.0, 1.0)
     private static let _freezeDetectThreshold = 2.0
 
-    // MARK: - Public
+    // MARK: - MulticastDelegate
 
     public typealias DelegateType = VideoViewDelegate
     public var delegates = MulticastDelegate<DelegateType>()

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -68,6 +68,7 @@ public typealias NativeRendererView = NativeViewType & RTCVideoRenderer
     }
 
     /// Calls addRenderer and/or removeRenderer internally for convenience.
+    @objc
     public weak var track: VideoTrack? {
         get { _state.track }
         set {

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -21,7 +21,7 @@ import MetalKit
 /// A ``NativeViewType`` that conforms to ``RTCVideoRenderer``.
 public typealias NativeRendererView = NativeViewType & RTCVideoRenderer
 
-public class VideoView: NativeView, MulticastDelegateCapable, Loggable {
+@objc public class VideoView: NativeView, MulticastDelegateCapable, Loggable {
 
     // MARK: - Static
 
@@ -34,14 +34,14 @@ public class VideoView: NativeView, MulticastDelegateCapable, Loggable {
     public var delegates = MulticastDelegate<DelegateType>()
 
     /// Specifies how to render the video withing the ``VideoView``'s bounds.
-    public enum LayoutMode: String, Codable, CaseIterable {
+    @objc public enum LayoutMode: Int {
         /// Video will be fully visible within the ``VideoView``.
         case fit
         /// Video will fully cover up the ``VideoView``.
         case fill
     }
 
-    public enum MirrorMode: String, Codable, CaseIterable {
+    @objc public enum MirrorMode: Int {
         /// Will mirror if the track is a front facing camera track.
         case auto
         case off
@@ -49,13 +49,13 @@ public class VideoView: NativeView, MulticastDelegateCapable, Loggable {
     }
 
     /// ``LayoutMode-swift.enum`` of the ``VideoView``.
-    public var layoutMode: LayoutMode {
+    @objc public var layoutMode: LayoutMode {
         get { _state.layoutMode }
         set { _state.mutate { $0.layoutMode = newValue } }
     }
 
     /// Flips the video horizontally, useful for local VideoViews.
-    public var mirrorMode: MirrorMode {
+    @objc public var mirrorMode: MirrorMode {
         get { _state.mirrorMode }
         set { _state.mutate { $0.mirrorMode = newValue } }
     }
@@ -85,12 +85,12 @@ public class VideoView: NativeView, MulticastDelegateCapable, Loggable {
     }
 
     /// If set to false, rendering will be paused temporarily. Useful for performance optimizations with UICollectionViewCell etc.
-    public var isEnabled: Bool {
+    @objc public var isEnabled: Bool {
         get { _state.isEnabled }
         set { _state.mutate { $0.isEnabled = newValue } }
     }
 
-    public override var isHidden: Bool {
+    @objc public override var isHidden: Bool {
         get { _state.isHidden }
         set {
             _state.mutate { $0.isHidden = newValue }
@@ -98,13 +98,13 @@ public class VideoView: NativeView, MulticastDelegateCapable, Loggable {
         }
     }
 
-    public var debugMode: Bool {
+    @objc public var debugMode: Bool {
         get { _state.debugMode }
         set { _state.mutate { $0.debugMode = newValue } }
     }
 
-    public var isRendering: Bool { _state.isRendering }
-    public var didRenderFirstFrame: Bool { _state.didRenderFirstFrame }
+    @objc public var isRendering: Bool { _state.isRendering }
+    @objc public var didRenderFirstFrame: Bool { _state.didRenderFirstFrame }
 
     // MARK: - Internal
 


### PR DESCRIPTION
Following Swift features are not support and needs re-write :
- enums with associated values
- structs
- optional values of primitive types
- Inheriting generic classes

### TODO
- [x] Make sure all ObjC method / protocol signatures looks correct
- [x] ObjC Helper for all Promises
- [x] Override `isEqual`