### PR TITLE
Fix async version of `publish(data:)`

### DIFF
--- a/Sources/LiveKit/Participant/LocalParticipant+Async.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant+Async.swift
@@ -104,7 +104,7 @@ public extension LocalParticipant {
                  reliability: Reliability = .reliable,
                  destinations: [RemoteParticipant]? = nil,
                  topic: String? = nil,
-                 options: DataPublishOptions?) async throws {
+                 options: DataPublishOptions? = nil) async throws {
 
         try await withCheckedThrowingContinuation { continuation in
             publish(data: data,


### PR DESCRIPTION
Compiler was resolving to Promise version of publish(data:) even when awaited because only the promise version had default options = nil. Now the async version has the default options = nil so the compiler will correctly resolve to the async version when awaited.

Non-breaking fix.