### PR TITLE
Fix SignalClient concurrency issues

### DIFF
--- a/Sources/LiveKit/Core/Engine+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Engine+SignalClientDelegate.swift
@@ -19,13 +19,13 @@ import Foundation
 @_implementationOnly import WebRTC
 
 extension Engine: SignalClientDelegate {
-    func signalClient(_: SignalClient, didMutateState state: SignalClient.State, oldState: SignalClient.State) {
+    func signalClient(_: SignalClient, didUpdateConnectionState connectionState: ConnectionState, oldState: ConnectionState, disconnectError: LiveKitError?) {
         // connectionState did update
-        if state.connectionState != oldState.connectionState,
+        if connectionState != oldState,
            // did disconnect
-           case .disconnected = state.connectionState,
+           case .disconnected = connectionState,
            // only attempt re-connect if disconnected(reason: network)
-           case .network = state.disconnectError?.type,
+           case .network = disconnectError?.type,
            // engine is currently connected state
            case .connected = _state.connectionState
         {

--- a/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
@@ -260,7 +260,7 @@ extension Room: SignalClientDelegate {
         }
     }
 
-    func signalClient(_: SignalClient, didMutateState _: SignalClient.State, oldState _: SignalClient.State) {}
+    func signalClient(_: SignalClient, didUpdateConnectionState _: ConnectionState, oldState _: ConnectionState, disconnectError _: LiveKitError?) {}
     func signalClient(_: SignalClient, didReceiveAnswer _: LKRTCSessionDescription) {}
     func signalClient(_: SignalClient, didReceiveOffer _: LKRTCSessionDescription) {}
     func signalClient(_: SignalClient, didReceiveIceCandidate _: LKRTCIceCandidate, target _: Livekit_SignalTarget) {}

--- a/Sources/LiveKit/Protocols/SignalClientDelegate.swift
+++ b/Sources/LiveKit/Protocols/SignalClientDelegate.swift
@@ -19,7 +19,7 @@ import Foundation
 @_implementationOnly import WebRTC
 
 protocol SignalClientDelegate: AnyObject {
-    func signalClient(_ signalClient: SignalClient, didMutateState state: SignalClient.State, oldState: SignalClient.State)
+    func signalClient(_ signalClient: SignalClient, didUpdateConnectionState newState: ConnectionState, oldState: ConnectionState, disconnectError: LiveKitError?)
     func signalClient(_ signalClient: SignalClient, didReceiveConnectResponse connectResponse: SignalClient.ConnectResponse)
     func signalClient(_ signalClient: SignalClient, didReceiveAnswer answer: LKRTCSessionDescription)
     func signalClient(_ signalClient: SignalClient, didReceiveOffer offer: LKRTCSessionDescription)


### PR DESCRIPTION
`SignalClient` is now an `actor`.