### PR TITLE
Reduce capturer's default FPS

### DIFF
--- a/Sources/LiveKit/Types/Options/CaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/CaptureOptions.swift
@@ -67,7 +67,7 @@ public struct ScreenShareCaptureOptions: VideoCaptureOptions, Equatable {
     public let useBroadcastExtension: Bool
 
     public init(dimensions: Dimensions = .h1080_169,
-                fps: Int = 30,
+                fps: Int = 15,
                 useBroadcastExtension: Bool = false
     ) {
         self.dimensions = dimensions
@@ -82,7 +82,7 @@ public struct BufferCaptureOptions: VideoCaptureOptions, Equatable {
     public let fps: Int
 
     public init(dimensions: Dimensions = .h1080_169,
-                fps: Int = 30) {
+                fps: Int = 15) {
         self.dimensions = dimensions
         self.fps = fps
     }


### PR DESCRIPTION
Capturers are generating more frames than consumed by WebRTC, lowering default to lower resource usage.