### PR TITLE
Actor pattern for `SignalClient`'s request / response queue

### DIFF
--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -294,9 +294,9 @@ internal extension Room {
             )
         }
 
-        engine.signalClient.cleanUp(reason: reason)
-
-        return engine.cleanUpRTC().then(on: queue) {
+        return promise(from: engine.signalClient.cleanUp, param1: reason).then(on: queue) {
+            self.engine.cleanUpRTC()
+        }.then(on: queue) {
             self.cleanUpParticipants()
         }.then(on: queue) {
             // reset state

--- a/Sources/LiveKit/Support/AsyncCompleter.swift
+++ b/Sources/LiveKit/Support/AsyncCompleter.swift
@@ -15,7 +15,6 @@
  */
 
 import Foundation
-import Promises
 
 internal enum AsyncCompleterError: LiveKitError {
     case timedOut

--- a/Sources/LiveKit/Support/AsyncQueueActor.swift
+++ b/Sources/LiveKit/Support/AsyncQueueActor.swift
@@ -26,6 +26,7 @@ internal actor AsyncQueueActor<T> {
     public private(set) var state: State = .resumed
     private var queue = [T]()
 
+    /// Mark as `.suspended`.
     func suspend() {
         state = .suspended
     }
@@ -34,6 +35,7 @@ internal actor AsyncQueueActor<T> {
         queue.append(value)
     }
 
+    /// Only enqueue if `.suspended` state, otherwise process immediately.
     func enqueue(_ value: T, ifResumed process: (T) async -> Void) async {
         if case .suspended = state {
             queue.append(value)
@@ -47,6 +49,7 @@ internal actor AsyncQueueActor<T> {
         state = .resumed
     }
 
+    /// Mark as `.resumed` and process each element with an async `block`.
     func resume(_ block: (T) async -> Void) async {
         state = .resumed
         if queue.isEmpty { return }

--- a/Sources/LiveKit/Support/AsyncQueueActor.swift
+++ b/Sources/LiveKit/Support/AsyncQueueActor.swift
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+internal actor AsyncQueueActor<T> {
+
+    public enum State {
+        case resumed
+        case suspended
+    }
+
+    public private(set) var state: State = .resumed
+    private var queue = [T]()
+
+    func suspend() {
+        state = .suspended
+    }
+
+    func enqueue(_ value: T) {
+        queue.append(value)
+    }
+
+    func enqueue(_ value: T, ifResumed process: (T) async -> Void) async {
+        if case .suspended = state {
+            queue.append(value)
+        } else {
+            await process(value)
+        }
+    }
+
+    func clear() {
+        queue.removeAll()
+        state = .resumed
+    }
+
+    func resume(_ block: (T) async -> Void) async {
+        state = .resumed
+        if queue.isEmpty { return }
+        for element in queue {
+            await block(element)
+        }
+        queue.removeAll()
+    }
+}


### PR DESCRIPTION
Actor pattern is a neat alternative to DispatchQueue to ensure the queue doesn't get mutated while enumerating / processing.