### PR TITLE
Fix random crash with Utils.modelIdentifier()

### DIFF
--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -76,11 +76,10 @@ internal class Utils {
             return nil
         }
 
-        guard let cString = modelData.withUnsafeBytes({ $0.baseAddress?.assumingMemoryBound(to: UInt8.self) }) else {
-            return nil
-        }
-
-        return String(cString: cString)
+        return modelData.withUnsafeBytes({ (pointer: UnsafeRawBufferPointer) -> String? in
+            guard let cString = pointer.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return nil }
+            return String(cString: cString)
+        })
         #elseif os(iOS)
         var systemInfo = utsname()
         uname(&systemInfo)


### PR DESCRIPTION
Tracked down random(rare) crash when connecting.