### PR TITLE
Make `LocalParticipant` non-Optional

### DIFF
--- a/Sources/LiveKit/Core/Engine.swift
+++ b/Sources/LiveKit/Core/Engine.swift
@@ -502,7 +502,7 @@ extension Engine {
 
         try await signalClient.sendSyncState(answer: previousAnswer.toPBType(),
                                              offer: previousOffer?.toPBType(),
-                                             subscription: subscription, publishTracks: room._state.localParticipant?.publishedTracksInfo(),
+                                             subscription: subscription, publishTracks: room.localParticipant.publishedTracksInfo(),
                                              dataChannels: publisherDC.infos())
     }
 }

--- a/Sources/LiveKit/Core/Room+Convenience.swift
+++ b/Sources/LiveKit/Core/Room+Convenience.swift
@@ -19,11 +19,9 @@ import Foundation
 public extension Room {
     var allParticipants: [Sid: Participant] {
         var result: [Sid: Participant] = remoteParticipants
-
-        if let localParticipant {
+        if !localParticipant.sid.isEmpty {
             result.updateValue(localParticipant, forKey: localParticipant.sid)
         }
-
         return result
     }
 }

--- a/Sources/LiveKit/Core/Room+EngineDelegate.swift
+++ b/Sources/LiveKit/Core/Room+EngineDelegate.swift
@@ -29,7 +29,7 @@ extension Room: EngineDelegate {
             }
 
             // Re-send track permissions
-            if case .connected = state.connectionState, let localParticipant {
+            if case .connected = state.connectionState {
                 Task {
                     do {
                         try await localParticipant.sendTrackSubscriptionPermissions()
@@ -82,9 +82,7 @@ extension Room: EngineDelegate {
             var seenSids = [String: Bool]()
             for speaker in speakers {
                 seenSids[speaker.sid] = true
-                if let localParticipant = state.localParticipant,
-                   speaker.sid == localParticipant.sid
-                {
+                if speaker.sid == localParticipant.sid {
                     localParticipant._state.mutate {
                         $0.audioLevel = speaker.level
                         $0.isSpeaking = true
@@ -101,7 +99,7 @@ extension Room: EngineDelegate {
                 }
             }
 
-            if let localParticipant = state.localParticipant, seenSids[localParticipant.sid] == nil {
+            if seenSids[localParticipant.sid] == nil {
                 localParticipant._state.mutate {
                     $0.audioLevel = 0.0
                     $0.isSpeaking = false

--- a/Sources/LiveKit/E2EE/E2EEManager.swift
+++ b/Sources/LiveKit/E2EE/E2EEManager.swift
@@ -63,16 +63,16 @@ public class E2EEManager: NSObject, ObservableObject, Loggable {
         }
         self.room = room
         self.room?.delegates.add(delegate: self)
-        self.room?.localParticipant?.tracks.forEach { (_: Sid, publication: TrackPublication) in
+        self.room?.localParticipant.tracks.forEach { (_: Sid, publication: TrackPublication) in
             if publication.encryptionType == EncryptionType.none {
-                self.log("E2EEManager::setup: local participant \(self.room!.localParticipant!.identity) track \(publication.sid) encryptionType is none, skip")
+                self.log("E2EEManager::setup: local participant \(self.room!.localParticipant.identity) track \(publication.sid) encryptionType is none, skip")
                 return
             }
             if publication.track?.rtpSender == nil {
                 self.log("E2EEManager::setup: publication.track?.rtpSender is nil, skip to create FrameCryptor!")
                 return
             }
-            let fc = addRtpSender(sender: publication.track!.rtpSender!, participantId: self.room!.localParticipant!.identity, trackSid: publication.sid)
+            let fc = addRtpSender(sender: publication.track!.rtpSender!, participantId: self.room!.localParticipant.identity, trackSid: publication.sid)
             trackPublications[fc] = publication
         }
 

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -33,6 +33,10 @@ public class LocalParticipant: Participant {
     private var allParticipantsAllowed: Bool = true
     private var trackPermissions: [ParticipantTrackPermission] = []
 
+    convenience init(room: Room) {
+        self.init(sid: "", identity: "", name: "", room: room)
+    }
+
     convenience init(from info: Livekit_ParticipantInfo,
                      room: Room)
     {

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -33,19 +33,8 @@ public class LocalParticipant: Participant {
     private var allParticipantsAllowed: Bool = true
     private var trackPermissions: [ParticipantTrackPermission] = []
 
-    convenience init(room: Room) {
-        self.init(sid: "", identity: "", name: "", room: room)
-    }
-
-    convenience init(from info: Livekit_ParticipantInfo,
-                     room: Room)
-    {
-        self.init(sid: info.sid,
-                  identity: info.identity,
-                  name: info.name,
-                  room: room)
-
-        updateFromInfo(info: info)
+    init(room: Room) {
+        super.init(sid: "", room: room)
     }
 
     func getTrackPublication(sid: Sid) -> LocalTrackPublication? {
@@ -325,7 +314,7 @@ public class LocalParticipant: Participant {
 
         // TODO: Revert internal state on failure
 
-        try await room.engine.signalClient.sendUpdateLocalMetadata(metadata, name: name)
+        try await room.engine.signalClient.sendUpdateLocalMetadata(metadata, name: name ?? "")
     }
 
     /// Sets and updates the name of the local participant.

--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -74,7 +74,7 @@ public class Participant: NSObject, ObservableObject, Loggable {
     // MARK: - Internal
 
     struct State: Equatable, Hashable {
-        let sid: Sid
+        var sid: Sid
         var identity: String
         var name: String
         var audioLevel: Float = 0.0
@@ -162,7 +162,7 @@ public class Participant: NSObject, ObservableObject, Loggable {
     func cleanUp(notify _notify: Bool = true) async {
         await unpublishAll(notify: _notify)
         // Reset state
-        _state.mutate { $0 = State(sid: $0.sid, identity: $0.identity, name: $0.name) }
+        _state.mutate { $0 = State(sid: "", identity: "", name: "") }
     }
 
     func unpublishAll(notify _: Bool = true) async {
@@ -176,6 +176,7 @@ public class Participant: NSObject, ObservableObject, Loggable {
 
     func updateFromInfo(info: Livekit_ParticipantInfo) {
         _state.mutate {
+            $0.sid = info.sid
             $0.identity = info.identity
             $0.name = info.name
             $0.metadata = info.metadata

--- a/Sources/LiveKit/Participant/RemoteParticipant.swift
+++ b/Sources/LiveKit/Participant/RemoteParticipant.swift
@@ -20,14 +20,8 @@ import Foundation
 
 @objc
 public class RemoteParticipant: Participant {
-    init(sid: Sid,
-         info: Livekit_ParticipantInfo?,
-         room: Room)
-    {
-        super.init(sid: sid,
-                   identity: info?.identity ?? "",
-                   name: info?.name ?? "",
-                   room: room)
+    init(sid: Sid, info: Livekit_ParticipantInfo?, room: Room) {
+        super.init(sid: sid, room: room)
 
         if let info {
             updateFromInfo(info: info)

--- a/Sources/LiveKit/Protocols/ParticipantDelegate.swift
+++ b/Sources/LiveKit/Protocols/ParticipantDelegate.swift
@@ -34,7 +34,7 @@ public protocol ParticipantDelegate: AnyObject {
     /// A ``Participant``'s name has updated.
     /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.
     @objc(participant:didUpdateName:) optional
-    func participant(_ participant: Participant, didUpdateName: String)
+    func participant(_ participant: Participant, didUpdateName: String?)
 
     /// The isSpeaking status of a ``Participant`` has changed.
     /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -79,7 +79,7 @@ public protocol RoomDelegateObjC: AnyObject {
 
     /// Same with ``ParticipantDelegate/participant(_:didUpdateName:)``.
     @objc(room:participant:didUpdateName:) optional
-    func room(_ room: Room, participant: Participant, didUpdateName: String)
+    func room(_ room: Room, participant: Participant, didUpdateName: String?)
 
     /// Same with ``ParticipantDelegate/participant(_:didUpdate:)-7zxk1``.
     @objc(room:participant:didUpdateConnectionQuality:) optional


### PR DESCRIPTION
I found `Room.localParticipant` being optional inconvenient so this PR makes it always available. (for v2)

`sid`, `identity`, `name` will all be an empty string for LocalParticipant until it connects.
I'm still thinking if this should be a `String?` instead.