### PR TITLE
Render frames directly from `VideoCapturer` for `LocalVideoTrack`s

### DIFF
--- a/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
+++ b/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
@@ -51,6 +51,7 @@ class BroadcastScreenCapturer: BufferCapturer {
             .toEncodeSafeDimensions()
 
         defer { self.dimensions = targetDimensions }
+
         let frameReader = SocketConnectionFrameReader()
         guard let socketConnection = BroadcastServerSocketConnection(filePath: filePath, streamDelegate: frameReader)
         else { return false }

--- a/Sources/LiveKit/Extensions/RTCVideoCapturerDelegate+Buffer.swift
+++ b/Sources/LiveKit/Extensions/RTCVideoCapturerDelegate+Buffer.swift
@@ -66,13 +66,15 @@ extension CGImagePropertyOrientation {
 
 extension LKRTCVideoCapturerDelegate {
     typealias OnResolveSourceDimensions = (Dimensions) -> Void
+    typealias OnDidCreateFrame = (LKRTCVideoFrame) -> Void
 
     /// capture a `CVPixelBuffer`, all other capture methods call this method internally.
     func capturer(_ capturer: LKRTCVideoCapturer,
                   didCapture pixelBuffer: CVPixelBuffer,
                   timeStampNs: Int64 = VideoCapturer.createTimeStampNs(),
                   rotation: RTCVideoRotation = ._0,
-                  onResolveSourceDimensions: OnResolveSourceDimensions? = nil)
+                  onResolveSourceDimensions: OnResolveSourceDimensions? = nil,
+                  onDidCreateFrame: OnDidCreateFrame? = nil)
     {
         // check if pixel format is supported by WebRTC
         let pixelFormat = CVPixelBufferGetPixelFormatType(pixelBuffer)
@@ -104,13 +106,15 @@ extension LKRTCVideoCapturerDelegate {
                                            timeStampNs: timeStampNs)
 
             self.capturer(capturer, didCapture: rtcFrame)
+            onDidCreateFrame?(rtcFrame)
         }
     }
 
     /// capture a `CMSampleBuffer`
     func capturer(_ capturer: LKRTCVideoCapturer,
                   didCapture sampleBuffer: CMSampleBuffer,
-                  onResolveSourceDimensions: OnResolveSourceDimensions? = nil)
+                  onResolveSourceDimensions: OnResolveSourceDimensions? = nil,
+                  onDidCreateFrame: OnDidCreateFrame? = nil)
     {
         // check if buffer is ready
         guard CMSampleBufferGetNumSamples(sampleBuffer) == 1,
@@ -145,7 +149,8 @@ extension LKRTCVideoCapturerDelegate {
                       didCapture: pixelBuffer,
                       timeStampNs: timeStampNs,
                       rotation: rotation ?? ._0,
-                      onResolveSourceDimensions: onResolveSourceDimensions)
+                      onResolveSourceDimensions: onResolveSourceDimensions,
+                      onDidCreateFrame: onDidCreateFrame)
     }
 }
 

--- a/Sources/LiveKit/Support/MulticastDelegate.swift
+++ b/Sources/LiveKit/Support/MulticastDelegate.swift
@@ -37,6 +37,16 @@ public class MulticastDelegate<T>: NSObject, Loggable {
         _queue = DispatchQueue(label: "LiveKitSDK.Multicast.\(label)", qos: qos, attributes: [])
     }
 
+    public var isDelegatesEmpty: Bool { countDelegates == 0 }
+    public var isDelegatesNotEmpty: Bool { countDelegates != 0 }
+
+    public var countDelegates: Int {
+        _queue.sync { [weak self] in
+            guard let self else { return 0 }
+            return self._set.allObjects.count
+        }
+    }
+
     public var allDelegates: [T] {
         _queue.sync { [weak self] in
             guard let self else { return [] }

--- a/Sources/LiveKit/Track/Capturers/BufferCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/BufferCapturer.swift
@@ -32,7 +32,7 @@ public class BufferCapturer: VideoCapturer {
     private let capturer = Engine.createVideoCapturer()
 
     /// The ``BufferCaptureOptions`` used for this capturer.
-    public var options: BufferCaptureOptions
+    public let options: BufferCaptureOptions
 
     init(delegate: LKRTCVideoCapturerDelegate, options: BufferCaptureOptions) {
         self.options = options

--- a/Sources/LiveKit/Track/Capturers/BufferCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/BufferCapturer.swift
@@ -41,43 +41,12 @@ public class BufferCapturer: VideoCapturer {
 
     /// Capture a ``CMSampleBuffer``.
     public func capture(_ sampleBuffer: CMSampleBuffer) {
-        delegate?.capturer(capturer, didCapture: sampleBuffer) { sourceDimensions in
-
-            let targetDimensions = sourceDimensions
-                .aspectFit(size: self.options.dimensions.max)
-                .toEncodeSafeDimensions()
-
-            defer { self.dimensions = targetDimensions }
-
-            guard let videoSource = self.delegate as? LKRTCVideoSource else { return }
-            videoSource.adaptOutputFormat(toWidth: targetDimensions.width,
-                                          height: targetDimensions.height,
-                                          fps: Int32(self.options.fps))
-        }
+        capture(sampleBuffer: sampleBuffer, withOptions: options)
     }
 
     /// Capture a ``CVPixelBuffer``.
-    public func capture(_ pixelBuffer: CVPixelBuffer,
-                        timeStampNs: Int64 = VideoCapturer.createTimeStampNs(),
-                        rotation: VideoRotation = ._0)
-    {
-        delegate?.capturer(capturer,
-                           didCapture: pixelBuffer,
-                           timeStampNs: timeStampNs,
-                           rotation: rotation.toRTCType())
-        { sourceDimensions in
-
-            let targetDimensions = sourceDimensions
-                .aspectFit(size: self.options.dimensions.max)
-                .toEncodeSafeDimensions()
-
-            defer { self.dimensions = targetDimensions }
-
-            guard let videoSource = self.delegate as? LKRTCVideoSource else { return }
-            videoSource.adaptOutputFormat(toWidth: targetDimensions.width,
-                                          height: targetDimensions.height,
-                                          fps: Int32(self.options.fps))
-        }
+    public func capture(_ pixelBuffer: CVPixelBuffer, timeStampNs: Int64 = VideoCapturer.createTimeStampNs(), rotation: VideoRotation = ._0) {
+        capture(pixelBuffer: pixelBuffer, timeStampNs: timeStampNs, rotation: rotation, withOptions: options)
     }
 }
 

--- a/Sources/LiveKit/Track/Capturers/BufferCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/BufferCapturer.swift
@@ -41,12 +41,12 @@ public class BufferCapturer: VideoCapturer {
 
     /// Capture a ``CMSampleBuffer``.
     public func capture(_ sampleBuffer: CMSampleBuffer) {
-        capture(sampleBuffer: sampleBuffer, withOptions: options)
+        capture(sampleBuffer: sampleBuffer, capturer: capturer, withOptions: options)
     }
 
     /// Capture a ``CVPixelBuffer``.
     public func capture(_ pixelBuffer: CVPixelBuffer, timeStampNs: Int64 = VideoCapturer.createTimeStampNs(), rotation: VideoRotation = ._0) {
-        capture(pixelBuffer: pixelBuffer, timeStampNs: timeStampNs, rotation: rotation, withOptions: options)
+        capture(pixelBuffer: pixelBuffer, capturer: capturer, timeStampNs: timeStampNs, rotation: rotation, withOptions: options)
     }
 }
 

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -264,7 +264,7 @@ class VideoCapturerDelegateAdapter: NSObject, LKRTCVideoCapturerDelegate {
         // Resolve real dimensions (apply frame rotation)
         cameraCapturer.dimensions = Dimensions(width: frame.width, height: frame.height).apply(rotation: frame.rotation)
         // Pass frame to video source
-        cameraCapturer.delegate?.capturer(capturer, didCapture: frame)
+        cameraCapturer.capture(capturer: capturer, didCapture: frame, withOptions: cameraCapturer.options)
     }
 }
 

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -218,16 +218,6 @@ public class CameraCapturer: VideoCapturer {
 
         log("starting camera capturer device: \(device), format: \(selectedFormat), fps: \(selectedFps)(\(fpsRange))", .info)
 
-        // adapt if requested dimensions and camera's dimensions don't match
-        if let videoSource = delegate as? LKRTCVideoSource,
-           selectedFormat.dimensions != self.options.dimensions
-        {
-            // self.log("adaptOutputFormat to: \(options.dimensions) fps: \(self.options.fps)")
-            videoSource.adaptOutputFormat(toWidth: options.dimensions.width,
-                                          height: options.dimensions.height,
-                                          fps: Int32(options.fps))
-        }
-
         try await capturer.startCapture(with: device, format: selectedFormat.format, fps: selectedFps)
 
         // Update internal vars
@@ -259,12 +249,12 @@ class VideoCapturerDelegateAdapter: NSObject, LKRTCVideoCapturerDelegate {
         self.cameraCapturer = cameraCapturer
     }
 
-    func capturer(_ capturer: LKRTCVideoCapturer, didCapture frame: LKRTCVideoFrame) {
+    func capturer(_: LKRTCVideoCapturer, didCapture frame: LKRTCVideoFrame) {
         guard let cameraCapturer else { return }
         // Resolve real dimensions (apply frame rotation)
         cameraCapturer.dimensions = Dimensions(width: frame.width, height: frame.height).apply(rotation: frame.rotation)
         // Pass frame to video source
-        cameraCapturer.capture(capturer: capturer, didCapture: frame, withOptions: cameraCapturer.options)
+        cameraCapturer.capture(frame: frame, withOptions: cameraCapturer.options)
     }
 }
 

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -249,12 +249,12 @@ class VideoCapturerDelegateAdapter: NSObject, LKRTCVideoCapturerDelegate {
         self.cameraCapturer = cameraCapturer
     }
 
-    func capturer(_: LKRTCVideoCapturer, didCapture frame: LKRTCVideoFrame) {
+    func capturer(_ capturer: LKRTCVideoCapturer, didCapture frame: LKRTCVideoFrame) {
         guard let cameraCapturer else { return }
         // Resolve real dimensions (apply frame rotation)
         cameraCapturer.dimensions = Dimensions(width: frame.width, height: frame.height).apply(rotation: frame.rotation)
         // Pass frame to video source
-        cameraCapturer.capture(frame: frame, withOptions: cameraCapturer.options)
+        cameraCapturer.capture(frame: frame, capturer: capturer, withOptions: cameraCapturer.options)
     }
 }
 

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -258,8 +258,6 @@ class VideoCapturerDelegateAdapter: NSObject, LKRTCVideoCapturerDelegate {
 
     func capturer(_ capturer: LKRTCVideoCapturer, didCapture frame: LKRTCVideoFrame) {
         guard let cameraCapturer else { return }
-        // Resolve real dimensions (apply frame rotation)
-        cameraCapturer.dimensions = Dimensions(width: frame.width, height: frame.height).apply(rotation: frame.rotation)
         // Pass frame to video source
         cameraCapturer.capture(frame: frame, capturer: capturer, withOptions: cameraCapturer.options)
     }

--- a/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
@@ -39,11 +39,11 @@ public class InAppScreenCapturer: VideoCapturer {
         guard didStart else { return false }
 
         // TODO: force pixel format kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
-        try await RPScreenRecorder.shared().startCapture { sampleBuffer, type, _ in
-
+        try await RPScreenRecorder.shared().startCapture { [weak self] sampleBuffer, type, _ in
+            guard let self else { return }
             // Only process .video
             if type == .video {
-                self.capture(sampleBuffer: sampleBuffer, withOptions: self.options)
+                self.capture(sampleBuffer: sampleBuffer, capturer: self.capturer, withOptions: self.options)
             }
         }
 

--- a/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
@@ -43,20 +43,7 @@ public class InAppScreenCapturer: VideoCapturer {
 
             // Only process .video
             if type == .video {
-                self.delegate?.capturer(self.capturer, didCapture: sampleBuffer) { sourceDimensions in
-
-                    let targetDimensions = sourceDimensions
-                        .aspectFit(size: self.options.dimensions.max)
-                        .toEncodeSafeDimensions()
-
-                    defer { self.dimensions = targetDimensions }
-
-                    guard let videoSource = self.delegate as? LKRTCVideoSource else { return }
-                    // self.log("adaptOutputFormat to: \(targetDimensions) fps: \(self.options.fps)")
-                    videoSource.adaptOutputFormat(toWidth: targetDimensions.width,
-                                                  height: targetDimensions.height,
-                                                  fps: Int32(self.options.fps))
-                }
+                self.capture(sampleBuffer: sampleBuffer, withOptions: self.options)
             }
         }
 

--- a/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
@@ -25,7 +25,7 @@ import ReplayKit
 @available(macOS 11.0, iOS 11.0, *)
 public class InAppScreenCapturer: VideoCapturer {
     private let capturer = Engine.createVideoCapturer()
-    private var options: ScreenShareCaptureOptions
+    private let options: ScreenShareCaptureOptions
 
     init(delegate: LKRTCVideoCapturerDelegate, options: ScreenShareCaptureOptions) {
         self.options = options

--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -156,7 +156,7 @@ public class MacOSScreenCapturer: VideoCapturer {
                                        rotation: ._0,
                                        timeStampNs: timeStampNs)
 
-        capture(frame: rtcFrame, withOptions: options)
+        capture(frame: rtcFrame, capturer: capturer, withOptions: options)
 
         // cache last frame
         _lastFrame = rtcFrame
@@ -184,7 +184,7 @@ extension MacOSScreenCapturer {
                                        timeStampNs: Self.createTimeStampNs())
 
         // Feed frame to WebRTC
-        capture(frame: newFrame, withOptions: options)
+        capture(frame: newFrame, capturer: capturer, withOptions: options)
     }
 }
 

--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -137,9 +137,6 @@ public class MacOSScreenCapturer: VideoCapturer {
             .aspectFit(size: options.dimensions.max)
             .toEncodeSafeDimensions()
 
-        // notify capturer for dimensions
-        defer { self.dimensions = targetDimensions }
-
         let rtcPixelBuffer = LKRTCCVPixelBuffer(pixelBuffer: pixelBuffer,
                                                 adaptedWidth: targetDimensions.width,
                                                 adaptedHeight: targetDimensions.height,

--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -40,8 +40,7 @@ public class MacOSScreenCapturer: VideoCapturer {
     private var _resendTimer: Task<Void, Error>?
 
     /// The ``ScreenShareCaptureOptions`` used for this capturer.
-    /// It is possible to modify the options but `restartCapture` must be called.
-    public var options: ScreenShareCaptureOptions
+    public let options: ScreenShareCaptureOptions
 
     init(delegate: LKRTCVideoCapturerDelegate, captureSource: MacOSScreenCaptureSource, options: ScreenShareCaptureOptions) {
         self.captureSource = captureSource

--- a/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
@@ -176,7 +176,10 @@ public class VideoCapturer: NSObject, Loggable, VideoCapturerProtocol {
 
 extension VideoCapturer {
     // Capture a RTCVideoFrame
-    func capture(frame: LKRTCVideoFrame, withOptions options: VideoCaptureOptions) {
+    func capture(frame: LKRTCVideoFrame,
+                 capturer: LKRTCVideoCapturer,
+                 withOptions options: VideoCaptureOptions)
+    {
         if let videoSource = delegate as? LKRTCVideoSource {
             videoSource.adaptOutputFormat(toWidth: options.dimensions.width,
                                           height: options.dimensions.height,
@@ -195,7 +198,10 @@ extension VideoCapturer {
     }
 
     // Capture a CMSampleBuffer
-    func capture(sampleBuffer: CMSampleBuffer, withOptions options: VideoCaptureOptions) {
+    func capture(sampleBuffer: CMSampleBuffer,
+                 capturer: LKRTCVideoCapturer,
+                 withOptions options: VideoCaptureOptions)
+    {
         delegate?.capturer(capturer, didCapture: sampleBuffer, onResolveSourceDimensions: { sourceDimensions in
 
             let targetDimensions = sourceDimensions
@@ -222,6 +228,7 @@ extension VideoCapturer {
 
     // Capture a CVPixelBuffer
     func capture(pixelBuffer: CVPixelBuffer,
+                 capturer: LKRTCVideoCapturer,
                  timeStampNs: Int64 = VideoCapturer.createTimeStampNs(),
                  rotation: VideoRotation = ._0,
                  withOptions options: VideoCaptureOptions)

--- a/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
@@ -186,6 +186,9 @@ extension VideoCapturer {
                                           fps: Int32(options.fps))
         }
 
+        // Resolve real dimensions (apply frame rotation)
+        dimensions = Dimensions(width: frame.width, height: frame.height).apply(rotation: frame.rotation)
+
         delegate?.capturer(capturer, didCapture: frame)
 
         if rendererDelegates.isDelegatesNotEmpty {

--- a/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
@@ -104,14 +104,26 @@ public class VideoCapturer: NSObject, Loggable, VideoCapturerProtocol {
         }
     }
 
-    func capture(capturer: LKRTCVideoCapturer, didCapture frame: LKRTCVideoFrame, withOptions options: VideoCaptureOptions) {
+    func capture(capturer: LKRTCVideoCapturer,
+                 didCapture frame: LKRTCVideoFrame,
+                 withOptions options: VideoCaptureOptions)
+    {
         delegate?.capturer(capturer, didCapture: frame)
-        // TODO: Optimize
-        if let lkVideoFrame = frame.toLKType() {
-            rendererDelegates.notify { renderer in
-                renderer.render?(frame: lkVideoFrame, videoCaptureOptions: options)
+        if rendererDelegates.isDelegatesNotEmpty {
+            if let lkVideoFrame = frame.toLKType() {
+                rendererDelegates.notify { renderer in
+                    renderer.render?(frame: lkVideoFrame, videoCaptureOptions: options)
+                }
             }
         }
+    }
+
+    func capturer(_ capturer: LKRTCVideoCapturer,
+                  didCapture sampleBuffer: CMSampleBuffer,
+                  onResolveSourceDimensions: LKRTCVideoCapturerDelegate.OnResolveSourceDimensions? = nil)
+    {
+        delegate?.capturer(capturer, didCapture: sampleBuffer, onResolveSourceDimensions: onResolveSourceDimensions)
+        // TODO: Implement
     }
 
     deinit {

--- a/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
@@ -65,11 +65,11 @@ public class LocalVideoTrack: Track, LocalTrack, VideoTrack {
 
 public extension LocalVideoTrack {
     func add(videoRenderer: VideoRenderer) {
-        super._add(videoRenderer: videoRenderer)
+        capturer.rendererDelegates.add(delegate: videoRenderer)
     }
 
     func remove(videoRenderer: VideoRenderer) {
-        super._remove(videoRenderer: videoRenderer)
+        capturer.rendererDelegates.remove(delegate: videoRenderer)
     }
 }
 

--- a/Sources/LiveKit/Types/Options/ScreenShareCaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/ScreenShareCaptureOptions.swift
@@ -35,7 +35,7 @@ public class ScreenShareCaptureOptions: NSObject, VideoCaptureOptions {
     public let includeCurrentApplication: Bool
 
     public init(dimensions: Dimensions = .h1080_169,
-                fps: Int = 15,
+                fps: Int = 30,
                 showCursor: Bool = true,
                 useBroadcastExtension: Bool = false,
                 includeCurrentApplication: Bool = false)


### PR DESCRIPTION
`VideoRenderer`s that are attached to a `LocalVideoTrack` will receive frames directly from `VideoCapturer` instead of frames processed in the WebRTC stack.

- [x] Check if VideoCapturer.options is thread-safe.
- [x] Check other if other VideoCapturers work correctly.
