### PR TITLE
Rename `LiveKit` class to `LiveKitSDK`

### DIFF
--- a/Sources/LiveKit/Core/Engine.swift
+++ b/Sources/LiveKit/Core/Engine.swift
@@ -86,7 +86,7 @@ class Engine: MulticastDelegate<EngineDelegate> {
         super.init()
 
         // log sdk & os versions
-        log("sdk: \(LiveKit.version), os: \(String(describing: Utils.os()))(\(Utils.osVersionString())), modelId: \(String(describing: Utils.modelIdentifier() ?? "unknown"))")
+        log("sdk: \(LiveKitSDK.version), os: \(String(describing: Utils.os()))(\(Utils.osVersionString())), modelId: \(String(describing: Utils.modelIdentifier() ?? "unknown"))")
 
         signalClient.add(delegate: self)
         ConnectivityListener.shared.add(delegate: self)

--- a/Sources/LiveKit/LiveKit+DeviceHelpers.swift
+++ b/Sources/LiveKit/LiveKit+DeviceHelpers.swift
@@ -16,7 +16,7 @@
 
 import AVFoundation
 
-public extension LiveKit {
+public extension LiveKitSDK {
     /// Helper method to ensure authorization for video(camera) / audio(microphone) permissions in a single call.
     static func ensureDeviceAccess(for types: Set<AVMediaType>) async -> Bool {
         assert(!types.isEmpty, "Please specify at least 1 type")

--- a/Sources/LiveKit/LiveKit.swift
+++ b/Sources/LiveKit/LiveKit.swift
@@ -32,7 +32,7 @@ let logger = Logger(label: "LiveKitSDK")
 /// Download the [Multiplatform SwiftUI Example](https://github.com/livekit/multiplatform-swiftui-example)
 /// to try out the features.
 @objc
-public class LiveKit: NSObject {
+public class LiveKitSDK: NSObject {
     @objc(sdkVersion)
     public static let version = "2.0.0"
 

--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -173,7 +173,7 @@ class Utils {
             URLQueryItem(name: "access_token", value: token),
             URLQueryItem(name: "protocol", value: connectOptions.protocolVersion.description),
             URLQueryItem(name: "sdk", value: "swift"),
-            URLQueryItem(name: "version", value: LiveKit.version),
+            URLQueryItem(name: "version", value: LiveKitSDK.version),
             // Additional client info
             URLQueryItem(name: "os", value: String(describing: os())),
             URLQueryItem(name: "os_version", value: osVersionString()),


### PR DESCRIPTION
Workaround for Xcode prefixing bug.