### PR TITLE
Support for updating name and metadata of LocalParticipant

### DIFF
--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -355,6 +355,10 @@ private extension SignalClient {
             notify { $0.signalClient(self, didUpdate: token) }
         case .pong(let r):
             onReceivedPong(r)
+        case .reconnect:
+            log("received reconnect message")
+        case .pongResp:
+            log("received pongResp message")
         }
     }
 }
@@ -572,6 +576,20 @@ internal extension SignalClient {
             $0.subscriptionPermission = Livekit_SubscriptionPermission.with {
                 $0.allParticipants = allParticipants
                 $0.trackPermissions = trackPermissions.map({ $0.toPBType() })
+            }
+        }
+
+        return sendRequest(r)
+    }
+
+    func sendUpdateLocalMetadata(_ metadata: String, name: String) -> Promise<Void> {
+
+        log()
+
+        let r = Livekit_SignalRequest.with {
+            $0.updateMetadata = Livekit_UpdateParticipantMetadata.with {
+                $0.metadata = metadata
+                $0.name = name
             }
         }
 

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -318,6 +318,30 @@ public class LocalParticipant: Participant {
         return sendTrackSubscriptionPermissions()
     }
 
+    /// Sets and updates the metadata of the local participant.
+    ///
+    /// Note: this requires `CanUpdateOwnMetadata` permission encoded in the token.
+    public func set(metadata: String) -> Promise<Void> {
+        // mutate state to set metadata and copy name from state
+        let name = _state.mutate {
+            $0.metadata = metadata
+            return $0.name
+        }
+        return room.engine.signalClient.sendUpdateLocalMetadata(metadata, name: name)
+    }
+
+    /// Sets and updates the name of the local participant.
+    ///
+    /// Note: this requires `CanUpdateOwnMetadata` permission encoded in the token.
+    public func set(name: String) -> Promise<Void> {
+        // mutate state to set name and copy metadata from state
+        let metadata = _state.mutate {
+            $0.name = name
+            return $0.metadata
+        }
+        return room.engine.signalClient.sendUpdateLocalMetadata(metadata ?? "", name: name)
+    }
+
     internal func sendTrackSubscriptionPermissions() -> Promise<Void> {
 
         guard room.engine._state.connectionState == .connected else {

--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -128,6 +128,18 @@ public class Participant: NSObject, Loggable {
                 }
             }
 
+            // name updated
+            if state.name != oldState.name {
+                // notfy participant delegates
+                self.delegates.notify(label: { "participant.didUpdateName: \(state.name)" }) {
+                    $0.participant?(self, didUpdateName: state.name)
+                }
+                // notify room delegates
+                self.room.delegates.notify(label: { "room.didUpdateName: \(state.name)" }) {
+                    $0.room?(self.room, participant: self, didUpdateName: state.name)
+                }
+            }
+
             if state.connectionQuality != oldState.connectionQuality {
                 self.delegates.notify(label: { "participant.didUpdate connectionQuality: \(self.connectionQuality)" }) {
                     $0.participant?(self, didUpdate: self.connectionQuality)

--- a/Sources/LiveKit/Protocols/ParticipantDelegate.swift
+++ b/Sources/LiveKit/Protocols/ParticipantDelegate.swift
@@ -32,6 +32,11 @@ public protocol ParticipantDelegate: AnyObject {
     @objc(participant:didUpdateMetadata:) optional
     func participant(_ participant: Participant, didUpdate metadata: String?)
 
+    /// A ``Participant``'s name has updated.
+    /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.
+    @objc(participant:didUpdateName:) optional
+    func participant(_ participant: Participant, didUpdateName: String)
+
     /// The isSpeaking status of a ``Participant`` has changed.
     /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.
     @objc(participant:didUpdateSpeaking:) optional

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -77,6 +77,10 @@ public protocol RoomDelegateObjC: AnyObject {
     @objc(room:participant:didUpdateMetadata:) optional
     func room(_ room: Room, participant: Participant, didUpdate metadata: String?)
 
+    /// Same with ``ParticipantDelegate/participant(_:didUpdateName:)``.
+    @objc(room:participant:didUpdateName:) optional
+    func room(_ room: Room, participant: Participant, didUpdateName: String)
+
     /// Same with ``ParticipantDelegate/participant(_:didUpdate:)-7zxk1``.
     @objc(room:participant:didUpdateConnectionQuality:) optional
     func room(_ room: Room, participant: Participant, didUpdate connectionQuality: ConnectionQuality)


### PR DESCRIPTION
https://github.com/livekit/client-sdk-js/pull/599

Should we have a way to fail if `CanUpdateOwnMetadata` permission doesn't exist ?
