### PR TITLE
Use NWPathMonitor

### DIFF
--- a/Sources/LiveKit/Core/Engine.swift
+++ b/Sources/LiveKit/Core/Engine.swift
@@ -847,6 +847,11 @@ internal extension Engine {
 
         RTCInitializeSSL()
 
+        logger.log("Initializing Field trials...", type: Engine.self)
+
+        let fieldTrials = [kRTCFieldTrialUseNWPathMonitor : kRTCFieldTrialEnabledValue]
+        RTCInitFieldTrialDictionary(fieldTrials)
+
         logger.log("Initializing PeerConnectionFactory...", type: Engine.self)
 
         #if LK_USING_CUSTOM_WEBRTC_BUILD


### PR DESCRIPTION
@davidliu :
> The dual sim phones not being able to connect turned out to be an iOS issue (context [here](https://livekit-users.slack.com/archives/C01KVTJH6BX/p1675880490424109?thread_ts=1674584023.271609&cid=C01KVTJH6BX)). There’s an open webrtc bug on it: https://bugs.chromium.org/p/webrtc/issues/detail?id=10966
> turns out that they implemented a fix as a field trial a long time ago, but still haven’t turned it on by default. tested with the community member, and sounds like it’s working with them. only thing needed to do to turn on the field trial is to simply call the following prior to initing the RTCPeerConnectionFactory.