### PR TITLE
Invoke internal delegates in Task.detached

### DIFF
--- a/Sources/LiveKit/Core/Engine+TransportDelegate.swift
+++ b/Sources/LiveKit/Core/Engine+TransportDelegate.swift
@@ -19,7 +19,7 @@ import Foundation
 @_implementationOnly import WebRTC
 
 extension Engine: TransportDelegate {
-    func transport(_ transport: Transport, didUpdateState pcState: RTCPeerConnectionState) {
+    func transport(_ transport: Transport, didUpdateState pcState: RTCPeerConnectionState) async {
         log("target: \(transport.target), state: \(pcState)")
 
         // primary connected
@@ -35,25 +35,25 @@ extension Engine: TransportDelegate {
         if _state.connectionState == .connected {
             // Attempt re-connect if primary or publisher transport failed
             if transport.isPrimary || (_state.hasPublished && transport.target == .publisher), [.disconnected, .failed].contains(pcState) {
-                Task {
+                do {
                     try await startReconnect(reason: .transport)
+                } catch {
+                    log("Failed calling startReconnect, error: \(error)", .error)
                 }
             }
         }
     }
 
-    func transport(_ transport: Transport, didGenerateIceCandidate iceCandidate: LKRTCIceCandidate) {
-        Task {
-            do {
-                log("sending iceCandidate")
-                try await signalClient.sendCandidate(candidate: iceCandidate, target: transport.target)
-            } catch {
-                log("Failed to send iceCandidate", .error)
-            }
+    func transport(_ transport: Transport, didGenerateIceCandidate iceCandidate: LKRTCIceCandidate) async {
+        do {
+            log("sending iceCandidate")
+            try await signalClient.sendCandidate(candidate: iceCandidate, target: transport.target)
+        } catch {
+            log("Failed to send iceCandidate, error: \(error)", .error)
         }
     }
 
-    func transport(_ transport: Transport, didAddTrack track: LKRTCMediaStreamTrack, rtpReceiver: LKRTCRtpReceiver, streams: [LKRTCMediaStream]) {
+    func transport(_ transport: Transport, didAddTrack track: LKRTCMediaStreamTrack, rtpReceiver: LKRTCRtpReceiver, streams: [LKRTCMediaStream]) async {
         guard !streams.isEmpty else {
             log("Received onTrack with no streams!", .warning)
             return
@@ -66,30 +66,28 @@ extension Engine: TransportDelegate {
                     removeWhen: { state, _ in state.connectionState == .disconnected })
             { [weak self] in
                 guard let self else { return }
-                self.notify { $0.engine(self, didAddTrack: track, rtpReceiver: rtpReceiver, stream: streams.first!) }
+                self.notifyAsync { await $0.engine(self, didAddTrack: track, rtpReceiver: rtpReceiver, stream: streams.first!) }
             }
         }
     }
 
-    func transport(_ transport: Transport, didRemoveTrack track: LKRTCMediaStreamTrack) {
+    func transport(_ transport: Transport, didRemoveTrack track: LKRTCMediaStreamTrack) async {
         if transport.target == .subscriber {
-            notify { $0.engine(self, didRemoveTrack: track) }
+            notifyAsync { await $0.engine(self, didRemoveTrack: track) }
         }
     }
 
-    func transport(_ transport: Transport, didOpenDataChannel dataChannel: LKRTCDataChannel) {
+    func transport(_ transport: Transport, didOpenDataChannel dataChannel: LKRTCDataChannel) async {
         log("Server opened data channel \(dataChannel.label)(\(dataChannel.readyState))")
 
-        Task {
-            if subscriberPrimary, transport.target == .subscriber {
-                switch dataChannel.label {
-                case LKRTCDataChannel.labels.reliable: await subscriberDataChannel.set(reliable: dataChannel)
-                case LKRTCDataChannel.labels.lossy: await subscriberDataChannel.set(lossy: dataChannel)
-                default: log("Unknown data channel label \(dataChannel.label)", .warning)
-                }
+        if subscriberPrimary, transport.target == .subscriber {
+            switch dataChannel.label {
+            case LKRTCDataChannel.labels.reliable: await subscriberDataChannel.set(reliable: dataChannel)
+            case LKRTCDataChannel.labels.lossy: await subscriberDataChannel.set(lossy: dataChannel)
+            default: log("Unknown data channel label \(dataChannel.label)", .warning)
             }
         }
     }
 
-    func transportShouldNegotiate(_: Transport) {}
+    func transportShouldNegotiate(_: Transport) async {}
 }

--- a/Sources/LiveKit/Core/Engine.swift
+++ b/Sources/LiveKit/Core/Engine.swift
@@ -68,8 +68,8 @@ class Engine: MulticastDelegate<EngineDelegate> {
     lazy var subscriberDataChannel: DataChannelPairActor = .init(onDataPacket: { [weak self] dataPacket in
         guard let self else { return }
         switch dataPacket.value {
-        case let .speaker(update): self.notify { $0.engine(self, didUpdateSpeakers: update.speakers) }
-        case let .user(userPacket): self.notify { $0.engine(self, didReceiveUserPacket: userPacket) }
+        case let .speaker(update): self.notifyAsync { await $0.engine(self, didUpdateSpeakers: update.speakers) }
+        case let .user(userPacket): self.notifyAsync { await $0.engine(self, didReceiveUserPacket: userPacket) }
         default: return
         }
     })
@@ -102,7 +102,7 @@ class Engine: MulticastDelegate<EngineDelegate> {
                 self.log("connectionState: \(oldState.connectionState) -> \(newState.connectionState), reconnectMode: \(String(describing: newState.reconnectMode))")
             }
 
-            self.notify { $0.engine(self, didMutateState: newState, oldState: oldState) }
+            self.notifyAsync { await $0.engine(self, didMutateState: newState, oldState: oldState) }
 
             // execution control
             self._blockProcessQueue.async { [weak self] in

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -52,7 +52,7 @@ actor SignalClient: Loggable {
                 log("\(oldValue) -> \(connectionState)")
             }
 
-            _delegates.notify { $0.signalClient(self, didUpdateConnectionState: self.connectionState, oldState: oldValue, disconnectError: self.disconnectError) }
+            _delegates.notifyAsync { await $0.signalClient(self, didUpdateConnectionState: self.connectionState, oldState: oldValue, disconnectError: self.disconnectError) }
         }
     }
 
@@ -291,69 +291,69 @@ private extension SignalClient {
         case let .join(joinResponse):
             _lastJoinResponse = joinResponse
             restartPingTimer()
-            _delegates.notify { $0.signalClient(self, didReceiveConnectResponse: .join(joinResponse)) }
+            _delegates.notifyAsync { await $0.signalClient(self, didReceiveConnectResponse: .join(joinResponse)) }
             _connectResponseCompleter.resume(returning: .join(joinResponse))
 
         case let .reconnect(response):
             restartPingTimer()
-            _delegates.notify { $0.signalClient(self, didReceiveConnectResponse: .reconnect(response)) }
+            _delegates.notifyAsync { await $0.signalClient(self, didReceiveConnectResponse: .reconnect(response)) }
             _connectResponseCompleter.resume(returning: .reconnect(response))
 
         case let .answer(sd):
-            _delegates.notify { $0.signalClient(self, didReceiveAnswer: sd.toRTCType()) }
+            _delegates.notifyAsync { await $0.signalClient(self, didReceiveAnswer: sd.toRTCType()) }
 
         case let .offer(sd):
-            _delegates.notify { $0.signalClient(self, didReceiveOffer: sd.toRTCType()) }
+            _delegates.notifyAsync { await $0.signalClient(self, didReceiveOffer: sd.toRTCType()) }
 
         case let .trickle(trickle):
             guard let rtcCandidate = try? Engine.createIceCandidate(fromJsonString: trickle.candidateInit) else {
                 return
             }
 
-            _delegates.notify { $0.signalClient(self, didReceiveIceCandidate: rtcCandidate, target: trickle.target) }
+            _delegates.notifyAsync { await $0.signalClient(self, didReceiveIceCandidate: rtcCandidate, target: trickle.target) }
 
         case let .update(update):
-            _delegates.notify { $0.signalClient(self, didUpdateParticipants: update.participants) }
+            _delegates.notifyAsync { await $0.signalClient(self, didUpdateParticipants: update.participants) }
 
         case let .roomUpdate(update):
-            _delegates.notify { $0.signalClient(self, didUpdateRoom: update.room) }
+            _delegates.notifyAsync { await $0.signalClient(self, didUpdateRoom: update.room) }
 
         case let .trackPublished(trackPublished):
             // not required to be handled because we use completer pattern for this case
-            _delegates.notify { $0.signalClient(self, didPublishLocalTrack: trackPublished) }
+            _delegates.notifyAsync { await $0.signalClient(self, didPublishLocalTrack: trackPublished) }
 
             log("[publish] resolving completer for cid: \(trackPublished.cid)")
             // Complete
             await _addTrackCompleters.resume(returning: trackPublished.track, for: trackPublished.cid)
 
         case let .trackUnpublished(trackUnpublished):
-            _delegates.notify { $0.signalClient(self, didUnpublishLocalTrack: trackUnpublished) }
+            _delegates.notifyAsync { await $0.signalClient(self, didUnpublishLocalTrack: trackUnpublished) }
 
         case let .speakersChanged(speakers):
-            _delegates.notify { $0.signalClient(self, didUpdateSpeakers: speakers.speakers) }
+            _delegates.notifyAsync { await $0.signalClient(self, didUpdateSpeakers: speakers.speakers) }
 
         case let .connectionQuality(quality):
-            _delegates.notify { $0.signalClient(self, didUpdateConnectionQuality: quality.updates) }
+            _delegates.notifyAsync { await $0.signalClient(self, didUpdateConnectionQuality: quality.updates) }
 
         case let .mute(mute):
-            _delegates.notify { $0.signalClient(self, didUpdateRemoteMute: mute.sid, muted: mute.muted) }
+            _delegates.notifyAsync { await $0.signalClient(self, didUpdateRemoteMute: mute.sid, muted: mute.muted) }
 
         case let .leave(leave):
-            _delegates.notify { $0.signalClient(self, didReceiveLeave: leave.canReconnect, reason: leave.reason) }
+            _delegates.notifyAsync { await $0.signalClient(self, didReceiveLeave: leave.canReconnect, reason: leave.reason) }
 
         case let .streamStateUpdate(states):
-            _delegates.notify { $0.signalClient(self, didUpdateTrackStreamStates: states.streamStates) }
+            _delegates.notifyAsync { await $0.signalClient(self, didUpdateTrackStreamStates: states.streamStates) }
 
         case let .subscribedQualityUpdate(update):
-            _delegates.notify { $0.signalClient(self, didUpdateSubscribedCodecs: update.subscribedCodecs,
-                                                qualities: update.subscribedQualities,
-                                                forTrackSid: update.trackSid) }
+            _delegates.notifyAsync { await $0.signalClient(self, didUpdateSubscribedCodecs: update.subscribedCodecs,
+                                                           qualities: update.subscribedQualities,
+                                                           forTrackSid: update.trackSid) }
 
         case let .subscriptionPermissionUpdate(permissionUpdate):
-            _delegates.notify { $0.signalClient(self, didUpdateSubscriptionPermission: permissionUpdate) }
+            _delegates.notifyAsync { await $0.signalClient(self, didUpdateSubscriptionPermission: permissionUpdate) }
 
         case let .refreshToken(token):
-            _delegates.notify { $0.signalClient(self, didUpdateToken: token) }
+            _delegates.notifyAsync { await $0.signalClient(self, didUpdateToken: token) }
 
         case let .pong(r):
             onReceivedPong(r)

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -201,19 +201,18 @@ extension Transport {
 extension Transport: LKRTCPeerConnectionDelegate {
     func peerConnection(_: LKRTCPeerConnection, didChange state: RTCPeerConnectionState) {
         log("[Connect] Transport(\(target)) did update state: \(state.description)")
-        notify { $0.transport(self, didUpdateState: state) }
+        notifyAsync { await $0.transport(self, didUpdateState: state) }
     }
 
     func peerConnection(_: LKRTCPeerConnection,
                         didGenerate candidate: LKRTCIceCandidate)
     {
-        // log("Did generate ice candidates \(candidate) for \(target)")
-        notify { $0.transport(self, didGenerateIceCandidate: candidate) }
+        notifyAsync { await $0.transport(self, didGenerateIceCandidate: candidate) }
     }
 
     func peerConnectionShouldNegotiate(_: LKRTCPeerConnection) {
         log("ShouldNegotiate for \(target)")
-        notify { $0.transportShouldNegotiate(self) }
+        notifyAsync { await $0.transportShouldNegotiate(self) }
     }
 
     func peerConnection(_: LKRTCPeerConnection,
@@ -226,7 +225,7 @@ extension Transport: LKRTCPeerConnectionDelegate {
         }
 
         log("type: \(type(of: track)), track.id: \(track.trackId), streams: \(streams.map { "Stream(hash: \($0.hash), id: \($0.streamId), videoTracks: \($0.videoTracks.count), audioTracks: \($0.audioTracks.count))" })")
-        notify { $0.transport(self, didAddTrack: track, rtpReceiver: rtpReceiver, streams: streams) }
+        notifyAsync { await $0.transport(self, didAddTrack: track, rtpReceiver: rtpReceiver, streams: streams) }
     }
 
     func peerConnection(_: LKRTCPeerConnection,
@@ -238,12 +237,12 @@ extension Transport: LKRTCPeerConnectionDelegate {
         }
 
         log("didRemove track: \(track.trackId)")
-        notify { $0.transport(self, didRemoveTrack: track) }
+        notifyAsync { await $0.transport(self, didRemoveTrack: track) }
     }
 
     func peerConnection(_: LKRTCPeerConnection, didOpen dataChannel: LKRTCDataChannel) {
         log("Received data channel \(dataChannel.label) for \(target)")
-        notify { $0.transport(self, didOpenDataChannel: dataChannel) }
+        notifyAsync { await $0.transport(self, didOpenDataChannel: dataChannel) }
     }
 
     func peerConnection(_: LKRTCPeerConnection, didChange _: RTCIceConnectionState) {}

--- a/Sources/LiveKit/Protocols/EngineDelegate.swift
+++ b/Sources/LiveKit/Protocols/EngineDelegate.swift
@@ -19,9 +19,9 @@ import Foundation
 @_implementationOnly import WebRTC
 
 protocol EngineDelegate: AnyObject {
-    func engine(_ engine: Engine, didMutateState state: Engine.State, oldState: Engine.State)
-    func engine(_ engine: Engine, didUpdateSpeakers speakers: [Livekit_SpeakerInfo])
-    func engine(_ engine: Engine, didAddTrack track: LKRTCMediaStreamTrack, rtpReceiver: LKRTCRtpReceiver, stream: LKRTCMediaStream)
-    func engine(_ engine: Engine, didRemoveTrack track: LKRTCMediaStreamTrack)
-    func engine(_ engine: Engine, didReceiveUserPacket packet: Livekit_UserPacket)
+    func engine(_ engine: Engine, didMutateState state: Engine.State, oldState: Engine.State) async
+    func engine(_ engine: Engine, didUpdateSpeakers speakers: [Livekit_SpeakerInfo]) async
+    func engine(_ engine: Engine, didAddTrack track: LKRTCMediaStreamTrack, rtpReceiver: LKRTCRtpReceiver, stream: LKRTCMediaStream) async
+    func engine(_ engine: Engine, didRemoveTrack track: LKRTCMediaStreamTrack) async
+    func engine(_ engine: Engine, didReceiveUserPacket packet: Livekit_UserPacket) async
 }

--- a/Sources/LiveKit/Protocols/SignalClientDelegate.swift
+++ b/Sources/LiveKit/Protocols/SignalClientDelegate.swift
@@ -19,21 +19,21 @@ import Foundation
 @_implementationOnly import WebRTC
 
 protocol SignalClientDelegate: AnyObject {
-    func signalClient(_ signalClient: SignalClient, didUpdateConnectionState newState: ConnectionState, oldState: ConnectionState, disconnectError: LiveKitError?)
-    func signalClient(_ signalClient: SignalClient, didReceiveConnectResponse connectResponse: SignalClient.ConnectResponse)
-    func signalClient(_ signalClient: SignalClient, didReceiveAnswer answer: LKRTCSessionDescription)
-    func signalClient(_ signalClient: SignalClient, didReceiveOffer offer: LKRTCSessionDescription)
-    func signalClient(_ signalClient: SignalClient, didReceiveIceCandidate iceCandidate: LKRTCIceCandidate, target: Livekit_SignalTarget)
-    func signalClient(_ signalClient: SignalClient, didPublishLocalTrack localTrack: Livekit_TrackPublishedResponse)
-    func signalClient(_ signalClient: SignalClient, didUnpublishLocalTrack localTrack: Livekit_TrackUnpublishedResponse)
-    func signalClient(_ signalClient: SignalClient, didUpdateParticipants participants: [Livekit_ParticipantInfo])
-    func signalClient(_ signalClient: SignalClient, didUpdateRoom room: Livekit_Room)
-    func signalClient(_ signalClient: SignalClient, didUpdateSpeakers speakers: [Livekit_SpeakerInfo])
-    func signalClient(_ signalClient: SignalClient, didUpdateConnectionQuality connectionQuality: [Livekit_ConnectionQualityInfo])
-    func signalClient(_ signalClient: SignalClient, didUpdateRemoteMute trackSid: String, muted: Bool)
-    func signalClient(_ signalClient: SignalClient, didUpdateTrackStreamStates streamStates: [Livekit_StreamStateInfo])
-    func signalClient(_ signalClient: SignalClient, didUpdateSubscribedCodecs codecs: [Livekit_SubscribedCodec], qualities: [Livekit_SubscribedQuality], forTrackSid sid: String)
-    func signalClient(_ signalClient: SignalClient, didUpdateSubscriptionPermission permission: Livekit_SubscriptionPermissionUpdate)
-    func signalClient(_ signalClient: SignalClient, didUpdateToken token: String)
-    func signalClient(_ signalClient: SignalClient, didReceiveLeave canReconnect: Bool, reason: Livekit_DisconnectReason)
+    func signalClient(_ signalClient: SignalClient, didUpdateConnectionState newState: ConnectionState, oldState: ConnectionState, disconnectError: LiveKitError?) async
+    func signalClient(_ signalClient: SignalClient, didReceiveConnectResponse connectResponse: SignalClient.ConnectResponse) async
+    func signalClient(_ signalClient: SignalClient, didReceiveAnswer answer: LKRTCSessionDescription) async
+    func signalClient(_ signalClient: SignalClient, didReceiveOffer offer: LKRTCSessionDescription) async
+    func signalClient(_ signalClient: SignalClient, didReceiveIceCandidate iceCandidate: LKRTCIceCandidate, target: Livekit_SignalTarget) async
+    func signalClient(_ signalClient: SignalClient, didPublishLocalTrack localTrack: Livekit_TrackPublishedResponse) async
+    func signalClient(_ signalClient: SignalClient, didUnpublishLocalTrack localTrack: Livekit_TrackUnpublishedResponse) async
+    func signalClient(_ signalClient: SignalClient, didUpdateParticipants participants: [Livekit_ParticipantInfo]) async
+    func signalClient(_ signalClient: SignalClient, didUpdateRoom room: Livekit_Room) async
+    func signalClient(_ signalClient: SignalClient, didUpdateSpeakers speakers: [Livekit_SpeakerInfo]) async
+    func signalClient(_ signalClient: SignalClient, didUpdateConnectionQuality connectionQuality: [Livekit_ConnectionQualityInfo]) async
+    func signalClient(_ signalClient: SignalClient, didUpdateRemoteMute trackSid: String, muted: Bool) async
+    func signalClient(_ signalClient: SignalClient, didUpdateTrackStreamStates streamStates: [Livekit_StreamStateInfo]) async
+    func signalClient(_ signalClient: SignalClient, didUpdateSubscribedCodecs codecs: [Livekit_SubscribedCodec], qualities: [Livekit_SubscribedQuality], forTrackSid sid: String) async
+    func signalClient(_ signalClient: SignalClient, didUpdateSubscriptionPermission permission: Livekit_SubscriptionPermissionUpdate) async
+    func signalClient(_ signalClient: SignalClient, didUpdateToken token: String) async
+    func signalClient(_ signalClient: SignalClient, didReceiveLeave canReconnect: Bool, reason: Livekit_DisconnectReason) async
 }

--- a/Sources/LiveKit/Protocols/TransportDelegate.swift
+++ b/Sources/LiveKit/Protocols/TransportDelegate.swift
@@ -19,10 +19,10 @@ import Foundation
 @_implementationOnly import WebRTC
 
 protocol TransportDelegate: AnyObject {
-    func transport(_ transport: Transport, didUpdateState state: RTCPeerConnectionState)
-    func transport(_ transport: Transport, didGenerateIceCandidate iceCandidate: LKRTCIceCandidate)
-    func transport(_ transport: Transport, didOpenDataChannel dataChannel: LKRTCDataChannel)
-    func transport(_ transport: Transport, didAddTrack track: LKRTCMediaStreamTrack, rtpReceiver: LKRTCRtpReceiver, streams: [LKRTCMediaStream])
-    func transport(_ transport: Transport, didRemoveTrack track: LKRTCMediaStreamTrack)
-    func transportShouldNegotiate(_ transport: Transport)
+    func transport(_ transport: Transport, didUpdateState state: RTCPeerConnectionState) async
+    func transport(_ transport: Transport, didGenerateIceCandidate iceCandidate: LKRTCIceCandidate) async
+    func transport(_ transport: Transport, didOpenDataChannel dataChannel: LKRTCDataChannel) async
+    func transport(_ transport: Transport, didAddTrack track: LKRTCMediaStreamTrack, rtpReceiver: LKRTCRtpReceiver, streams: [LKRTCMediaStream]) async
+    func transport(_ transport: Transport, didRemoveTrack track: LKRTCMediaStreamTrack) async
+    func transportShouldNegotiate(_ transport: Transport) async
 }


### PR DESCRIPTION
Invoke internal delegates `TransportDelegate`, `SignalClientDelegate`, `EngineDelegate` in Task.detached context.