### PR TITLE
Fixed Xcode 13 compilation by helping the compiler

### DIFF
--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -108,10 +108,11 @@ internal class DataChannelPair: NSObject, Loggable {
         let serializedData = try packet.serializedData()
         let rtcData = Engine.createDataBuffer(data: serializedData)
 
-        let result = { switch reliability {
-        case .reliable: return reliableChannel.sendData(rtcData)
-        case .lossy: return lossyChannel.sendData(rtcData)
-        }
+        let result = { () -> Bool in
+            switch reliability {
+                case .reliable: return reliableChannel.sendData(rtcData)
+                case .lossy: return lossyChannel.sendData(rtcData)
+            }
         }()
 
         guard result else {

--- a/Sources/LiveKit/Core/Engine.swift
+++ b/Sources/LiveKit/Core/Engine.swift
@@ -254,7 +254,7 @@ internal class Engine: MulticastDelegate<EngineDelegate> {
                                                              throw: { TransportError.timedOut(message: "publisher didn't connect") })
             }
 
-            return publisherConnectCompleter.then {
+            return publisherConnectCompleter.then { () -> Promise<Void> in
                 self.log("send data: publisher connected...")
                 // wait for publisherDC to open
                 return self.publisherDC.openCompleter


### PR DESCRIPTION
## Issue

Compiling with Xcode 13 fails with the following errors:
```
./client-sdk-swift/Sources/LiveKit/Core/DataChannelPair.swift:111:22: error: cannot infer return type for closure with multiple statements; add explicit type to disambiguate
        let result = { switch reliability {
                     ^
                       () -> <#Result#> in 
```
```
client-sdk-swift/Sources/LiveKit/Core/Engine.swift:260:41: error: unexpected non-void return value in void function
                return self.publisherDC.openCompleter
                                        ^
```

## Solution
Help the compiler by adding explicit closure types.