### PR TITLE
Variable sampleRate for `toAVAudioPCMBuffer()`

### DIFF
--- a/Sources/LiveKit/Convenience/AudioProcessing.swift
+++ b/Sources/LiveKit/Convenience/AudioProcessing.swift
@@ -27,9 +27,9 @@ public struct AudioLevel {
 public extension LKAudioBuffer {
     /// Convert to AVAudioPCMBuffer float buffer will be normalized to 32 bit.
     @objc
-    func toAVAudioPCMBuffer(sampleRate: Double) -> AVAudioPCMBuffer? {
+    func toAVAudioPCMBuffer() -> AVAudioPCMBuffer? {
         guard let audioFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
-                                              sampleRate: sampleRate,
+                                              sampleRate: Double(frames / channels * 100),
                                               channels: AVAudioChannelCount(channels),
                                               interleaved: false),
             let pcmBuffer = AVAudioPCMBuffer(pcmFormat: audioFormat,

--- a/Sources/LiveKit/Convenience/AudioProcessing.swift
+++ b/Sources/LiveKit/Convenience/AudioProcessing.swift
@@ -27,9 +27,9 @@ public struct AudioLevel {
 public extension LKAudioBuffer {
     /// Convert to AVAudioPCMBuffer float buffer will be normalized to 32 bit.
     @objc
-    func toAVAudioPCMBuffer() -> AVAudioPCMBuffer? {
+    func toAVAudioPCMBuffer(sampleRate: Double) -> AVAudioPCMBuffer? {
         guard let audioFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
-                                              sampleRate: 48000,
+                                              sampleRate: sampleRate,
                                               channels: AVAudioChannelCount(channels),
                                               interleaved: false),
             let pcmBuffer = AVAudioPCMBuffer(pcmFormat: audioFormat,

--- a/Sources/LiveKit/Convenience/AudioProcessing.swift
+++ b/Sources/LiveKit/Convenience/AudioProcessing.swift
@@ -29,7 +29,7 @@ public extension LKAudioBuffer {
     @objc
     func toAVAudioPCMBuffer() -> AVAudioPCMBuffer? {
         guard let audioFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
-                                              sampleRate: Double(frames / channels * 100),
+                                              sampleRate: Double(frames * 100),
                                               channels: AVAudioChannelCount(channels),
                                               interleaved: false),
             let pcmBuffer = AVAudioPCMBuffer(pcmFormat: audioFormat,


### PR DESCRIPTION
Dynamically compute sampleRate instead of hardcoding.