### PR TITLE
Extend AudioCustomProcessingDelegate

### DIFF
--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -248,6 +248,15 @@ public class Room: NSObject, ObservableObject, Loggable {
 
         try await engine.connect(url, token, connectOptions: connectOptions)
 
+        // Notify audio processing delegates
+        if let capturePost = AudioManager.shared.capturePostProcessingDelegate {
+            capturePost.audioProcessingRoomDidConnect?(withUrl: url, token: token)
+        }
+
+        if let renderPre = AudioManager.shared.renderPreProcessingDelegate {
+            renderPre.audioProcessingRoomDidConnect?(withUrl: url, token: token)
+        }
+
         log("Connected to \(String(describing: self))", .info)
     }
 

--- a/Sources/LiveKit/Track/AudioManager.swift
+++ b/Sources/LiveKit/Track/AudioManager.swift
@@ -88,9 +88,23 @@ public extension LKAudioBuffer {
 
 @objc
 public protocol AudioCustomProcessingDelegate {
+    @objc
     func audioProcessingInitialize(sampleRate sampleRateHz: Int, channels: Int)
+
+    @objc
     func audioProcessingProcess(audioBuffer: LKAudioBuffer)
+
+    @objc
     func audioProcessingRelease()
+
+    // MARK: - Available from 2.0.6 (Optional)
+
+    /// Invoked everytime when a Room connects.
+    @objc optional
+    func audioProcessingRoomDidConnect(withUrl url: String, token: String)
+
+    @objc optional
+    func audioProcessingName() -> String
 }
 
 class AudioCustomProcessingDelegateAdapter: NSObject, LKRTCAudioCustomProcessingDelegate {


### PR DESCRIPTION
Adds optional delegate methods to `AudioCustomProcessingDelegate`
So that the processor can receive information about the Room.
Useful for implementing Krisp audio processors etc.