### PR TITLE
Remove hardcoded iceServers defaults

### DIFF
--- a/Sources/LiveKit/Extensions/RTCConfiguration.swift
+++ b/Sources/LiveKit/Extensions/RTCConfiguration.swift
@@ -19,9 +19,6 @@ import WebRTC
 
 extension RTCConfiguration {
 
-    public static let defaultIceServers = ["stun:stun.l.google.com:19302",
-                                           "stun:stun1.l.google.com:19302"]
-
     public static func liveKitDefault() -> RTCConfiguration {
 
         let result = DispatchQueue.webRTC.sync { RTCConfiguration() }
@@ -30,8 +27,6 @@ extension RTCConfiguration {
         result.candidateNetworkPolicy = .all
         result.tcpCandidatePolicy = .enabled
         result.iceTransportPolicy = .all
-
-        result.iceServers = [ DispatchQueue.webRTC.sync { RTCIceServer(urlStrings: defaultIceServers) } ]
 
         return result
     }


### PR DESCRIPTION
When the `iceServers` isn't empty, the transport configuration logic can't differentiate if it's user provided `iceServers` and doesn't use the server provided values.... 😞