### PR TITLE
improvements for E2EE.

### DIFF
--- a/LiveKitClient.podspec
+++ b/LiveKitClient.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
 
   spec.source_files   = 'Sources/**/*'
 
-  spec.dependency 'WebRTC-SDK', '~> 114.5735.02'
+  spec.dependency 'WebRTC-SDK', '~> 114.5735.05'
   spec.dependency 'SwiftProtobuf'
   spec.dependency 'PromisesSwift'
   spec.dependency 'Logging'

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "WebRTC", url: "https://github.com/webrtc-sdk/Specs.git", .exact("114.5735.04")),
+        .package(name: "WebRTC", url: "https://github.com/webrtc-sdk/Specs.git", .exact("114.5735.05")),
         .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", .upToNextMajor(from: "1.21.0")),
         .package(name: "Promises", url: "https://github.com/google/promises.git", .upToNextMajor(from: "2.2.0")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.5.2"))

--- a/Sources/LiveKit/E2EE/E2EEManager.swift
+++ b/Sources/LiveKit/E2EE/E2EEManager.swift
@@ -37,10 +37,10 @@ public class E2EEManager: NSObject, ObservableObject, Loggable {
         self.room = room
         self.room?.delegates.add(delegate: self)
         self.room?.localParticipant?.tracks.forEach({ (_: Sid, publication: TrackPublication) in
-                if publication.encryptionType == EncryptionType.none {
-                    self.log("E2EEManager::setup: local participant \(self.room!.localParticipant!.identity) track \(publication.sid) encryptionType is none, skip");
-                    return
-                }
+            if publication.encryptionType == EncryptionType.none {
+                self.log("E2EEManager::setup: local participant \(self.room!.localParticipant!.identity) track \(publication.sid) encryptionType is none, skip");
+                return
+            }
             let fc = addRtpSender(sender: publication.track!.rtpSender!, participantId: self.room!.localParticipant!.identity, trackSid: publication.sid)
             trackPublications[fc] = publication
         })
@@ -65,23 +65,19 @@ public class E2EEManager: NSObject, ObservableObject, Loggable {
     }
 
     func addRtpSender(sender: RTCRtpSender, participantId: String, trackSid: Sid) -> RTCFrameCryptor {
-        var mapKey = [String: Sid]()
-        mapKey[participantId] = trackSid
         self.log("addRtpSender \(participantId) to E2EEManager")
         let frameCryptor = RTCFrameCryptor(rtpSender: sender, participantId: participantId, algorithm: RTCCyrptorAlgorithm.aesGcm, keyProvider: self.e2eeOptions.keyProvider.rtcKeyProvider!)
         frameCryptor.delegate = self
-        frameCryptors[mapKey] = frameCryptor
+        frameCryptors[[participantId: trackSid]] = frameCryptor
         frameCryptor.enabled = self.enabled
         return frameCryptor
     }
 
     func addRtpReceiver(receiver: RTCRtpReceiver, participantId: String, trackSid: Sid) -> RTCFrameCryptor {
-        var mapKey = [String: Sid]()
-        mapKey[participantId] = trackSid
         self.log("addRtpReceiver \(participantId)  to E2EEManager")
         let frameCryptor = RTCFrameCryptor(rtpReceiver: receiver, participantId: participantId, algorithm: RTCCyrptorAlgorithm.aesGcm, keyProvider: self.e2eeOptions.keyProvider.rtcKeyProvider!)
         frameCryptor.delegate = self
-        frameCryptors[mapKey] = frameCryptor
+        frameCryptors[[participantId: trackSid]] = frameCryptor
         frameCryptor.enabled = self.enabled
         return frameCryptor
     }

--- a/Sources/LiveKit/E2EE/E2EEManager.swift
+++ b/Sources/LiveKit/E2EE/E2EEManager.swift
@@ -30,6 +30,14 @@ public class E2EEManager: NSObject, ObservableObject, Loggable {
         self.e2eeOptions = e2eeOptions
     }
 
+    public func keyProvider() -> BaseKeyProvider {
+        return self.e2eeOptions.keyProvider
+    }
+
+    public func getFrameCryptors() -> [[String: Sid]: RTCFrameCryptor] {
+        return self.frameCryptors
+    }
+
     public func setup(room: Room) {
         if self.room != room {
             cleanUp()

--- a/Sources/LiveKit/E2EE/KeyProvider.swift
+++ b/Sources/LiveKit/E2EE/KeyProvider.swift
@@ -71,11 +71,37 @@ public class BaseKeyProvider: Loggable {
         }
 
         if participantId == nil {
-            self.log("Please provide valid participantId for non-SharedKey mode.")
+            self.log("setKey: Please provide valid participantId for non-SharedKey mode.")
             return
         }
 
         let keyData = key.data(using: .utf8)!
         rtcKeyProvider?.setKey(keyData, with: index!, forParticipant: participantId!)
+    }
+
+    public func ratchetKey(participantId: String? = nil, index: Int32? = 0) -> Data? {
+        if options.sharedKey {
+            return rtcKeyProvider?.ratchetSharedKey(index ?? 0)
+        }
+
+        if participantId == nil {
+            self.log("ratchetKey: Please provide valid participantId for non-SharedKey mode.")
+            return nil
+        }
+
+        return rtcKeyProvider?.ratchetKey(participantId!, with: index ?? 0)
+    }
+
+    public func exportKey(participantId: String? = nil, index: Int32? = 0) -> Data? {
+        if options.sharedKey {
+            return rtcKeyProvider?.exportSharedKey(index ?? 0)
+        }
+
+        if participantId == nil {
+            self.log("exportKey: Please provide valid participantId for non-SharedKey mode.")
+            return nil
+        }
+
+        return rtcKeyProvider?.exportKey(participantId!, with: index ?? 0)
     }
 }


### PR DESCRIPTION
changes:
- [x] No breaking of existing APIs
- [x] Align with js/rust API, add KeyProviderOptions, and expose key provider from e2eeManager
- [x] Remove framecryptor when unpublish/unsubscribe
- [x] Do not add unencrypted publications to E2EE manager, skip encryption
- [x] Add ratchet, export key API for shared key and participant key
- [x] Updated WebRTC.framework to 114.5735.05, including e2ee improvements