### PR TITLE
Deprecate old delegates

### DIFF
--- a/Sources/LiveKit/Protocols/ParticipantDelegate.swift
+++ b/Sources/LiveKit/Protocols/ParticipantDelegate.swift
@@ -36,7 +36,7 @@ public protocol ParticipantDelegate: AnyObject {
     /// A ``Participant``'s name has updated.
     /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.
     @objc optional
-    func participant(_ participant: Participant, didUpdateName name: String?)
+    func participant(_ participant: Participant, didUpdateName name: String)
 
     /// The isSpeaking status of a ``Participant`` has changed.
     /// `participant` Can be a ``LocalParticipant`` or a ``RemoteParticipant``.

--- a/Sources/LiveKit/Protocols/ParticipantDelegate.swift
+++ b/Sources/LiveKit/Protocols/ParticipantDelegate.swift
@@ -115,4 +115,91 @@ public protocol ParticipantDelegate: AnyObject {
     /// Data was received from a ``RemoteParticipant``.
     @objc optional
     func participant(_ participant: RemoteParticipant, didReceiveData data: Data, forTopic topic: String)
+
+    // MARK: - Deprecated
+
+    /// Renamed to ``ParticipantDelegate/participant(_:didUpdateMetadata:)``.
+    @available(*, unavailable, renamed: "participant(_:didUpdateMetadata:)")
+    @objc(participant:didUpdateMetadata_:) optional
+    func participant(_ participant: Participant, didUpdate metadata: String?)
+
+    // Renamed to ``ParticipantDelegate/participant(_:didUpdateName:)``.
+    // @available(*, unavailable, renamed: "participant(_:didUpdateName:)")
+    // @objc(participant:didUpdateName_:) optional
+    // func participant(_ participant: Participant, didUpdateName: String)
+
+    /// Renamed to ``ParticipantDelegate/participant(_:didUpdateIsSpeaking:)``.
+    @available(*, unavailable, renamed: "participant(_:didUpdateIsSpeaking:)")
+    @objc(participant:didUpdateSpeaking:) optional
+    func participant(_ participant: Participant, didUpdate speaking: Bool)
+
+    /// Renamed to ``ParticipantDelegate/participant(_:didUpdateConnectionQuality:)``.
+    @available(*, unavailable, renamed: "participant(_:didUpdateConnectionQuality:)")
+    @objc(participant:didUpdateConnectionQuality_:) optional
+    func participant(_ participant: Participant, didUpdate connectionQuality: ConnectionQuality)
+
+    /// Renamed to ``ParticipantDelegate/participant(_:track:didUpdateIsMuted:)``.
+    @available(*, unavailable, renamed: "participant(_:track:didUpdateIsMuted:)")
+    @objc(participant:publication:didUpdateMuted:) optional
+    func participant(_ participant: Participant, didUpdate publication: TrackPublication, muted: Bool)
+
+    /// Renamed to ``ParticipantDelegate/participant(_:didUpdatePermissions:)``.
+    @available(*, unavailable, renamed: "participant(_:didUpdatePermissions:)")
+    @objc(participant:didUpdatePermissions_:) optional
+    func participant(_ participant: Participant, didUpdate permissions: ParticipantPermissions)
+
+    /// Renamed to ``ParticipantDelegate/participant(_:track:didUpdateStreamState:)``.
+    @available(*, unavailable, renamed: "participant(_:track:didUpdateStreamState:)")
+    @objc(participant:publication:didUpdateStreamState:) optional
+    func participant(_ participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, streamState: StreamState)
+
+    /// Renamed to ``ParticipantDelegate/participant(_:track:didUpdateIsSubscriptionAllowed:)``.
+    @available(*, unavailable, renamed: "participant(_:track:didUpdateIsSubscriptionAllowed:)")
+    @objc(participant:publication:didUpdateCanSubscribe:) optional
+    func participant(_ participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, permission allowed: Bool)
+
+    /// Renamed to ``ParticipantDelegate/participant(_:didPublishTrack:)-8e9iw``.
+    @available(*, unavailable, renamed: "participant(_:didPublishTrack:)")
+    @objc(remoteParticipant:didPublish:) optional
+    func participant(_ participant: RemoteParticipant, didPublish publication: RemoteTrackPublication)
+
+    /// Renamed to ``ParticipantDelegate/participant(_:didUnpublishTrack:)-1roup``.
+    @available(*, unavailable, renamed: "participant(_:didUnpublishTrack:)")
+    @objc(remoteParticipant:didUnpublish:) optional
+    func participant(_ participant: RemoteParticipant, didUnpublish publication: RemoteTrackPublication)
+
+    /// Renamed to ``ParticipantDelegate/participant(_:didPublishTrack:)-7emm``.
+    @available(*, unavailable, renamed: "participant(_:didPublishTrack:)")
+    @objc(localParticipant:didPublish:) optional
+    func localParticipant(_ participant: LocalParticipant, didPublish publication: LocalTrackPublication)
+
+    /// Renamed to ``ParticipantDelegate/participant(_:didUnpublishTrack:)-4pv3r``.
+    @available(*, unavailable, renamed: "participant(_:didUnpublishTrack:)")
+    @objc(localParticipant:didUnpublish:) optional
+    func localParticipant(_ participant: LocalParticipant, didUnpublish publication: LocalTrackPublication)
+
+    /// Renamed to ``ParticipantDelegate/participant(_:didSubscribeTrack:)``.
+    @available(*, unavailable, renamed: "participant(_:didSubscribeTrack:)")
+    @objc(participant:didSubscribe:track:) optional
+    func participant(_ participant: RemoteParticipant, didSubscribe publication: RemoteTrackPublication, track: Track)
+
+    /// Renamed to ``ParticipantDelegate/participant(_:didFailToSubscribeTrack:withError:)``.
+    @available(*, unavailable, renamed: "participant(_:didFailToSubscribeTrack:withError:)")
+    @objc(participant:didFailToSubscribeTrackWithSid:error:) optional
+    func participant(_ participant: RemoteParticipant, didFailToSubscribe trackSid: String, error: Error)
+
+    /// Renamed to ``ParticipantDelegate/participant(_:didUnsubscribeTrack:)``.
+    @available(*, unavailable, renamed: "participant(_:didUnsubscribeTrack:)")
+    @objc(participant:didUnsubscribePublication:track:) optional
+    func participant(_ participant: RemoteParticipant, didUnsubscribe publication: RemoteTrackPublication, track: Track)
+
+    /// Renamed to ``ParticipantDelegate/participant(_:didReceiveData:forTopic:)``.
+    @available(*, unavailable, renamed: "participant(_:didReceiveData:forTopic:)")
+    @objc(participant:didReceiveData:) optional
+    func participant(_ participant: RemoteParticipant, didReceive data: Data)
+
+    /// Renamed to ``ParticipantDelegate/participant(_:didReceiveData:forTopic:)``.
+    @available(*, unavailable, renamed: "participant(_:didReceiveData:forTopic:)")
+    @objc(participant:didReceiveData:topic:) optional
+    func participant(_ participant: RemoteParticipant, didReceiveData data: Data, topic: String)
 }

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -93,7 +93,7 @@ public protocol RoomDelegate: AnyObject {
 
     /// ``Participant/name`` has updated.
     @objc optional
-    func room(_ room: Room, participant: Participant, didUpdateName: String?)
+    func room(_ room: Room, participant: Participant, didUpdateName: String)
 
     /// ``Participant/connectionQuality`` has updated.
     @objc optional
@@ -203,10 +203,10 @@ public protocol RoomDelegate: AnyObject {
     @objc(room:participant:didUpdateMetadata_:) optional
     func room(_ room: Room, participant: Participant, didUpdate metadata: String?)
 
-    /// Renamed to ``RoomDelegate/room(_:participant:didUpdateName:)``.
-    @available(*, unavailable, renamed: "room(_:participant:didUpdateName:)")
-    @objc(room:participant:didUpdateName_:) optional
-    func room(_ room: Room, participant: Participant, didUpdateName: String)
+    // Renamed to ``RoomDelegate/room(_:participant:didUpdateName:)``.
+    // @available(*, unavailable, renamed: "room(_:participant:didUpdateName:)")
+    // @objc(room:participant:didUpdateName_:) optional
+    // func room(_ room: Room, participant: Participant, didUpdateName: String)
 
     /// Renamed to ``RoomDelegate/room(_:participant:didUpdateConnectionQuality:)``.
     @available(*, unavailable, renamed: "room(_:participant:didUpdateConnectionQuality:)")

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -150,4 +150,136 @@ public protocol RoomDelegate: AnyObject {
     /// ``RemoteTrackPublication/isSubscriptionAllowed`` has updated.
     @objc optional
     func room(_ room: Room, participant: RemoteParticipant, track: RemoteTrackPublication, didUpdateIsSubscriptionAllowed isSubscriptionAllowed: Bool)
+
+    // MARK: - Deprecated
+
+    /// Renamed to ``RoomDelegate/room(_:didUpdateConnectionState:from:)``.
+    @available(*, unavailable, renamed: "room(_:didUpdateConnectionState:from:)")
+    @objc(room:didUpdateConnectionState:oldConnectionState:) optional
+    func room(_ room: Room, didUpdate connectionState: ConnectionState, oldValue: ConnectionState)
+
+    /// Renamed to ``RoomDelegate/roomDidConnect(_:)``.
+    @available(*, unavailable, renamed: "roomDidConnect(_:)")
+    @objc(room:didConnectIsReconnect:) optional
+    func room(_ room: Room, didConnect isReconnect: Bool)
+
+    /// Renamed to ``RoomDelegate/room(_:didFailToConnectWithError:)``.
+    @available(*, unavailable, renamed: "room(_:didFailToConnectWithError:)")
+    @objc optional
+    func room(_ room: Room, didFailToConnect error: Error)
+
+    /// Renamed to ``RoomDelegate/room(_:didDisconnectWithError:)``.
+    @available(*, unavailable, renamed: "room(_:didDisconnectWithError:)")
+    @objc optional
+    func room(_ room: Room, didDisconnect error: Error?)
+
+    /// Renamed to ``RoomDelegate/room(_:participantDidConnect:)``.
+    @available(*, unavailable, renamed: "room(_:participantDidConnect:)")
+    @objc(room:participantDidJoin:) optional
+    func room(_ room: Room, participantDidJoin participant: RemoteParticipant)
+
+    /// Renamed to ``RoomDelegate/room(_:participantDidDisconnect:)``.
+    @available(*, unavailable, renamed: "room(_:participantDidDisconnect:)")
+    @objc(room:participantDidLeave:) optional
+    func room(_ room: Room, participantDidLeave participant: RemoteParticipant)
+
+    /// Renamed to ``RoomDelegate/room(_:didUpdateSpeakingParticipants:)``.
+    @available(*, unavailable, renamed: "room(_:didUpdateSpeakingParticipants:)")
+    @objc(room:didUpdateSpeakers:) optional
+    func room(_ room: Room, didUpdate speakers: [Participant])
+
+    /// Renamed to ``RoomDelegate/room(_:didUpdateMetadata:)``.
+    @available(*, unavailable, renamed: "room(_:didUpdateMetadata:)")
+    @objc(room:didUpdateMetadata_:) optional
+    func room(_ room: Room, didUpdate metadata: String?)
+
+    /// Renamed to ``RoomDelegate/room(_:didUpdateIsRecording:)``.
+    @available(*, unavailable, renamed: "room(_:didUpdateIsRecording:)")
+    @objc(room:didUpdateIsRecording_:) optional
+    func room(_ room: Room, didUpdate isRecording: Bool)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:didUpdateMetadata:)``.
+    @available(*, unavailable, renamed: "room(_:participant:didUpdateMetadata:)")
+    @objc(room:participant:didUpdateMetadata_:) optional
+    func room(_ room: Room, participant: Participant, didUpdate metadata: String?)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:didUpdateName:)``.
+    @available(*, unavailable, renamed: "room(_:participant:didUpdateName:)")
+    @objc(room:participant:didUpdateName_:) optional
+    func room(_ room: Room, participant: Participant, didUpdateName: String)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:didUpdateConnectionQuality:)``.
+    @available(*, unavailable, renamed: "room(_:participant:didUpdateConnectionQuality:)")
+    @objc(room:participant:didUpdateConnectionQuality_:) optional
+    func room(_ room: Room, participant: Participant, didUpdate connectionQuality: ConnectionQuality)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:track:didUpdateIsMuted:)``.
+    @available(*, unavailable, renamed: "room(_:participant:track:didUpdateIsMuted:)")
+    @objc(room:participant:publication:didUpdateMuted:) optional
+    func room(_ room: Room, participant: Participant, didUpdate publication: TrackPublication, muted: Bool)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:didUpdatePermissions:)``.
+    @available(*, unavailable, renamed: "room(_:participant:didUpdatePermissions:)")
+    @objc(room:participant:didUpdatePermissions_:) optional
+    func room(_ room: Room, participant: Participant, didUpdate permissions: ParticipantPermissions)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:track:didUpdateStreamState:)``.
+    @available(*, unavailable, renamed: "room(_:participant:track:didUpdateStreamState:)")
+    @objc(room:participant:publication:didUpdateStreamState:) optional
+    func room(_ room: Room, participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, streamState: StreamState)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:didPublishTrack:)-418lx``.
+    @available(*, unavailable, renamed: "room(_:participant:didPublishTrack:)")
+    @objc(room:participant:didPublishPublication:) optional
+    func room(_ room: Room, participant: RemoteParticipant, didPublish publication: RemoteTrackPublication)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:didUnpublishTrack:)-1jsz8``.
+    @available(*, unavailable, renamed: "room(_:participant:didUnpublishTrack:)")
+    @objc(room:participant:didUnpublishPublication:) optional
+    func room(_ room: Room, participant: RemoteParticipant, didUnpublish publication: RemoteTrackPublication)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:didSubscribeTrack:)``.
+    @available(*, unavailable, renamed: "room(_:participant:didSubscribeTrack:)")
+    @objc(room:participant:didSubscribePublication:track:) optional
+    func room(_ room: Room, participant: RemoteParticipant, didSubscribe publication: RemoteTrackPublication, track: Track)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:didFailToSubscribeTrack:withError:)``.
+    @available(*, unavailable, renamed: "room(_:participant:didFailToSubscribeTrack:withError:)")
+    @objc optional
+    func room(_ room: Room, participant: RemoteParticipant, didFailToSubscribe trackSid: String, error: Error)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:didUnsubscribeTrack:)``.
+    @available(*, unavailable, renamed: "room(_:participant:didUnsubscribeTrack:)")
+    @objc(room:publication:didUnsubscribePublication:track:) optional
+    func room(_ room: Room, participant: RemoteParticipant, didUnsubscribe publication: RemoteTrackPublication, track: Track)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:didReceiveData:forTopic:)``.
+    @available(*, unavailable, renamed: "room(_:participant:didReceiveData:forTopic:)")
+    @objc(room:participant:didReceiveData:) optional
+    func room(_ room: Room, participant: RemoteParticipant?, didReceive data: Data)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:didReceiveData:forTopic:)``.
+    @available(*, unavailable, renamed: "room(_:participant:didReceiveData:forTopic:)")
+    @objc(room:participant:didReceiveData:topic:) optional
+    func room(_ room: Room, participant: RemoteParticipant?, didReceiveData data: Data, topic: String)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:didPublishTrack:)-8xoph``.
+    @available(*, unavailable, renamed: "room(_:participant:didPublishTrack:)")
+    @objc(room:localParticipant:didPublishPublication:) optional
+    func room(_ room: Room, localParticipant: LocalParticipant, didPublish publication: LocalTrackPublication)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:didUnpublishTrack:)-4r2nn``.
+    @available(*, unavailable, renamed: "room(_:participant:didUnpublishTrack:)")
+    @objc(room:localParticipant:didUnpublishPublication:) optional
+    func room(_ room: Room, localParticipant: LocalParticipant, didUnpublish publication: LocalTrackPublication)
+
+    /// Renamed to ``RoomDelegate/room(_:participant:didUpdatePermissions:)``.
+    @available(*, unavailable, renamed: "room(_:participant:didUpdatePermissions:)")
+    @objc optional
+    func room(_ room: Room, participant: RemoteParticipant, didUpdate publication: RemoteTrackPublication, permission allowed: Bool)
+
+    /// Renamed to ``RoomDelegate/room(_:track:didUpdateE2EEState:)``.
+    @available(*, unavailable, renamed: "room(_:track:didUpdateE2EEState:)")
+    @objc(room:publication:didUpdateE2EEState:) optional
+    func room(_ room: Room, publication: TrackPublication, didUpdateE2EEState: E2EEState)
 }


### PR DESCRIPTION
Allow Xcode to warn renamed delegates.