### PR TITLE
Fix: `CameraCapturer` report actual frame dimensions

### DIFF
--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -24,8 +24,6 @@ import ReplayKit
 
 public class CameraCapturer: VideoCapturer {
 
-    private let capturer: RTCCameraVideoCapturer
-
     @objc
     public static func captureDevices() -> [AVCaptureDevice] {
         DispatchQueue.liveKitWebRTC.sync { RTCCameraVideoCapturer.captureDevices() }
@@ -80,8 +78,12 @@ public class CameraCapturer: VideoCapturer {
         }
     }
 
+    // RTCCameraVideoCapturer used internally for now
+    private lazy var capturer: RTCCameraVideoCapturer = {
+        DispatchQueue.liveKitWebRTC.sync { RTCCameraVideoCapturer(delegate: self) }
+    }()
+
     init(delegate: RTCVideoCapturerDelegate, options: CameraCaptureOptions) {
-        self.capturer = DispatchQueue.liveKitWebRTC.sync { RTCCameraVideoCapturer(delegate: delegate) }
         self.options = options
         super.init(delegate: delegate)
 
@@ -205,8 +207,6 @@ public class CameraCapturer: VideoCapturer {
 
                     // update internal vars
                     self.device = device
-                    // this will trigger to re-compute encodings for sender parameters if dimensions have updated
-                    self.dimensions = self.options.dimensions
 
                     // successfully started
                     resolve(true)
@@ -236,6 +236,16 @@ public class CameraCapturer: VideoCapturer {
                 }
             }
         }
+    }
+}
+
+extension CameraCapturer: RTCVideoCapturerDelegate {
+
+    public func capturer(_ capturer: RTCVideoCapturer, didCapture frame: RTCVideoFrame) {
+        // Resolve real dimensions
+        self.dimensions = Dimensions(width: frame.width, height: frame.height).apply(rotation: frame.rotation)
+        // Pass frame to video source
+        delegate?.capturer(capturer, didCapture: frame)
     }
 }
 

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -242,7 +242,7 @@ public class CameraCapturer: VideoCapturer {
 extension CameraCapturer: RTCVideoCapturerDelegate {
 
     public func capturer(_ capturer: RTCVideoCapturer, didCapture frame: RTCVideoFrame) {
-        // Resolve real dimensions
+        // Resolve real dimensions (apply frame rotation)
         self.dimensions = Dimensions(width: frame.width, height: frame.height).apply(rotation: frame.rotation)
         // Pass frame to video source
         delegate?.capturer(capturer, didCapture: frame)


### PR DESCRIPTION
Fix: `CameraCapturer` report actual frame dimensions, instead of reporting dimensions in options as initial dimensions.