### PR TITLE
Set sender maxBitrateBps when publishing audio tracks

### DIFF
--- a/Sources/LiveKit/Core/Engine.swift
+++ b/Sources/LiveKit/Core/Engine.swift
@@ -906,19 +906,26 @@ internal extension Engine {
     }
 
     static func createRtpEncodingParameters(rid: String? = nil,
-                                            encoding: VideoEncoding? = nil,
-                                            scaleDown: Double = 1.0,
+                                            encoding: MediaEncoding? = nil,
+                                            scaleDownBy: Double? = nil,
                                             active: Bool = true) -> RTCRtpEncodingParameters {
 
         let result = DispatchQueue.webRTC.sync { RTCRtpEncodingParameters() }
 
         result.isActive = active
         result.rid = rid
-        result.scaleResolutionDownBy = NSNumber(value: scaleDown)
+
+        if let scaleDownBy = scaleDownBy {
+            result.scaleResolutionDownBy = NSNumber(value: scaleDownBy)
+        }
 
         if let encoding = encoding {
-            result.maxFramerate = NSNumber(value: encoding.maxFps)
             result.maxBitrateBps = NSNumber(value: encoding.maxBitrate)
+
+            // VideoEncoding specific
+            if let videoEncoding = encoding as? VideoEncoding {
+                result.maxFramerate = NSNumber(value: videoEncoding.maxFps)
+            }
         }
 
         return result

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -118,7 +118,16 @@ public class LocalParticipant: Participant {
                 } else if track is LocalAudioTrack {
                     // additional params for Audio
                     let publishOptions = (publishOptions as? AudioPublishOptions) ?? self.room._state.options.defaultAudioPublishOptions
+
                     populator.disableDtx = !publishOptions.dtx
+
+                    let encoding = publishOptions.encoding ?? AudioEncoding.presetSpeech
+
+                    self.log("[publish] maxBitrate: \(encoding.maxBitrate)")
+
+                    transInit.sendEncodings = [
+                        Engine.createRtpEncodingParameters(encoding: encoding)
+                    ]
                 }
 
                 return transInit

--- a/Sources/LiveKit/Protocols/MediaEncoding.swift
+++ b/Sources/LiveKit/Protocols/MediaEncoding.swift
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import WebRTC
+
+@objc
+public protocol MediaEncoding {
+    //
+    var maxBitrate: Int { get }
+}

--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -207,7 +207,7 @@ internal class Utils {
         let encoding = preferredEncoding ?? dimensions.computeSuggestedPreset(in: dimensions.computeSuggestedPresets(isScreenShare: isScreenShare))
 
         guard publishOptions.simulcast else {
-            return [Engine.createRtpEncodingParameters(encoding: encoding)]
+            return [Engine.createRtpEncodingParameters(encoding: encoding, scaleDownBy: 1)]
         }
 
         let baseParameters = VideoParameters(dimensions: dimensions,

--- a/Sources/LiveKit/Types/AudioEncoding.swift
+++ b/Sources/LiveKit/Types/AudioEncoding.swift
@@ -18,44 +18,55 @@ import Foundation
 import WebRTC
 
 @objc
-public class VideoEncoding: NSObject, MediaEncoding {
+public class AudioEncoding: NSObject, MediaEncoding {
 
     @objc
     public var maxBitrate: Int
 
     @objc
-    public var maxFps: Int
-
-    @objc
-    public init(maxBitrate: Int, maxFps: Int) {
+    public init(maxBitrate: Int) {
         self.maxBitrate = maxBitrate
-        self.maxFps = maxFps
     }
 
     // MARK: - Equal
 
     public override func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? Self else { return false }
-        return self.maxBitrate == other.maxBitrate &&
-            self.maxFps == other.maxFps
+        return self.maxBitrate == other.maxBitrate
     }
 
     public override var hash: Int {
         var hasher = Hasher()
         hasher.combine(maxBitrate)
-        hasher.combine(maxFps)
         return hasher.finalize()
     }
 }
 
-extension VideoEncoding: Comparable {
+extension AudioEncoding: Comparable {
 
-    public static func < (lhs: VideoEncoding, rhs: VideoEncoding) -> Bool {
-
-        if lhs.maxBitrate == rhs.maxBitrate {
-            return lhs.maxFps < rhs.maxFps
-        }
-
-        return lhs.maxBitrate < rhs.maxBitrate
+    public static func < (lhs: AudioEncoding, rhs: AudioEncoding) -> Bool {
+        lhs.maxBitrate < rhs.maxBitrate
     }
+}
+
+// MARK: - Presets
+
+@objc
+extension AudioEncoding {
+
+    internal static let presets = [
+        presetTelephone,
+        presetSpeech,
+        presetMusic,
+        presetMusicStereo,
+        presetMusicHighQuality,
+        presetMusicHighQualityStereo
+    ]
+
+    public static let presetTelephone = AudioEncoding(maxBitrate: 12_000)
+    public static let presetSpeech = AudioEncoding(maxBitrate: 20_000)
+    public static let presetMusic = AudioEncoding(maxBitrate: 32_000)
+    public static let presetMusicStereo = AudioEncoding(maxBitrate: 48_000)
+    public static let presetMusicHighQuality = AudioEncoding(maxBitrate: 64_000)
+    public static let presetMusicHighQualityStereo = AudioEncoding(maxBitrate: 96_000)
 }

--- a/Sources/LiveKit/Types/Dimensions.swift
+++ b/Sources/LiveKit/Types/Dimensions.swift
@@ -143,7 +143,7 @@ extension Dimensions {
             let parameters = Engine.createRtpEncodingParameters(
                 rid: rid,
                 encoding: preset.encoding,
-                scaleDown: Double(max) / Double(preset.dimensions.max)
+                scaleDownBy: Double(max) / Double(preset.dimensions.max)
             )
 
             result.append(parameters)

--- a/Sources/LiveKit/Types/Options/PublishOptions.swift
+++ b/Sources/LiveKit/Types/Options/PublishOptions.swift
@@ -90,17 +90,19 @@ public class AudioPublishOptions: NSObject, PublishOptions {
     @objc
     public let name: String?
 
-    public let bitrate: Int?
+    /// preferred encoding parameters
+    @objc
+    public let encoding: AudioEncoding?
 
     @objc
     public let dtx: Bool
 
     public init(name: String? = nil,
-                bitrate: Int? = nil,
+                encoding: AudioEncoding? = nil,
                 dtx: Bool = true) {
 
         self.name = name
-        self.bitrate = bitrate
+        self.encoding = encoding
         self.dtx = dtx
     }
 
@@ -109,14 +111,14 @@ public class AudioPublishOptions: NSObject, PublishOptions {
     public override func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? Self else { return false }
         return self.name == other.name &&
-            self.bitrate == other.bitrate &&
+            self.encoding == other.encoding &&
             self.dtx == other.dtx
     }
 
     public override var hash: Int {
         var hasher = Hasher()
         hasher.combine(name)
-        hasher.combine(bitrate)
+        hasher.combine(encoding)
         hasher.combine(dtx)
         return hasher.finalize()
     }


### PR DESCRIPTION
From the JS SDK:

- Set sender encoding (`maxBitrateBps`) for audio tracks.
- Include missing audio presets.
