### PR TITLE
Remove `.mixWithOthers` when category `.playAndRecord`

### DIFF
--- a/Sources/LiveKit/Track/AudioManager.swift
+++ b/Sources/LiveKit/Track/AudioManager.swift
@@ -165,7 +165,6 @@ public class AudioManager: Loggable {
                 }
 
                 configuration.categoryOptions = [
-                    .mixWithOthers,
                     .allowBluetooth,
                     .allowBluetoothA2DP,
                     .allowAirPlay


### PR DESCRIPTION
`.mixWithOthers` is still present for `.playback` category for watch only use cases (like livestream)