### PR TITLE
Explicit delegate signatures

### DIFF
--- a/Sources/LiveKit/Core/Room+EngineDelegate.swift
+++ b/Sources/LiveKit/Core/Room+EngineDelegate.swift
@@ -40,7 +40,7 @@ extension Room: EngineDelegate {
             }
 
             delegates.notify(label: { "room.didUpdate connectionState: \(state.connectionState) oldValue: \(oldState.connectionState)" }) {
-                $0.room?(self, didUpdate: state.connectionState, oldValue: oldState.connectionState)
+                $0.room?(self, didUpdateConnectionState: state.connectionState, oldConnectionState: oldState.connectionState)
             }
 
             // Legacy connection delegates
@@ -49,9 +49,9 @@ extension Room: EngineDelegate {
                 delegates.notify { $0.room?(self, didConnect: didReconnect) }
             } else if case .disconnected = state.connectionState {
                 if case .connecting = oldState.connectionState {
-                    delegates.notify { $0.room?(self, didFailToConnect: oldState.disconnectError) }
+                    delegates.notify { $0.room?(self, didFailToConnectWithError: oldState.disconnectError) }
                 } else {
-                    delegates.notify { $0.room?(self, didDisconnect: state.disconnectError) }
+                    delegates.notify { $0.room?(self, didDisconnectWithError: state.disconnectError) }
                 }
             }
         }
@@ -116,7 +116,7 @@ extension Room: EngineDelegate {
             guard let self else { return }
 
             self.delegates.notify(label: { "room.didUpdate speakers: \(activeSpeakers)" }) {
-                $0.room?(self, didUpdate: activeSpeakers)
+                $0.room?(self, didUpdateSpeakingParticipants: activeSpeakers)
             }
         }
     }

--- a/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
@@ -133,7 +133,7 @@ extension Room: SignalClientDelegate {
             guard let self else { return }
 
             self.delegates.notify(label: { "room.didUpdate speakers: \(speakers)" }) {
-                $0.room?(self, didUpdate: activeSpeakers)
+                $0.room?(self, didUpdateSpeakingParticipants: activeSpeakers)
             }
         }
     }

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -181,7 +181,7 @@ public class Room: NSObject, ObservableObject, Loggable {
                     guard let self else { return }
 
                     self.delegates.notify(label: { "room.didUpdate metadata: \(metadata)" }) {
-                        $0.room?(self, didUpdate: metadata)
+                        $0.room?(self, didUpdateMetadata: metadata)
                     }
                 }
             }
@@ -194,7 +194,7 @@ public class Room: NSObject, ObservableObject, Loggable {
                     guard let self else { return }
 
                     self.delegates.notify(label: { "room.didUpdate isRecording: \(newState.isRecording)" }) {
-                        $0.room?(self, didUpdate: newState.isRecording)
+                        $0.room?(self, didUpdateIsRecording: newState.isRecording)
                     }
                 }
             }

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -207,7 +207,7 @@ public class LocalParticipant: Participant {
 
             // Notify didPublish
             delegates.notify(label: { "localParticipant.didPublish \(publication)" }) {
-                $0.localParticipant?(self, didPublish: publication)
+                $0.localParticipant?(self, didPublishPublication: publication)
             }
             room.delegates.notify(label: { "localParticipant.didPublish \(publication)" }) {
                 $0.room?(self.room, localParticipant: self, didPublishPublication: publication)
@@ -259,7 +259,7 @@ public class LocalParticipant: Participant {
         func _notifyDidUnpublish() async {
             guard _notify else { return }
             delegates.notify(label: { "localParticipant.didUnpublish \(publication)" }) {
-                $0.localParticipant?(self, didUnpublish: publication)
+                $0.localParticipant?(self, didUnpublishPublication: publication)
             }
             room.delegates.notify(label: { "room.didUnpublish \(publication)" }) {
                 $0.room?(self.room, localParticipant: self, didUnpublishPublication: publication)
@@ -403,7 +403,7 @@ public class LocalParticipant: Participant {
 
         if didUpdate {
             delegates.notify(label: { "participant.didUpdatePermissions: \(newValue)" }) {
-                $0.participant?(self, didUpdate: newValue)
+                $0.participant?(self, didUpdatePermissions: newValue)
             }
             room.delegates.notify(label: { "room.didUpdatePermissions: \(newValue)" }) {
                 $0.room?(self.room, participant: self, didUpdatePermissions: newValue)

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -210,7 +210,7 @@ public class LocalParticipant: Participant {
                 $0.localParticipant?(self, didPublish: publication)
             }
             room.delegates.notify(label: { "localParticipant.didPublish \(publication)" }) {
-                $0.room?(self.room, localParticipant: self, didPublish: publication)
+                $0.room?(self.room, localParticipant: self, didPublishPublication: publication)
             }
 
             log("[publish] success \(publication)", .info)
@@ -262,7 +262,7 @@ public class LocalParticipant: Participant {
                 $0.localParticipant?(self, didUnpublish: publication)
             }
             room.delegates.notify(label: { "room.didUnpublish \(publication)" }) {
-                $0.room?(self.room, localParticipant: self, didUnpublish: publication)
+                $0.room?(self.room, localParticipant: self, didUnpublishPublication: publication)
             }
         }
 
@@ -402,11 +402,11 @@ public class LocalParticipant: Participant {
         let didUpdate = super.set(permissions: newValue)
 
         if didUpdate {
-            delegates.notify(label: { "participant.didUpdate permissions: \(newValue)" }) {
+            delegates.notify(label: { "participant.didUpdatePermissions: \(newValue)" }) {
                 $0.participant?(self, didUpdate: newValue)
             }
-            room.delegates.notify(label: { "room.didUpdate permissions: \(newValue)" }) {
-                $0.room?(self.room, participant: self, didUpdate: newValue)
+            room.delegates.notify(label: { "room.didUpdatePermissions: \(newValue)" }) {
+                $0.room?(self.room, participant: self, didUpdatePermissions: newValue)
             }
         }
 

--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -115,7 +115,7 @@ public class Participant: NSObject, ObservableObject, Loggable {
                     $0.participant?(self, didUpdate: metadata)
                 }
                 self.room.delegates.notify(label: { "room.didUpdate metadata: \(metadata)" }) {
-                    $0.room?(self.room, participant: self, didUpdate: metadata)
+                    $0.room?(self.room, participant: self, didUpdateMetadata: metadata)
                 }
             }
 
@@ -136,7 +136,7 @@ public class Participant: NSObject, ObservableObject, Loggable {
                     $0.participant?(self, didUpdate: self.connectionQuality)
                 }
                 self.room.delegates.notify(label: { "room.didUpdate connectionQuality: \(self.connectionQuality)" }) {
-                    $0.room?(self.room, participant: self, didUpdate: self.connectionQuality)
+                    $0.room?(self.room, participant: self, didUpdateConnectionQuality: self.connectionQuality)
                 }
             }
 

--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -102,7 +102,7 @@ public class Participant: NSObject, ObservableObject, Loggable {
 
             if newState.isSpeaking != oldState.isSpeaking {
                 self.delegates.notify(label: { "participant.didUpdate isSpeaking: \(self.isSpeaking)" }) {
-                    $0.participant?(self, didUpdate: self.isSpeaking)
+                    $0.participant?(self, didUpdateIsSpeaking: self.isSpeaking)
                 }
             }
 
@@ -112,7 +112,7 @@ public class Participant: NSObject, ObservableObject, Loggable {
                oldState.metadata == nil ? !metadata.isEmpty : true
             {
                 self.delegates.notify(label: { "participant.didUpdate metadata: \(metadata)" }) {
-                    $0.participant?(self, didUpdate: metadata)
+                    $0.participant?(self, didUpdateMetadata: metadata)
                 }
                 self.room.delegates.notify(label: { "room.didUpdate metadata: \(metadata)" }) {
                     $0.room?(self.room, participant: self, didUpdateMetadata: metadata)
@@ -133,7 +133,7 @@ public class Participant: NSObject, ObservableObject, Loggable {
 
             if newState.connectionQuality != oldState.connectionQuality {
                 self.delegates.notify(label: { "participant.didUpdate connectionQuality: \(self.connectionQuality)" }) {
-                    $0.participant?(self, didUpdate: self.connectionQuality)
+                    $0.participant?(self, didUpdateConnectionQuality: self.connectionQuality)
                 }
                 self.room.delegates.notify(label: { "room.didUpdate connectionQuality: \(self.connectionQuality)" }) {
                     $0.room?(self.room, participant: self, didUpdateConnectionQuality: self.connectionQuality)

--- a/Sources/LiveKit/Participant/RemoteParticipant.swift
+++ b/Sources/LiveKit/Participant/RemoteParticipant.swift
@@ -135,7 +135,7 @@ public class RemoteParticipant: Participant {
             $0.participant?(self, didSubscribe: publication, track: track)
         }
         room.delegates.notify(label: { "room.didSubscribe \(publication)" }) {
-            $0.room?(self.room, participant: self, didSubscribePublication: publication, track: track)
+            $0.room?(self.room, participant: self, didSubscribePublication: publication)
         }
     }
 
@@ -186,7 +186,7 @@ public class RemoteParticipant: Participant {
                 $0.participant?(self, didUnsubscribe: publication, track: track)
             }
             room.delegates.notify(label: { "room.didUnsubscribe \(publication)" }) {
-                $0.room?(self.room, participant: self, didUnsubscribePublication: publication, track: track)
+                $0.room?(self.room, participant: self, didUnsubscribePublication: publication)
             }
         }
 

--- a/Sources/LiveKit/Participant/RemoteParticipant.swift
+++ b/Sources/LiveKit/Participant/RemoteParticipant.swift
@@ -59,7 +59,7 @@ public class RemoteParticipant: Participant {
 
             for publication in newTrackPublications.values {
                 self.delegates.notify(label: { "participant.didPublish \(publication)" }) {
-                    $0.participant?(self, didPublish: publication)
+                    $0.participant?(self, didPublishPublication: publication)
                 }
                 self.room.delegates.notify(label: { "room.didPublish \(publication)" }) {
                     $0.room?(self.room, participant: self, didPublishPublication: publication)
@@ -132,7 +132,7 @@ public class RemoteParticipant: Participant {
         try await track.start()
 
         delegates.notify(label: { "participant.didSubscribe \(publication)" }) {
-            $0.participant?(self, didSubscribe: publication, track: track)
+            $0.participant?(self, didSubscribePublication: publication)
         }
         room.delegates.notify(label: { "room.didSubscribe \(publication)" }) {
             $0.room?(self.room, participant: self, didSubscribePublication: publication)
@@ -163,7 +163,7 @@ public class RemoteParticipant: Participant {
         func _notifyUnpublish() async {
             guard _notify else { return }
             delegates.notify(label: { "participant.didUnpublish \(publication)" }) {
-                $0.participant?(self, didUnpublish: publication)
+                $0.participant?(self, didUnpublishPublication: publication)
             }
             room.delegates.notify(label: { "room.didUnpublish \(publication)" }) {
                 $0.room?(self.room, participant: self, didUnpublishPublication: publication)
@@ -183,7 +183,7 @@ public class RemoteParticipant: Participant {
         if _notify {
             // Notify unsubscribe
             delegates.notify(label: { "participant.didUnsubscribe \(publication)" }) {
-                $0.participant?(self, didUnsubscribe: publication, track: track)
+                $0.participant?(self, didUnsubscribePublication: publication)
             }
             room.delegates.notify(label: { "room.didUnsubscribe \(publication)" }) {
                 $0.room?(self.room, participant: self, didUnsubscribePublication: publication)

--- a/Sources/LiveKit/Participant/RemoteParticipant.swift
+++ b/Sources/LiveKit/Participant/RemoteParticipant.swift
@@ -62,7 +62,7 @@ public class RemoteParticipant: Participant {
                     $0.participant?(self, didPublish: publication)
                 }
                 self.room.delegates.notify(label: { "room.didPublish \(publication)" }) {
-                    $0.room?(self.room, participant: self, didPublish: publication)
+                    $0.room?(self.room, participant: self, didPublishPublication: publication)
                 }
             }
         }
@@ -135,7 +135,7 @@ public class RemoteParticipant: Participant {
             $0.participant?(self, didSubscribe: publication, track: track)
         }
         room.delegates.notify(label: { "room.didSubscribe \(publication)" }) {
-            $0.room?(self.room, participant: self, didSubscribe: publication, track: track)
+            $0.room?(self.room, participant: self, didSubscribePublication: publication, track: track)
         }
     }
 
@@ -166,7 +166,7 @@ public class RemoteParticipant: Participant {
                 $0.participant?(self, didUnpublish: publication)
             }
             room.delegates.notify(label: { "room.didUnpublish \(publication)" }) {
-                $0.room?(self.room, participant: self, didUnpublish: publication)
+                $0.room?(self.room, participant: self, didUnpublishPublication: publication)
             }
         }
 
@@ -186,7 +186,7 @@ public class RemoteParticipant: Participant {
                 $0.participant?(self, didUnsubscribe: publication, track: track)
             }
             room.delegates.notify(label: { "room.didUnsubscribe \(publication)" }) {
-                $0.room?(self.room, participant: self, didUnsubscribe: publication, track: track)
+                $0.room?(self.room, participant: self, didUnsubscribePublication: publication, track: track)
             }
         }
 

--- a/Sources/LiveKit/Protocols/ParticipantDelegate.swift
+++ b/Sources/LiveKit/Protocols/ParticipantDelegate.swift
@@ -23,28 +23,35 @@ import Foundation
 /// All delegate methods are optional.
 ///
 /// To ensure each participant's delegate is registered, you can look through ``Room/localParticipant`` and ``Room/remoteParticipants`` on connect
-/// and register it on new participants inside ``RoomDelegate/room(_:participantDidJoin:)-9bkm4``
+/// and register it on new participants inside ``RoomDelegate/room(_:participantDidJoin:)``
 @objc
 public protocol ParticipantDelegate: AnyObject {
+    // MARK: - Participant
+
     /// A ``Participant``'s metadata has updated.
     /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.
     @objc(participant:didUpdateMetadata:) optional
-    func participant(_ participant: Participant, didUpdate metadata: String?)
+    func participant(_ participant: Participant, didUpdateMetadata metadata: String?)
 
     /// A ``Participant``'s name has updated.
     /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.
     @objc(participant:didUpdateName:) optional
-    func participant(_ participant: Participant, didUpdateName: String?)
+    func participant(_ participant: Participant, didUpdateName name: String?)
 
     /// The isSpeaking status of a ``Participant`` has changed.
     /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.
     @objc(participant:didUpdateSpeaking:) optional
-    func participant(_ participant: Participant, didUpdate speaking: Bool)
+    func participant(_ participant: Participant, didUpdateIsSpeaking isSpeaking: Bool)
 
     /// The connection quality of a ``Participant`` has updated.
     /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.
     @objc(participant:didUpdateConnectionQuality:) optional
-    func participant(_ participant: Participant, didUpdate connectionQuality: ConnectionQuality)
+    func participant(_ participant: Participant, didUpdateConnectionQuality connectionQuality: ConnectionQuality)
+
+    @objc(participant:didUpdatePermissions:) optional
+    func participant(_ participant: Participant, didUpdatePermissions permissions: ParticipantPermissions)
+
+    // MARK: - TrackPublication
 
     /// `muted` state has updated for the ``Participant``'s ``TrackPublication``.
     ///
@@ -53,54 +60,57 @@ public protocol ParticipantDelegate: AnyObject {
     ///
     /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.
     @objc(participant:publication:didUpdateMuted:) optional
-    func participant(_ participant: Participant, didUpdate publication: TrackPublication, muted: Bool)
+    func participant(_ participant: Participant, didUpdatePublication publication: TrackPublication, isMuted: Bool)
 
-    @objc(participant:didUpdatePermissions:) optional
-    func participant(_ participant: Participant, didUpdate permissions: ParticipantPermissions)
+    // MARK: - LocalTrackPublication
 
-    /// ``RemoteTrackPublication/streamState`` has updated for the ``RemoteParticipant``.
-    @objc(participant:publication:didUpdateStreamState:) optional
-    func participant(_ participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, streamState: StreamState)
+    /// The ``LocalParticipant`` has published a ``LocalTrackPublication``.
+    @objc(localParticipant:didPublish:) optional
+    func localParticipant(_ participant: LocalParticipant, didPublishPublication publication: LocalTrackPublication)
 
-    /// ``RemoteTrackPublication/subscriptionAllowed`` has updated for the ``RemoteParticipant``.
-    @objc(participant:publication:didUpdateCanSubscribe:) optional
-    func participant(_ participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, permission allowed: Bool)
+    /// The ``LocalParticipant`` has unpublished a ``LocalTrackPublication``.
+    @objc(localParticipant:didUnpublish:) optional
+    func localParticipant(_ participant: LocalParticipant, didUnpublishPublication publication: LocalTrackPublication)
+
+    // MARK: - RemoteTrackPublication
 
     /// When a new ``RemoteTrackPublication`` is published to ``Room`` after the ``LocalParticipant`` has joined.
     ///
     /// This delegate method will not be called for tracks that are already published.
     @objc(remoteParticipant:didPublish:) optional
-    func participant(_ participant: RemoteParticipant, didPublish publication: RemoteTrackPublication)
+    func participant(_ participant: RemoteParticipant, didPublishPublication publication: RemoteTrackPublication)
 
     /// The ``RemoteParticipant`` has unpublished a ``RemoteTrackPublication``.
     @objc(remoteParticipant:didUnpublish:) optional
-    func participant(_ participant: RemoteParticipant, didUnpublish publication: RemoteTrackPublication)
-
-    /// The ``LocalParticipant`` has published a ``LocalTrackPublication``.
-    @objc(localParticipant:didPublish:) optional
-    func localParticipant(_ participant: LocalParticipant, didPublish publication: LocalTrackPublication)
-
-    /// The ``LocalParticipant`` has unpublished a ``LocalTrackPublication``.
-    @objc(localParticipant:didUnpublish:) optional
-    func localParticipant(_ participant: LocalParticipant, didUnpublish publication: LocalTrackPublication)
+    func participant(_ participant: RemoteParticipant, didUnpublishPublication publication: RemoteTrackPublication)
 
     /// The ``LocalParticipant`` has subscribed to a new ``RemoteTrackPublication``.
     ///
     /// This event will always fire as long as new tracks are ready for use.
-    @objc(participant:didSubscribe:track:) optional
-    func participant(_ participant: RemoteParticipant, didSubscribe publication: RemoteTrackPublication, track: Track)
+    @objc(participant:didSubscribe:) optional
+    func participant(_ participant: RemoteParticipant, didSubscribePublication publication: RemoteTrackPublication)
+
+    /// Unsubscribed from a ``RemoteTrackPublication`` and  is no longer available.
+    ///
+    /// Clients should listen to this event and handle cleanup.
+    @objc(participant:didUnsubscribePublication:) optional
+    func participant(_ participant: RemoteParticipant, didUnsubscribePublication publication: RemoteTrackPublication)
 
     /// Could not subscribe to a track.
     ///
     /// This is an error state, the subscription can be retried.
     @objc(participant:didFailToSubscribeTrackWithSid:error:) optional
-    func participant(_ participant: RemoteParticipant, didFailToSubscribe trackSid: String, error: Error)
+    func participant(_ participant: RemoteParticipant, didFailToSubscribe trackSid: String, error: LiveKitError)
 
-    /// Unsubscribed from a ``RemoteTrackPublication`` and  is no longer available.
-    ///
-    /// Clients should listen to this event and handle cleanup.
-    @objc(participant:didUnsubscribePublication:track:) optional
-    func participant(_ participant: RemoteParticipant, didUnsubscribe publication: RemoteTrackPublication, track: Track)
+    /// ``TrackPublication/streamState`` has updated for the ``RemoteTrackPublication``.
+    @objc(participant:publication:didUpdateStreamState:) optional
+    func participant(_ participant: RemoteParticipant, didUpdatePublication publication: RemoteTrackPublication, streamState: StreamState)
+
+    /// ``RemoteTrackPublication/subscriptionAllowed`` has updated for the ``RemoteTrackPublication``.
+    @objc(participant:publication:didUpdateCanSubscribe:) optional
+    func participant(_ participant: RemoteParticipant, didUpdatePublication publication: RemoteTrackPublication, isSubscriptionAllowed: Bool)
+
+    // MARK: - Data
 
     /// Data was received from a ``RemoteParticipant``.
     @objc(participant:didReceiveData:topic:) optional

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -34,7 +34,7 @@ import Foundation
 @objc
 public protocol RoomDelegate: AnyObject {
     @objc(room:didUpdateConnectionState:oldConnectionState:) optional
-    func room(_ room: Room, didUpdate connectionState: ConnectionState, oldValue oldConnectionState: ConnectionState)
+    func room(_ room: Room, didUpdateConnectionState connectionState: ConnectionState, oldConnectionState: ConnectionState)
 
     /// Successfully connected to the room.
     @objc(room:didConnectIsReconnect:) optional
@@ -42,12 +42,12 @@ public protocol RoomDelegate: AnyObject {
 
     /// Could not connect to the room.
     @objc(room:didFailToConnectWithError:) optional
-    func room(_ room: Room, didFailToConnect error: LiveKitError?)
+    func room(_ room: Room, didFailToConnectWithError error: LiveKitError?)
 
     /// Client disconnected from the room unexpectedly.
     /// Using ``room(_:didUpdate:oldValue:)`` is preferred since `.disconnected` state of ``ConnectionState`` provides ``DisconnectReason`` (Swift only).
     @objc(room:didDisconnectWithError:) optional
-    func room(_ room: Room, didDisconnect error: LiveKitError?)
+    func room(_ room: Room, didDisconnectWithError error: LiveKitError?)
 
     /// When a ``RemoteParticipant`` joins after the ``LocalParticipant``.
     /// It will not emit events for participants that are already in the room.
@@ -62,20 +62,20 @@ public protocol RoomDelegate: AnyObject {
     ///
     /// List of speakers are ordered by their ``Participant/audioLevel``, loudest speakers first.
     /// This will include the ``LocalParticipant`` too.
-    @objc(room:didUpdateSpeakers:) optional
-    func room(_ room: Room, didUpdate speakers: [Participant])
+    @objc(room:didUpdateSpeakingParticipants:) optional
+    func room(_ room: Room, didUpdateSpeakingParticipants participants: [Participant])
 
     /// ``Room``'s metadata has been updated.
     @objc(room:didUpdateMetadata:) optional
-    func room(_ room: Room, didUpdate metadata: String?)
+    func room(_ room: Room, didUpdateMetadata metadata: String?)
 
     /// ``Room``'s recording state has been updated.
     @objc(room:didUpdateIsRecording:) optional
-    func room(_ room: Room, didUpdate isRecording: Bool)
+    func room(_ room: Room, didUpdateIsRecording isRecording: Bool)
 
     /// Same with ``ParticipantDelegate/participant(_:didUpdate:)-46iut``.
     @objc(room:participant:didUpdateMetadata:) optional
-    func room(_ room: Room, participant: Participant, didUpdate metadata: String?)
+    func room(_ room: Room, participant: Participant, didUpdateMetadata: String?)
 
     /// Same with ``ParticipantDelegate/participant(_:didUpdateName:)``.
     @objc(room:participant:didUpdateName:) optional
@@ -83,14 +83,14 @@ public protocol RoomDelegate: AnyObject {
 
     /// Same with ``ParticipantDelegate/participant(_:didUpdate:)-7zxk1``.
     @objc(room:participant:didUpdateConnectionQuality:) optional
-    func room(_ room: Room, participant: Participant, didUpdate connectionQuality: ConnectionQuality)
+    func room(_ room: Room, participant: Participant, didUpdateConnectionQuality connectionQuality: ConnectionQuality)
 
     /// Same with ``ParticipantDelegate/participant(_:didUpdate:)-84m89``.
-    @objc(room:participant:publication:didUpdateMuted:) optional
-    func room(_ room: Room, participant: Participant, didUpdate publication: TrackPublication, muted: Bool)
+    @objc(room:participant:publication:didUpdateIsMuted:) optional
+    func room(_ room: Room, participant: Participant, didUpdatePublication publication: TrackPublication, isMuted: Bool)
 
     @objc(room:participant:didUpdatePermissions:) optional
-    func room(_ room: Room, participant: Participant, didUpdate permissions: ParticipantPermissions)
+    func room(_ room: Room, participant: Participant, didUpdatePermissions permissions: ParticipantPermissions)
 
     /// Same with ``ParticipantDelegate/participant(_:didUpdate:streamState:)-1lu8t``.
     @objc(room:participant:publication:didUpdateStreamState:) optional
@@ -98,23 +98,23 @@ public protocol RoomDelegate: AnyObject {
 
     /// Same with ``ParticipantDelegate/participant(_:didPublish:)-60en3``.
     @objc(room:participant:didPublishPublication:) optional
-    func room(_ room: Room, participant: RemoteParticipant, didPublish publication: RemoteTrackPublication)
+    func room(_ room: Room, participant: RemoteParticipant, didPublishPublication publication: RemoteTrackPublication)
 
     /// Same with ``ParticipantDelegate/participant(_:didUnpublish:)-3bkga``.
     @objc(room:participant:didUnpublishPublication:) optional
-    func room(_ room: Room, participant: RemoteParticipant, didUnpublish publication: RemoteTrackPublication)
+    func room(_ room: Room, participant: RemoteParticipant, didUnpublishPublication publication: RemoteTrackPublication)
 
     /// Same with ``ParticipantDelegate/participant(_:didSubscribe:track:)-7mngl``.
     @objc(room:participant:didSubscribePublication:track:) optional
-    func room(_ room: Room, participant: RemoteParticipant, didSubscribe publication: RemoteTrackPublication, track: Track)
+    func room(_ room: Room, participant: RemoteParticipant, didSubscribePublication publication: RemoteTrackPublication, track: Track)
 
     /// Same with ``ParticipantDelegate/participant(_:didFailToSubscribe:error:)-10pn4``.
     @objc optional
-    func room(_ room: Room, participant: RemoteParticipant, didFailToSubscribe trackSid: String, error: Error)
+    func room(_ room: Room, participant: RemoteParticipant, didFailToSubscribe trackSid: String, error: LiveKitError)
 
     /// Same with ``ParticipantDelegate/participant(_:didUnsubscribe:track:)-3ksvp``.
     @objc(room:publication:didUnsubscribePublication:track:) optional
-    func room(_ room: Room, participant: RemoteParticipant, didUnsubscribe publication: RemoteTrackPublication, track: Track)
+    func room(_ room: Room, participant: RemoteParticipant, didUnsubscribePublication publication: RemoteTrackPublication, track: Track)
 
     /// Same with ``ParticipantDelegate/participant(_:didReceive:)-2t55a``
     /// participant could be nil if data was sent by server api.
@@ -123,17 +123,17 @@ public protocol RoomDelegate: AnyObject {
 
     /// Same with ``ParticipantDelegate/localParticipant(_:didPublish:)-90j2m``.
     @objc(room:localParticipant:didPublishPublication:) optional
-    func room(_ room: Room, localParticipant: LocalParticipant, didPublish publication: LocalTrackPublication)
+    func room(_ room: Room, localParticipant: LocalParticipant, didPublishPublication publication: LocalTrackPublication)
 
     /// Same with ``ParticipantDelegate/participant(_:didUnpublish:)-3bkga``.
     @objc(room:localParticipant:didUnpublishPublication:) optional
-    func room(_ room: Room, localParticipant: LocalParticipant, didUnpublish publication: LocalTrackPublication)
+    func room(_ room: Room, localParticipant: LocalParticipant, didUnpublishPublication publication: LocalTrackPublication)
 
     /// Same with ``ParticipantDelegate/participant(_:didUpdate:permission:)``.
     @objc optional
-    func room(_ room: Room, participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, permission allowed: Bool)
+    func room(_ room: Room, participant: RemoteParticipant, didUpdatePublication publication: RemoteTrackPublication, isSubscriptionAllowed: Bool)
 
     /// ``Room``'e2ee state has been updated.
     @objc(room:publication:didUpdateE2EEState:) optional
-    func room(_ room: Room, publication: TrackPublication, didUpdateE2EEState: E2EEState)
+    func room(_ room: Room, publication: TrackPublication, didUpdateE2EEState e2eeState: E2EEState)
 }

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -47,7 +47,6 @@ public protocol RoomDelegate: AnyObject {
     func room(_ room: Room, didFailToConnectWithError error: LiveKitError?)
 
     /// Client disconnected from the room unexpectedly.
-    /// Using ``room(_:didUpdate:oldValue:)`` is preferred since `.disconnected` state of ``ConnectionState`` provides ``DisconnectReason`` (Swift only).
     @objc(room:didDisconnectWithError:) optional
     func room(_ room: Room, didDisconnectWithError error: LiveKitError?)
 
@@ -77,7 +76,7 @@ public protocol RoomDelegate: AnyObject {
     @objc(room:didUpdateSpeakingParticipants:) optional
     func room(_ room: Room, didUpdateSpeakingParticipants participants: [Participant])
 
-    /// Same with ``ParticipantDelegate/participant(_:didUpdate:)-46iut``.
+    /// Same with ``ParticipantDelegate/participant(_:didUpdateMetadata:)``.
     @objc(room:participant:didUpdateMetadata:) optional
     func room(_ room: Room, participant: Participant, didUpdateMetadata: String?)
 
@@ -85,11 +84,11 @@ public protocol RoomDelegate: AnyObject {
     @objc(room:participant:didUpdateName:) optional
     func room(_ room: Room, participant: Participant, didUpdateName: String?)
 
-    /// Same with ``ParticipantDelegate/participant(_:didUpdate:)-7zxk1``.
+    /// Same with ``ParticipantDelegate/participant(_:didUpdateConnectionQuality:)``.
     @objc(room:participant:didUpdateConnectionQuality:) optional
     func room(_ room: Room, participant: Participant, didUpdateConnectionQuality connectionQuality: ConnectionQuality)
 
-    /// Same with ``ParticipantDelegate/participant(_:didUpdate:)-84m89``.
+    /// Same with ``ParticipantDelegate/participant(_:didUpdatePublication:isMuted:)``.
     @objc(room:participant:publication:didUpdateIsMuted:) optional
     func room(_ room: Room, participant: Participant, didUpdatePublication publication: TrackPublication, isMuted: Bool)
 
@@ -98,47 +97,47 @@ public protocol RoomDelegate: AnyObject {
 
     // MARK: - LocalTrackPublication
 
-    /// Same with ``ParticipantDelegate/localParticipant(_:didPublish:)-90j2m``.
+    /// Same with ``ParticipantDelegate/localParticipant(_:didPublishPublication:)``.
     @objc(room:localParticipant:didPublishPublication:) optional
     func room(_ room: Room, localParticipant: LocalParticipant, didPublishPublication publication: LocalTrackPublication)
 
-    /// Same with ``ParticipantDelegate/participant(_:didUnpublish:)-3bkga``.
+    /// Same with ``ParticipantDelegate/localParticipant(_:didUnpublishPublication:)``.
     @objc(room:localParticipant:didUnpublishPublication:) optional
     func room(_ room: Room, localParticipant: LocalParticipant, didUnpublishPublication publication: LocalTrackPublication)
 
     // MARK: - RemoteTrackPublication
 
-    /// Same with ``ParticipantDelegate/participant(_:didPublish:)-60en3``.
+    /// Same with ``ParticipantDelegate/participant(_:didPublishPublication:)``.
     @objc(room:participant:didPublishPublication:) optional
     func room(_ room: Room, participant: RemoteParticipant, didPublishPublication publication: RemoteTrackPublication)
 
-    /// Same with ``ParticipantDelegate/participant(_:didUnpublish:)-3bkga``.
+    /// Same with ``ParticipantDelegate/participant(_:didUnpublishPublication:)``.
     @objc(room:participant:didUnpublishPublication:) optional
     func room(_ room: Room, participant: RemoteParticipant, didUnpublishPublication publication: RemoteTrackPublication)
 
-    /// Same with ``ParticipantDelegate/participant(_:didSubscribe:track:)-7mngl``.
+    /// Same with ``ParticipantDelegate/participant(_:didSubscribePublication:)``.
     @objc(room:participant:didSubscribePublication:) optional
     func room(_ room: Room, participant: RemoteParticipant, didSubscribePublication publication: RemoteTrackPublication)
 
-    /// Same with ``ParticipantDelegate/participant(_:didUnsubscribe:track:)-3ksvp``.
+    /// Same with ``ParticipantDelegate/participant(_:didUnsubscribePublication:)``.
     @objc(room:publication:didUnsubscribePublication:) optional
     func room(_ room: Room, participant: RemoteParticipant, didUnsubscribePublication publication: RemoteTrackPublication)
 
-    /// Same with ``ParticipantDelegate/participant(_:didUpdate:streamState:)-1lu8t``.
+    /// Same with ``ParticipantDelegate/participant(_:didUpdatePublication:streamState:)``.
     @objc(room:participant:publication:didUpdateStreamState:) optional
     func room(_ room: Room, participant: RemoteParticipant, didUpdatePublication publication: RemoteTrackPublication, streamState: StreamState)
 
-    /// Same with ``ParticipantDelegate/participant(_:didUpdate:permission:)``.
+    /// Same with ``ParticipantDelegate/participant(_:didUpdatePublication:isSubscriptionAllowed:)``.
     @objc optional
     func room(_ room: Room, participant: RemoteParticipant, didUpdatePublication publication: RemoteTrackPublication, isSubscriptionAllowed: Bool)
 
-    /// Same with ``ParticipantDelegate/participant(_:didFailToSubscribe:error:)-10pn4``.
+    /// Same with ``ParticipantDelegate/participant(_:didFailToSubscribe:error:)``.
     @objc optional
     func room(_ room: Room, participant: RemoteParticipant, didFailToSubscribe trackSid: String, error: LiveKitError)
 
     // MARK: - Data
 
-    /// Same with ``ParticipantDelegate/participant(_:didReceive:)-2t55a``
+    /// Same with ``ParticipantDelegate/participant(_:didReceiveData:topic:)``
     /// participant could be nil if data was sent by server api.
     @objc(room:participant:didReceiveData:topic:) optional
     func room(_ room: Room, participant: RemoteParticipant?, didReceiveData data: Data, topic: String)

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -33,6 +33,8 @@ import Foundation
 /// See the source code of [Swift Example App](https://github.com/livekit/client-example-swift) for more examples.
 @objc
 public protocol RoomDelegate: AnyObject {
+    // MARK: - Room
+
     @objc(room:didUpdateConnectionState:oldConnectionState:) optional
     func room(_ room: Room, didUpdateConnectionState connectionState: ConnectionState, oldConnectionState: ConnectionState)
 
@@ -49,6 +51,16 @@ public protocol RoomDelegate: AnyObject {
     @objc(room:didDisconnectWithError:) optional
     func room(_ room: Room, didDisconnectWithError error: LiveKitError?)
 
+    /// ``Room``'s metadata has been updated.
+    @objc(room:didUpdateMetadata:) optional
+    func room(_ room: Room, didUpdateMetadata metadata: String?)
+
+    /// ``Room``'s recording state has been updated.
+    @objc(room:didUpdateIsRecording:) optional
+    func room(_ room: Room, didUpdateIsRecording isRecording: Bool)
+
+    // MARK: - Participant
+
     /// When a ``RemoteParticipant`` joins after the ``LocalParticipant``.
     /// It will not emit events for participants that are already in the room.
     @objc(room:participantDidJoin:) optional
@@ -64,14 +76,6 @@ public protocol RoomDelegate: AnyObject {
     /// This will include the ``LocalParticipant`` too.
     @objc(room:didUpdateSpeakingParticipants:) optional
     func room(_ room: Room, didUpdateSpeakingParticipants participants: [Participant])
-
-    /// ``Room``'s metadata has been updated.
-    @objc(room:didUpdateMetadata:) optional
-    func room(_ room: Room, didUpdateMetadata metadata: String?)
-
-    /// ``Room``'s recording state has been updated.
-    @objc(room:didUpdateIsRecording:) optional
-    func room(_ room: Room, didUpdateIsRecording isRecording: Bool)
 
     /// Same with ``ParticipantDelegate/participant(_:didUpdate:)-46iut``.
     @objc(room:participant:didUpdateMetadata:) optional
@@ -92,9 +96,17 @@ public protocol RoomDelegate: AnyObject {
     @objc(room:participant:didUpdatePermissions:) optional
     func room(_ room: Room, participant: Participant, didUpdatePermissions permissions: ParticipantPermissions)
 
-    /// Same with ``ParticipantDelegate/participant(_:didUpdate:streamState:)-1lu8t``.
-    @objc(room:participant:publication:didUpdateStreamState:) optional
-    func room(_ room: Room, participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, streamState: StreamState)
+    // MARK: - LocalTrackPublication
+
+    /// Same with ``ParticipantDelegate/localParticipant(_:didPublish:)-90j2m``.
+    @objc(room:localParticipant:didPublishPublication:) optional
+    func room(_ room: Room, localParticipant: LocalParticipant, didPublishPublication publication: LocalTrackPublication)
+
+    /// Same with ``ParticipantDelegate/participant(_:didUnpublish:)-3bkga``.
+    @objc(room:localParticipant:didUnpublishPublication:) optional
+    func room(_ room: Room, localParticipant: LocalParticipant, didUnpublishPublication publication: LocalTrackPublication)
+
+    // MARK: - RemoteTrackPublication
 
     /// Same with ``ParticipantDelegate/participant(_:didPublish:)-60en3``.
     @objc(room:participant:didPublishPublication:) optional
@@ -105,33 +117,33 @@ public protocol RoomDelegate: AnyObject {
     func room(_ room: Room, participant: RemoteParticipant, didUnpublishPublication publication: RemoteTrackPublication)
 
     /// Same with ``ParticipantDelegate/participant(_:didSubscribe:track:)-7mngl``.
-    @objc(room:participant:didSubscribePublication:track:) optional
-    func room(_ room: Room, participant: RemoteParticipant, didSubscribePublication publication: RemoteTrackPublication, track: Track)
+    @objc(room:participant:didSubscribePublication:) optional
+    func room(_ room: Room, participant: RemoteParticipant, didSubscribePublication publication: RemoteTrackPublication)
+
+    /// Same with ``ParticipantDelegate/participant(_:didUnsubscribe:track:)-3ksvp``.
+    @objc(room:publication:didUnsubscribePublication:) optional
+    func room(_ room: Room, participant: RemoteParticipant, didUnsubscribePublication publication: RemoteTrackPublication)
+
+    /// Same with ``ParticipantDelegate/participant(_:didUpdate:streamState:)-1lu8t``.
+    @objc(room:participant:publication:didUpdateStreamState:) optional
+    func room(_ room: Room, participant: RemoteParticipant, didUpdatePublication publication: RemoteTrackPublication, streamState: StreamState)
+
+    /// Same with ``ParticipantDelegate/participant(_:didUpdate:permission:)``.
+    @objc optional
+    func room(_ room: Room, participant: RemoteParticipant, didUpdatePublication publication: RemoteTrackPublication, isSubscriptionAllowed: Bool)
 
     /// Same with ``ParticipantDelegate/participant(_:didFailToSubscribe:error:)-10pn4``.
     @objc optional
     func room(_ room: Room, participant: RemoteParticipant, didFailToSubscribe trackSid: String, error: LiveKitError)
 
-    /// Same with ``ParticipantDelegate/participant(_:didUnsubscribe:track:)-3ksvp``.
-    @objc(room:publication:didUnsubscribePublication:track:) optional
-    func room(_ room: Room, participant: RemoteParticipant, didUnsubscribePublication publication: RemoteTrackPublication, track: Track)
+    // MARK: - Data
 
     /// Same with ``ParticipantDelegate/participant(_:didReceive:)-2t55a``
     /// participant could be nil if data was sent by server api.
     @objc(room:participant:didReceiveData:topic:) optional
     func room(_ room: Room, participant: RemoteParticipant?, didReceiveData data: Data, topic: String)
 
-    /// Same with ``ParticipantDelegate/localParticipant(_:didPublish:)-90j2m``.
-    @objc(room:localParticipant:didPublishPublication:) optional
-    func room(_ room: Room, localParticipant: LocalParticipant, didPublishPublication publication: LocalTrackPublication)
-
-    /// Same with ``ParticipantDelegate/participant(_:didUnpublish:)-3bkga``.
-    @objc(room:localParticipant:didUnpublishPublication:) optional
-    func room(_ room: Room, localParticipant: LocalParticipant, didUnpublishPublication publication: LocalTrackPublication)
-
-    /// Same with ``ParticipantDelegate/participant(_:didUpdate:permission:)``.
-    @objc optional
-    func room(_ room: Room, participant: RemoteParticipant, didUpdatePublication publication: RemoteTrackPublication, isSubscriptionAllowed: Bool)
+    // MARK: - E2EE
 
     /// ``Room``'e2ee state has been updated.
     @objc(room:publication:didUpdateE2EEState:) optional

--- a/Sources/LiveKit/TrackPublications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/RemoteTrackPublication.swift
@@ -144,7 +144,7 @@ public class RemoteTrackPublication: TrackPublication {
 
             if let oldValue, newValue == nil, let participant = participant as? RemoteParticipant {
                 participant.delegates.notify(label: { "participant.didUnsubscribe \(self)" }) {
-                    $0.participant?(participant, didUnsubscribe: self, track: oldValue)
+                    $0.participant?(participant, didUnsubscribePublication: self)
                 }
                 participant.room.delegates.notify(label: { "room.didUnsubscribe \(self)" }) {
                     $0.room?(participant.room, participant: participant, didUnsubscribePublication: self)
@@ -193,10 +193,10 @@ extension RemoteTrackPublication {
 
         // if track exists, track will emit the following events
         if track == nil {
-            participant.delegates.notify(label: { "participant.didUpdate muted: \(newValue)" }) {
-                $0.participant?(participant, didUpdate: self, muted: newValue)
+            participant.delegates.notify(label: { "participant.didUpdatePublication isMuted: \(newValue)" }) {
+                $0.participant?(participant, didUpdatePublication: self, isMuted: newValue)
             }
-            participant.room.delegates.notify(label: { "room.didUpdate muted: \(newValue)" }) {
+            participant.room.delegates.notify(label: { "room.didUpdatePublication isMuted: \(newValue)" }) {
                 $0.room?(participant.room, participant: participant, didUpdatePublication: self, isMuted: newValue)
             }
         }
@@ -208,7 +208,7 @@ extension RemoteTrackPublication {
 
         guard let participant = participant as? RemoteParticipant else { return }
         participant.delegates.notify(label: { "participant.didUpdate permission: \(newValue)" }) {
-            $0.participant?(participant, didUpdate: self, permission: newValue)
+            $0.participant?(participant, didUpdatePublication: self, isSubscriptionAllowed: newValue)
         }
         participant.room.delegates.notify(label: { "room.didUpdate permission: \(newValue)" }) {
             $0.room?(participant.room, participant: participant, didUpdatePublication: self, isSubscriptionAllowed: newValue)

--- a/Sources/LiveKit/TrackPublications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/RemoteTrackPublication.swift
@@ -147,7 +147,7 @@ public class RemoteTrackPublication: TrackPublication {
                     $0.participant?(participant, didUnsubscribe: self, track: oldValue)
                 }
                 participant.room.delegates.notify(label: { "room.didUnsubscribe \(self)" }) {
-                    $0.room?(participant.room, participant: participant, didUnsubscribe: self, track: oldValue)
+                    $0.room?(participant.room, participant: participant, didUnsubscribePublication: self, track: oldValue)
                 }
             }
         }
@@ -197,7 +197,7 @@ extension RemoteTrackPublication {
                 $0.participant?(participant, didUpdate: self, muted: newValue)
             }
             participant.room.delegates.notify(label: { "room.didUpdate muted: \(newValue)" }) {
-                $0.room?(participant.room, participant: participant, didUpdate: self, muted: newValue)
+                $0.room?(participant.room, participant: participant, didUpdatePublication: self, isMuted: newValue)
             }
         }
     }
@@ -211,7 +211,7 @@ extension RemoteTrackPublication {
             $0.participant?(participant, didUpdate: self, permission: newValue)
         }
         participant.room.delegates.notify(label: { "room.didUpdate permission: \(newValue)" }) {
-            $0.room?(participant.room, participant: participant, didUpdate: self, permission: newValue)
+            $0.room?(participant.room, participant: participant, didUpdatePublication: self, isSubscriptionAllowed: newValue)
         }
     }
 }

--- a/Sources/LiveKit/TrackPublications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/RemoteTrackPublication.swift
@@ -147,7 +147,7 @@ public class RemoteTrackPublication: TrackPublication {
                     $0.participant?(participant, didUnsubscribe: self, track: oldValue)
                 }
                 participant.room.delegates.notify(label: { "room.didUnsubscribe \(self)" }) {
-                    $0.room?(participant.room, participant: participant, didUnsubscribePublication: self, track: oldValue)
+                    $0.room?(participant.room, participant: participant, didUnsubscribePublication: self)
                 }
             }
         }

--- a/Sources/LiveKit/TrackPublications/TrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/TrackPublication.swift
@@ -135,7 +135,7 @@ public class TrackPublication: NSObject, ObservableObject, Loggable {
                         $0.participant?(participant, didUpdate: trackPublication, streamState: newState.streamState)
                     }
                     participant.room.delegates.notify(label: { "room.didUpdate \(trackPublication) streamState: \(newState.streamState)" }) {
-                        $0.room?(participant.room, participant: participant, didUpdate: trackPublication, streamState: newState.streamState)
+                        $0.room?(participant.room, participant: participant, didUpdatePublication: trackPublication, streamState: newState.streamState)
                     }
                 }
             }

--- a/Sources/LiveKit/TrackPublications/TrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/TrackPublication.swift
@@ -132,7 +132,7 @@ public class TrackPublication: NSObject, ObservableObject, Loggable {
             if newState.streamState != oldState.streamState {
                 if let participant = self.participant as? RemoteParticipant, let trackPublication = self as? RemoteTrackPublication {
                     participant.delegates.notify(label: { "participant.didUpdate \(trackPublication) streamState: \(newState.streamState)" }) {
-                        $0.participant?(participant, didUpdate: trackPublication, streamState: newState.streamState)
+                        $0.participant?(participant, didUpdatePublication: trackPublication, streamState: newState.streamState)
                     }
                     participant.room.delegates.notify(label: { "room.didUpdate \(trackPublication) streamState: \(newState.streamState)" }) {
                         $0.room?(participant.room, participant: participant, didUpdatePublication: trackPublication, streamState: newState.streamState)
@@ -216,7 +216,7 @@ extension TrackPublication: TrackDelegateInternal {
             }
 
             participant.delegates.notify {
-                $0.participant?(participant, didUpdate: self, muted: muted)
+                $0.participant?(participant, didUpdatePublication: self, isMuted: muted)
             }
             participant.room.delegates.notify {
                 $0.room?(participant.room, participant: participant, didUpdatePublication: self, isMuted: self.muted)

--- a/Sources/LiveKit/TrackPublications/TrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/TrackPublication.swift
@@ -219,7 +219,7 @@ extension TrackPublication: TrackDelegateInternal {
                 $0.participant?(participant, didUpdate: self, muted: muted)
             }
             participant.room.delegates.notify {
-                $0.room?(participant.room, participant: participant, didUpdate: self, muted: self.muted)
+                $0.room?(participant.room, participant: participant, didUpdatePublication: self, isMuted: self.muted)
             }
 
             // TrackPublication.muted is a computed property depending on Track.muted


### PR DESCRIPTION
A few delegates had the same signatures (by using overloading) such as:

`room(_ room: Room, didUpdate speakers: [Participant])`
`room(_ room: Room, didUpdate metadata: String?)`
`room(_ room: Room, didUpdate isRecording: Bool)`

This pattern will break if add another method of the same type will be added in the future:
`room(_ room: Room, didUpdate isSomeExampleFlag: Bool)`

Additionally, since labels can be omitted in Swift, the implementation side can be ambiguous:
```Swift
func room(_: Room, didUpdate _: String?) {
  // ...
}

func room(_: Room, didUpdate _: Bool) {
  // ...
}
```

This PR makes delegate signatures explicit and future-proof by including the label in the signature:

`room(_ room: Room, didUpdateSpeakingParticipants participants: [Participant])`
`room(_ room: Room, didUpdateMetadata metadata: String?)`
`room(_ room: Room, didUpdateIsRecording isRecording: Bool)`

I can deprecate the old methods, but since this will be part of v2 release maybe it's not required to deprecate.