### PR TITLE
Audio processing convenience methods

### DIFF
--- a/Sources/LiveKit/Convenience/AudioProcessing.swift
+++ b/Sources/LiveKit/Convenience/AudioProcessing.swift
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Accelerate
+import AVFoundation
+import Foundation
+
+public struct AudioLevel {
+    /// Linear Scale RMS Value
+    public let average: Float
+    public let peak: Float
+}
+
+public extension LKAudioBuffer {
+    /// Convert to AVAudioPCMBuffer float buffer will be normalized to 32 bit.
+    @objc
+    func toAVAudioPCMBuffer() -> AVAudioPCMBuffer? {
+        guard let audioFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                              sampleRate: 48000,
+                                              channels: AVAudioChannelCount(channels),
+                                              interleaved: false),
+            let pcmBuffer = AVAudioPCMBuffer(pcmFormat: audioFormat,
+                                             frameCapacity: AVAudioFrameCount(frames))
+        else {
+            return nil
+        }
+
+        pcmBuffer.frameLength = AVAudioFrameCount(frames)
+
+        guard let targetBufferPointer = pcmBuffer.floatChannelData else { return nil }
+
+        // Optimized version
+        var normalizationFactor: Float = 1.0 / 32768.0
+
+        for i in 0 ..< channels {
+            vDSP_vsmul(rawBuffer(forChannel: i),
+                       1,
+                       &normalizationFactor,
+                       targetBufferPointer[i],
+                       1,
+                       vDSP_Length(frames))
+        }
+
+        return pcmBuffer
+    }
+}
+
+public extension AVAudioPCMBuffer {
+    /// Computes Peak and Linear Scale RMS Value (Average) for all channels.
+    func audioLevels() -> [AudioLevel] {
+        var result: [AudioLevel] = []
+        guard let data = floatChannelData else {
+            // Not containing float data
+            return result
+        }
+
+        for i in 0 ..< Int(format.channelCount) {
+            let channelData = data[i]
+            var max: Float = 0.0
+            vDSP_maxv(channelData, stride, &max, vDSP_Length(frameLength))
+            var rms: Float = 0.0
+            vDSP_rmsqv(channelData, stride, &rms, vDSP_Length(frameLength))
+
+            // No conversion to dB, return linear scale values directly
+            result.append(AudioLevel(average: rms, peak: max))
+        }
+
+        return result
+    }
+}
+
+public extension Sequence where Iterator.Element == AudioLevel {
+    /// Combines all elements into a single audio level by computing the average value of all elements.
+    func combine() -> AudioLevel? {
+        var count = 0
+        let totalSums: (averageSum: Float, peakSum: Float) = reduce((averageSum: 0.0, peakSum: 0.0)) { totals, audioLevel in
+            count += 1
+            return (totals.averageSum + audioLevel.average,
+                    totals.peakSum + audioLevel.peak)
+        }
+
+        guard count > 0 else { return nil }
+
+        return AudioLevel(average: totalSums.averageSum / Float(count),
+                          peak: totalSums.peakSum / Float(count))
+    }
+}

--- a/Sources/LiveKit/Track/AudioManager.swift
+++ b/Sources/LiveKit/Track/AudioManager.swift
@@ -53,39 +53,6 @@ public class LKAudioBuffer: NSObject {
     }
 }
 
-// MARK: - Helper extension
-
-public extension LKAudioBuffer {
-    @objc
-    func toAVAudioPCMBuffer() -> AVAudioPCMBuffer? {
-        guard let audioFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
-                                              sampleRate: 48000,
-                                              channels: AVAudioChannelCount(channels),
-                                              interleaved: false),
-            let pcmBuffer = AVAudioPCMBuffer(pcmFormat: audioFormat,
-                                             frameCapacity: AVAudioFrameCount(frames))
-        else {
-            return nil
-        }
-
-        pcmBuffer.frameLength = AVAudioFrameCount(frames)
-
-        guard let targetBufferPointer = pcmBuffer.floatChannelData?[0] else { return nil }
-
-        // Optimized version
-        var normalizationFactor: Float = 1.0 / 32768.0
-
-        vDSP_vsmul(rawBuffer(forChannel: 0),
-                   1,
-                   &normalizationFactor,
-                   targetBufferPointer,
-                   1,
-                   vDSP_Length(frames))
-
-        return pcmBuffer
-    }
-}
-
 @objc
 public protocol AudioCustomProcessingDelegate {
     func audioProcessingInitialize(sampleRate sampleRateHz: Int, channels: Int)


### PR DESCRIPTION
* Adds intuitive audio level computing methods.
* Improves `toAVAudioPCMBuffer()` to handle multi-channel.

Example
```swift
let level = audioBuffer.toAVAudioPCMBuffer()?.audioLevels().combine()
```
