### PR TITLE
fix: `RemoteParticipant`s properties already empty when `didDisconnect` delegate invoked

### DIFF
--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -153,6 +153,12 @@ public class Participant: NSObject, ObservableObject, Loggable {
     func cleanUp(notify _notify: Bool = true) async {
         await unpublishAll(notify: _notify)
         // Reset state
+        if let self = self as? RemoteParticipant {
+            // ...
+            room.delegates.notify(label: { "room.remoteParticipantDidDisconnect:" }) {
+                $0.room?(self.room, participantDidDisconnect: self)
+            }
+        }
         _state.mutate { $0 = State(sid: "", identity: "", name: "") }
     }
 

--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -154,8 +154,7 @@ public class Participant: NSObject, ObservableObject, Loggable {
         await unpublishAll(notify: _notify)
         // Reset state
         if let self = self as? RemoteParticipant {
-            // ...
-            room.delegates.notify(label: { "room.remoteParticipantDidDisconnect:" }) {
+            room.delegates.notify(label: { "room.participantDidDisconnect:" }) {
                 $0.room?(self.room, participantDidDisconnect: self)
             }
         }

--- a/Sources/LiveKit/Participant/RemoteParticipant.swift
+++ b/Sources/LiveKit/Participant/RemoteParticipant.swift
@@ -139,14 +139,6 @@ public class RemoteParticipant: Participant {
         }
     }
 
-    override func cleanUp(notify _notify: Bool = true) async {
-        await super.cleanUp(notify: _notify)
-
-        room.delegates.notify(label: { "room.remoteParticipantDidDisconnect:" }) {
-            $0.room?(self.room, participantDidDisconnect: self)
-        }
-    }
-
     override public func unpublishAll(notify _notify: Bool = true) async {
         // Build a list of Publications
         let publications = _state.trackPublications.values.compactMap { $0 as? RemoteTrackPublication }


### PR DESCRIPTION
Should fix: https://github.com/livekit/client-sdk-swift/issues/300#event-11465204583

Correct order should be:
1. Unpublish all remote tracks
2. Invoke delegate
3. Reset state (clear properties)