### PR TITLE
hq audio: pass (max avg) audiobitrate to sfu

### DIFF
--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -119,6 +119,7 @@ public class LocalParticipant: Participant {
                     // additional params for Audio
                     let publishOptions = (publishOptions as? AudioPublishOptions) ?? self.room._state.options.defaultAudioPublishOptions
                     populator.disableDtx = !publishOptions.dtx
+                    populator.bitrate = publishOptions.bitrate
                 }
 
                 return transInit

--- a/Sources/LiveKit/Protos/livekit_models.pb.swift
+++ b/Sources/LiveKit/Protos/livekit_models.pb.swift
@@ -546,6 +546,8 @@ struct Livekit_TrackInfo {
   /// true if RED (Redundant Encoding) is disabled for audio
   var disableRed: Bool = false
 
+  var bitrate: UInt32 = 0
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -1660,6 +1662,7 @@ extension Livekit_TrackInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
     13: .same(proto: "codecs"),
     14: .same(proto: "stereo"),
     15: .standard(proto: "disable_red"),
+    16: .standard(proto: "bitrate"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1683,6 +1686,7 @@ extension Livekit_TrackInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
       case 13: try { try decoder.decodeRepeatedMessageField(value: &self.codecs) }()
       case 14: try { try decoder.decodeSingularBoolField(value: &self.stereo) }()
       case 15: try { try decoder.decodeSingularBoolField(value: &self.disableRed) }()
+      case 16: try { try decoder.decodeSingularUInt32Field(value: &self.bitrate) }()
       default: break
       }
     }
@@ -1734,6 +1738,10 @@ extension Livekit_TrackInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
     if self.disableRed != false {
       try visitor.visitSingularBoolField(value: self.disableRed, fieldNumber: 15)
     }
+    if self.bitrate != 0 {
+      try visitor.visitSingularUInt32Field(value: self.bitrate, fieldNumber: 16)
+    }
+      
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1753,6 +1761,7 @@ extension Livekit_TrackInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
     if lhs.codecs != rhs.codecs {return false}
     if lhs.stereo != rhs.stereo {return false}
     if lhs.disableRed != rhs.disableRed {return false}
+    if lhs.bitrate != rhs.bitrate {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/LiveKit/Protos/livekit_rtc.pb.swift
+++ b/Sources/LiveKit/Protos/livekit_rtc.pb.swift
@@ -701,6 +701,8 @@ struct Livekit_AddTrackRequest {
   /// true if RED (Redundant Encoding) is disabled for audio
   var disableRed: Bool = false
 
+  var bitrate: UInt32 = 0
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -2043,6 +2045,7 @@ extension Livekit_AddTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._Message
     11: .same(proto: "sid"),
     12: .same(proto: "stereo"),
     13: .standard(proto: "disable_red"),
+    14: .standard(proto: "bitrate"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -2064,6 +2067,7 @@ extension Livekit_AddTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._Message
       case 11: try { try decoder.decodeSingularStringField(value: &self.sid) }()
       case 12: try { try decoder.decodeSingularBoolField(value: &self.stereo) }()
       case 13: try { try decoder.decodeSingularBoolField(value: &self.disableRed) }()
+      case 14: try { try decoder.decodeSingularUInt32Field(value: &self.bitrate) }()
       default: break
       }
     }
@@ -2109,6 +2113,9 @@ extension Livekit_AddTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._Message
     if self.disableRed != false {
       try visitor.visitSingularBoolField(value: self.disableRed, fieldNumber: 13)
     }
+    if self.bitrate != 0 {
+      try visitor.visitSingularUInt32Field(value: self.bitrate, fieldNumber: 14)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -2126,6 +2133,7 @@ extension Livekit_AddTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._Message
     if lhs.sid != rhs.sid {return false}
     if lhs.stereo != rhs.stereo {return false}
     if lhs.disableRed != rhs.disableRed {return false}
+    if lhs.bitrate != rhs.bitrate {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/LiveKit/Types/Options/PublishOptions.swift
+++ b/Sources/LiveKit/Types/Options/PublishOptions.swift
@@ -90,13 +90,13 @@ public class AudioPublishOptions: NSObject, PublishOptions {
     @objc
     public let name: String?
 
-    public let bitrate: Int?
+    public let bitrate: UInt32
 
     @objc
     public let dtx: Bool
 
     public init(name: String? = nil,
-                bitrate: Int? = nil,
+                bitrate: UInt32 = 0,
                 dtx: Bool = true) {
 
         self.name = name


### PR DESCRIPTION
Per the Opus spec if maxaveragebitrate is not specified in the SDP the max value (510kbps) will be used - however, WebRTC has its own default that caps bitrates to around 32kbps, unless maxaveragebitrate is provided.

There are several PRs needed for this: the client sdks to pass any non-default audio bitrate settings, and server-side to actually set maxaveragebitrate when provided by the sender.

Tested by streaming a stereo track (using BlackHole as virtual input device) from the macOS app, via the go sfu server, to the client-sdk-js sample app in-browser, which conveniently shows bitrate stats for audio-only tracks. I noticed it is always limited to around 50kbps without these changes, but will now go as high as 350+ kbps (and noticeably better quality).

In the swift sdk, bitrate was already intended to be passed in RoomOptions, but the client library neglects to pass it along.

```
            defaultAudioPublishOptions: AudioPublishOptions(
              bitrate: 510_000,
              dtx: true
            ),
```

The previously unused bitrate attribute was an Int, I've changed it to be a UInt32 for consistency with other protobuf fields 

I have end-to-end tested this but it needs the other PRs merging (https://github.com/livekit/livekit/pull/1179) for the higher bit rates to actually kick in.

