### PR TITLE
support app sharing in screen capture

### DIFF
--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -68,9 +68,10 @@ import Foundation
                       let content = displaySource.scContent as? SCShareableContent,
                       let nativeDisplay = displaySource.nativeType as? SCDisplay
             {
-                let excludedApps = content.applications.filter { app in
+                let excludedApps = !self.options.includeCurrentApplication ? content.applications.filter { app in
                     Bundle.main.bundleIdentifier == app.bundleIdentifier
-                }
+                } : []
+                                
                 filter = SCContentFilter(display: nativeDisplay, excludingApplications: excludedApps, exceptingWindows: [])
             } else {
                 throw TrackError.capturer(message: "Unable to resolve SCContentFilter")

--- a/Sources/LiveKit/Types/Options/ScreenShareCaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/ScreenShareCaptureOptions.swift
@@ -30,16 +30,20 @@ public class ScreenShareCaptureOptions: NSObject, VideoCaptureOptions {
 
     @objc
     public let useBroadcastExtension: Bool
+    
+    @objc
+    public let includeCurrentApplication: Bool
 
     public init(dimensions: Dimensions = .h1080_169,
                 fps: Int = 15,
                 showCursor: Bool = true,
-                useBroadcastExtension: Bool = false)
-    {
+                useBroadcastExtension: Bool = false,
+                includeCurrentApplication: Bool = false) {
         self.dimensions = dimensions
         self.fps = fps
         self.showCursor = showCursor
         self.useBroadcastExtension = useBroadcastExtension
+        self.includeCurrentApplication = includeCurrentApplication
     }
 
     // MARK: - Equal
@@ -49,7 +53,8 @@ public class ScreenShareCaptureOptions: NSObject, VideoCaptureOptions {
         return dimensions == other.dimensions &&
             fps == other.fps &&
             showCursor == other.showCursor &&
-            useBroadcastExtension == other.useBroadcastExtension
+            useBroadcastExtension == other.useBroadcastExtension &&
+            includeCurrentApplication == other.includeCurrentApplication
     }
 
     override public var hash: Int {
@@ -58,6 +63,7 @@ public class ScreenShareCaptureOptions: NSObject, VideoCaptureOptions {
         hasher.combine(fps)
         hasher.combine(showCursor)
         hasher.combine(useBroadcastExtension)
+        hasher.combine(includeCurrentApplication)
         return hasher.finalize()
     }
 }


### PR DESCRIPTION
Hello everyone, my issue revolves around the inability to share app content during screen sharing. I attempted to use MacOSScreenCapturer.sources with the parameter includeCurrentApplication set to true, but unfortunately, it did not yield the desired outcome.

In order to address this issue, I made the following pull request (PR) changes. In these changes, I introduced the includeCurrentApplication parameter to ScreenShareCaptureOptions and utilized it to exclude the app filter in MacOSScreenCapturer. This modification enables the retrieval of sources as demonstrated in the following code snippet:

```
_ = MacOSScreenCapturer.mainDisplaySource().then { displaySource in
    Task {
        let options = ScreenShareCaptureOptions(dimensions: .h720_43,
                                                fps: 5,
                                                includeCurrentApplication: true)
        
        let mainTrack = LocalVideoTrack.createMacOSScreenShareTrack(source: displaySource, options: options)
        
        Task { @MainActor in
            self.tracks = [mainTrack]
        }
        
        await withThrowingTaskGroup(of: Void.self) { group in
            group.addTask {
                try await mainTrack.start()
            }
        }
    }
}

```

This solution consistently works and provides a convenient resolution. If there is a misunderstanding on my part, and the issue can be resolved without these changes, please reach out to me and provide an explanation. 

Thank you in advance!