### PR TITLE
Prefixed LiveKitWebRTC package & xcframework

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(name: "WebRTC", url: "https://github.com/livekit/webrtc-xcframework.git", .exact("114.5735.10")),
+        .package(name: "LiveKitWebRTC", url: "https://github.com/livekit/webrtc-xcframework.git", .branch("prefixed-package-name")),
         .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", .upToNextMajor(from: "1.25.2")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.5.3")),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
@@ -28,7 +28,7 @@ let package = Package(
             name: "LiveKit",
             dependencies: [
                 .target(name: "CHeaders"),
-                "WebRTC",
+                "LiveKitWebRTC",
                 "SwiftProtobuf",
                 .product(name: "Logging", package: "swift-log"),
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(name: "LiveKitWebRTC", url: "https://github.com/livekit/webrtc-xcframework.git", .branch("prefixed-package-name")),
+        .package(name: "LiveKitWebRTC", url: "https://github.com/livekit/webrtc-xcframework.git", .exact("114.5735.11")),
         .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", .upToNextMajor(from: "1.25.2")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.5.3")),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),

--- a/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
+++ b/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
@@ -22,7 +22,7 @@
         import UIKit
     #endif
 
-    @_implementationOnly import WebRTC
+    @_implementationOnly import LiveKitWebRTC
 
     class BroadcastScreenCapturer: BufferCapturer {
         static let kRTCScreensharingSocketFD = "rtc_SSFD"

--- a/Sources/LiveKit/Broadcast/SocketConnectionFrameReader.swift
+++ b/Sources/LiveKit/Broadcast/SocketConnectionFrameReader.swift
@@ -18,7 +18,7 @@ import CoreImage
 import CoreVideo
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 private class Message {
     // Initializing a CIContext object is costly, so we use a singleton instead

--- a/Sources/LiveKit/Core/DataChannelPairActor.swift
+++ b/Sources/LiveKit/Core/DataChannelPairActor.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 actor DataChannelPairActor: NSObject, Loggable {
     // MARK: - Types

--- a/Sources/LiveKit/Core/Engine+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Engine+SignalClientDelegate.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 extension Engine: SignalClientDelegate {
     func signalClient(_ signalClient: SignalClient, didUpdateConnectionState connectionState: ConnectionState, oldState: ConnectionState, disconnectError: LiveKitError?) async {

--- a/Sources/LiveKit/Core/Engine+TransportDelegate.swift
+++ b/Sources/LiveKit/Core/Engine+TransportDelegate.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 extension RTCPeerConnectionState {
     var isConnected: Bool {

--- a/Sources/LiveKit/Core/Engine+WebRTC.swift
+++ b/Sources/LiveKit/Core/Engine+WebRTC.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 private extension Array where Element: LKRTCVideoCodecInfo {
     func rewriteCodecsIfNeeded() -> [LKRTCVideoCodecInfo] {

--- a/Sources/LiveKit/Core/Engine.swift
+++ b/Sources/LiveKit/Core/Engine.swift
@@ -20,7 +20,7 @@ import Foundation
     import Network
 #endif
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 class Engine: Loggable {
     // MARK: - Public

--- a/Sources/LiveKit/Core/Room+EngineDelegate.swift
+++ b/Sources/LiveKit/Core/Room+EngineDelegate.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 extension Room: EngineDelegate {
     func engine(_: Engine, didMutateState state: Engine.State, oldState: Engine.State) async {

--- a/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 extension Room: SignalClientDelegate {
     func signalClient(_: SignalClient, didReceiveLeave canReconnect: Bool, reason: Livekit_DisconnectReason) async {

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 actor SignalClient: Loggable {
     // MARK: - Types

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -17,7 +17,7 @@
 import Foundation
 import SwiftProtobuf
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 actor Transport: NSObject, Loggable {
     // MARK: - Types

--- a/Sources/LiveKit/E2EE/E2EEManager.swift
+++ b/Sources/LiveKit/E2EE/E2EEManager.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public class E2EEManager: NSObject, ObservableObject, Loggable {

--- a/Sources/LiveKit/E2EE/KeyProvider.swift
+++ b/Sources/LiveKit/E2EE/KeyProvider.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 public let defaultRatchetSalt: String = "LKFrameEncryptionKey"
 public let defaultMagicBytes: String = "LK-ROCKS"

--- a/Sources/LiveKit/E2EE/State.swift
+++ b/Sources/LiveKit/E2EE/State.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public enum E2EEState: Int {

--- a/Sources/LiveKit/Errors.swift
+++ b/Sources/LiveKit/Errors.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 public enum LiveKitErrorType: Int {
     case unknown = 0

--- a/Sources/LiveKit/Extensions/CustomStringConvertible.swift
+++ b/Sources/LiveKit/Extensions/CustomStringConvertible.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 extension TrackSettings: CustomStringConvertible {
     public var description: String {

--- a/Sources/LiveKit/Extensions/LKRTCRtpSender.swift
+++ b/Sources/LiveKit/Extensions/LKRTCRtpSender.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 extension LKRTCRtpSender: Loggable {
     // ...

--- a/Sources/LiveKit/Extensions/RTCConfiguration.swift
+++ b/Sources/LiveKit/Extensions/RTCConfiguration.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 extension LKRTCConfiguration {
     static func liveKitDefault() -> LKRTCConfiguration {

--- a/Sources/LiveKit/Extensions/RTCDataChannel+Util.swift
+++ b/Sources/LiveKit/Extensions/RTCDataChannel+Util.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 extension LKRTCDataChannel {
     enum labels {

--- a/Sources/LiveKit/Extensions/RTCI420Buffer.swift
+++ b/Sources/LiveKit/Extensions/RTCI420Buffer.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 extension LKRTCI420Buffer {
     func toPixelBuffer() -> CVPixelBuffer? {

--- a/Sources/LiveKit/Extensions/RTCMediaConstraints.swift
+++ b/Sources/LiveKit/Extensions/RTCMediaConstraints.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 extension LKRTCMediaConstraints {
     //    static let defaultOfferConstraints = RTCMediaConstraints(

--- a/Sources/LiveKit/Extensions/RTCRtpTransceiver.swift
+++ b/Sources/LiveKit/Extensions/RTCRtpTransceiver.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 extension LKRTCRtpTransceiver: Loggable {
     /// Attempts to set preferred video codec.

--- a/Sources/LiveKit/Extensions/RTCVideoCapturerDelegate+Buffer.swift
+++ b/Sources/LiveKit/Extensions/RTCVideoCapturerDelegate+Buffer.swift
@@ -20,7 +20,7 @@ import Foundation
     import ReplayKit
 #endif
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 extension FixedWidthInteger {
     func roundUp(toMultipleOf powerOfTwo: Self) -> Self {

--- a/Sources/LiveKit/LiveKit.swift
+++ b/Sources/LiveKit/LiveKit.swift
@@ -16,8 +16,8 @@
 
 import Foundation
 
+@_implementationOnly import LiveKitWebRTC
 @_implementationOnly import Logging
-@_implementationOnly import WebRTC
 
 let logger = Logger(label: "LiveKitSDK")
 

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -20,7 +20,7 @@ import Foundation
     import ReplayKit
 #endif
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public class LocalParticipant: Participant {

--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public class Participant: NSObject, ObservableObject, Loggable {

--- a/Sources/LiveKit/Participant/RemoteParticipant.swift
+++ b/Sources/LiveKit/Participant/RemoteParticipant.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public class RemoteParticipant: Participant {

--- a/Sources/LiveKit/Protocols/AudioRenderer.swift
+++ b/Sources/LiveKit/Protocols/AudioRenderer.swift
@@ -17,7 +17,7 @@
 import CoreMedia
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public protocol AudioRenderer {

--- a/Sources/LiveKit/Protocols/EngineDelegate.swift
+++ b/Sources/LiveKit/Protocols/EngineDelegate.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 protocol EngineDelegate: AnyObject {
     func engine(_ engine: Engine, didMutateState state: Engine.State, oldState: Engine.State) async

--- a/Sources/LiveKit/Protocols/SignalClientDelegate.swift
+++ b/Sources/LiveKit/Protocols/SignalClientDelegate.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 protocol SignalClientDelegate: AnyObject {
     func signalClient(_ signalClient: SignalClient, didUpdateConnectionState newState: ConnectionState, oldState: ConnectionState, disconnectError: LiveKitError?) async

--- a/Sources/LiveKit/Protocols/TrackDelegate.swift
+++ b/Sources/LiveKit/Protocols/TrackDelegate.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public protocol TrackDelegate: AnyObject {

--- a/Sources/LiveKit/Protocols/TransportDelegate.swift
+++ b/Sources/LiveKit/Protocols/TransportDelegate.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 protocol TransportDelegate: AnyObject {
     func transport(_ transport: Transport, didUpdateState state: RTCPeerConnectionState) async

--- a/Sources/LiveKit/Protocols/VideoRenderer.swift
+++ b/Sources/LiveKit/Protocols/VideoRenderer.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public protocol VideoRenderer {

--- a/Sources/LiveKit/Protocols/VideoViewDelegate.swift
+++ b/Sources/LiveKit/Protocols/VideoViewDelegate.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public protocol VideoViewDelegate: AnyObject {

--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 typealias DebouncFunc = () -> Void
 

--- a/Sources/LiveKit/SwiftUI/SwiftUIAudioRoutePickerButton.swift
+++ b/Sources/LiveKit/SwiftUI/SwiftUIAudioRoutePickerButton.swift
@@ -18,7 +18,7 @@ import AVKit
 import Foundation
 import SwiftUI
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 public struct SwiftUIAudioRoutePickerButton: NativeViewRepresentable {
     typealias ViewType = AVRoutePickerView

--- a/Sources/LiveKit/Track/AudioManager.swift
+++ b/Sources/LiveKit/Track/AudioManager.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 // Wrapper for LKRTCAudioBuffer
 @objc

--- a/Sources/LiveKit/Track/AudioTrack.swift
+++ b/Sources/LiveKit/Track/AudioTrack.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public protocol AudioTrack where Self: Track {}

--- a/Sources/LiveKit/Track/Capturers/BufferCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/BufferCapturer.swift
@@ -17,7 +17,7 @@
 import CoreMedia
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 /// A ``VideoCapturer`` that can capture ``CMSampleBuffer``s.
 ///

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -20,7 +20,7 @@ import Foundation
     import ReplayKit
 #endif
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 public class CameraCapturer: VideoCapturer {
     @objc

--- a/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
@@ -20,7 +20,7 @@ import Foundation
     import ReplayKit
 #endif
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @available(macOS 11.0, iOS 11.0, *)
 public class InAppScreenCapturer: VideoCapturer {

--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -21,7 +21,7 @@ import Foundation
     import ScreenCaptureKit
 #endif
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 #if os(macOS)
 

--- a/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 protocol VideoCapturerProtocol {
     var capturer: LKRTCVideoCapturer { get }

--- a/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public class LocalAudioTrack: Track, LocalTrack, AudioTrack {

--- a/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public class LocalVideoTrack: Track, LocalTrack, VideoTrack {

--- a/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public class RemoteAudioTrack: Track, RemoteTrack, AudioTrack {

--- a/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public class RemoteVideoTrack: Track, RemoteTrack, VideoTrack {

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public class Track: NSObject, Loggable {

--- a/Sources/LiveKit/Track/VideoTrack.swift
+++ b/Sources/LiveKit/Track/VideoTrack.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public protocol VideoTrack where Self: Track {

--- a/Sources/LiveKit/TrackPublications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/RemoteTrackPublication.swift
@@ -17,7 +17,7 @@
 import CoreGraphics
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public enum SubscriptionState: Int, Codable {

--- a/Sources/LiveKit/Types/AudioDevice.swift
+++ b/Sources/LiveKit/Types/AudioDevice.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public class AudioDevice: NSObject, MediaDevice {

--- a/Sources/LiveKit/Types/AudioEncoding.swift
+++ b/Sources/LiveKit/Types/AudioEncoding.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public class AudioEncoding: NSObject, MediaEncoding {

--- a/Sources/LiveKit/Types/Dimensions.swift
+++ b/Sources/LiveKit/Types/Dimensions.swift
@@ -17,7 +17,7 @@
 import CoreMedia
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public class Dimensions: NSObject, Loggable {

--- a/Sources/LiveKit/Types/IceCandidate.swift
+++ b/Sources/LiveKit/Types/IceCandidate.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 struct IceCandidate: Codable {
     let sdp: String

--- a/Sources/LiveKit/Types/IceServer.swift
+++ b/Sources/LiveKit/Types/IceServer.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 /// Options used when establishing a connection.
 @objc

--- a/Sources/LiveKit/Types/Options/AudioCaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/AudioCaptureOptions.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public class AudioCaptureOptions: NSObject, CaptureOptions {

--- a/Sources/LiveKit/Types/Options/BufferCaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/BufferCaptureOptions.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public class BufferCaptureOptions: NSObject, VideoCaptureOptions {

--- a/Sources/LiveKit/Types/SessionDescription.swift
+++ b/Sources/LiveKit/Types/SessionDescription.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 extension LKRTCSessionDescription {
     func toPBType() -> Livekit_SessionDescription {

--- a/Sources/LiveKit/Types/TrackStatistics.swift
+++ b/Sources/LiveKit/Types/TrackStatistics.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public class TrackStatistics: NSObject, Loggable {

--- a/Sources/LiveKit/Types/TrackStreamState.swift
+++ b/Sources/LiveKit/Types/TrackStreamState.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 @objc
 public enum StreamState: Int {

--- a/Sources/LiveKit/Types/VideoFrame.swift
+++ b/Sources/LiveKit/Types/VideoFrame.swift
@@ -17,7 +17,7 @@
 import CoreMedia
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 public protocol VideoBuffer {}
 

--- a/Sources/LiveKit/Types/VideoRotation.swift
+++ b/Sources/LiveKit/Types/VideoRotation.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 public enum VideoRotation: Int {
     case _0 = 0

--- a/Sources/LiveKit/Views/SampleBufferVideoRenderer.swift
+++ b/Sources/LiveKit/Views/SampleBufferVideoRenderer.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 class SampleBufferVideoRenderer: NativeView, Loggable {
     public let sampleBufferDisplayLayer: AVSampleBufferDisplayLayer

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -18,7 +18,7 @@ import AVFoundation
 import Foundation
 import MetalKit
 
-@_implementationOnly import WebRTC
+@_implementationOnly import LiveKitWebRTC
 
 /// A ``NativeViewType`` that conforms to ``RTCVideoRenderer``.
 typealias NativeRendererView = LKRTCVideoRenderer & Mirrorable & NativeViewType


### PR DESCRIPTION
In addition to the ObjC symbol prefixing, this prefixes both package name and WebRTC.xcframework with `LiveKit`.
I think @ _implementationOnly is not required any more, but it helps compiler to warn if any symbol is exported.

Depends on https://github.com/livekit/webrtc-xcframework/releases/tag/114.5735.11