### PR TITLE
Smooth transition for `VideoView` capture position update

### DIFF
--- a/Sources/LiveKit/Support/NativeView.swift
+++ b/Sources/LiveKit/Support/NativeView.swift
@@ -64,6 +64,10 @@ open class NativeView: NativeViewType {
     public func bringSubviewToFront(_ view: NSView) {
         addSubview(view)
     }
+
+    public func insertSubview(_ view: NSView, belowSubview: NSView) {
+        addSubview(view, positioned: .below, relativeTo: belowSubview)
+    }
     #endif
 
     open func performLayout() {

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -596,7 +596,7 @@ extension VideoView: VideoRenderer {
             // Update renderTarget if capture position changes
             if let oldCaptureDevicePosition, oldCaptureDevicePosition != captureDevice?.position {
                 $0.renderTarget = .secondary
-                $0.remainingRenderCountBeforeSwap = 3
+                $0.remainingRenderCountBeforeSwap = $0.transitionMode == .none ? 3 : 0
             }
 
             return $0

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -569,9 +569,7 @@ extension VideoView: VideoRenderer {
             $0.renderDate = Date()
 
             // Update renderTarget if capture position changes
-            if let oldCaptureDevicePosition,
-               oldCaptureDevicePosition != captureDevice?.position
-            {
+            if let oldCaptureDevicePosition, oldCaptureDevicePosition != captureDevice?.position {
                 $0.renderTarget = .secondary
             }
 

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -665,8 +665,8 @@ extension VideoView: VideoRenderer {
 
         // Currently only for iOS
         #if os(iOS)
-        let (mode, duration) = _state.read { ($0.transitionMode, $0.transitionDuration) }
-        if let transitionOption = mode.toAnimationOption() {
+        let (mode, duration, position) = _state.read { ($0.transitionMode, $0.transitionDuration, $0.captureDevice?.realPosition) }
+        if let transitionOption = mode.toAnimationOption(fromPosition: position) {
             UIView.transition(with: self, duration: duration, options: transitionOption, animations: block, completion: nil)
         } else {
             block()
@@ -817,9 +817,13 @@ extension AVCaptureDevice {
 
 #if os(iOS)
 extension VideoView.TransitionMode {
-    func toAnimationOption() -> UIView.AnimationOptions? {
+    func toAnimationOption(fromPosition position: AVCaptureDevice.Position? = nil) -> UIView.AnimationOptions? {
         switch self {
-        case .flip: return .transitionFlipFromRight
+        case .flip:
+            if position == .back {
+                return .transitionFlipFromLeft
+            }
+            return .transitionFlipFromRight
         case .crossDissolve: return .transitionCrossDissolve
         default: return nil
         }

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -191,6 +191,7 @@ public class VideoView: NativeView, Loggable {
         // Transition related
         var renderTarget: RenderTarget = .primary
         var isSwapping: Bool = false
+        var remainingRenderCountBeforeSwap: Int = 0 // Number of frames to be rendered on secondary until swap is initiated
         var transitionMode: TransitionMode = .crossDissolve
         var transitionDuration: TimeInterval = 0.3
 
@@ -595,6 +596,7 @@ extension VideoView: VideoRenderer {
             // Update renderTarget if capture position changes
             if let oldCaptureDevicePosition, oldCaptureDevicePosition != captureDevice?.position {
                 $0.renderTarget = .secondary
+                $0.remainingRenderCountBeforeSwap = 3
             }
 
             return $0
@@ -613,8 +615,12 @@ extension VideoView: VideoRenderer {
 
                 let shouldSwap = _state.mutate {
                     let oldIsSwapping = $0.isSwapping
-                    $0.isSwapping = true
-                    return !oldIsSwapping
+                    if $0.remainingRenderCountBeforeSwap <= 0 {
+                        $0.isSwapping = true
+                    } else {
+                        $0.remainingRenderCountBeforeSwap -= 1
+                    }
+                    return !oldIsSwapping && $0.isSwapping
                 }
 
                 if shouldSwap {

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -136,11 +136,16 @@ public class VideoView: NativeView, Loggable {
     /// This is only available when the renderer is using AVSampleBufferDisplayLayer.
     /// Recommended to be accessed from main thread.
     public var avSampleBufferDisplayLayer: AVSampleBufferDisplayLayer? {
-        guard let nr = _nativeRenderer as? SampleBufferVideoRenderer else { return nil }
+        guard let nr = _primaryRenderer as? SampleBufferVideoRenderer else { return nil }
         return nr.sampleBufferDisplayLayer
     }
 
     // MARK: - Internal
+
+    enum RenderTarget {
+        case primary
+        case secondary
+    }
 
     struct State {
         weak var track: Track?
@@ -158,10 +163,12 @@ public class VideoView: NativeView, Loggable {
 
         var isDebugMode: Bool = false
 
-        // render states
+        // Render states
         var renderDate: Date?
         var didRenderFirstFrame: Bool = false
         var isRendering: Bool = false
+        var renderTarget: RenderTarget = .primary
+        var isSwapping: Bool = false
 
         // Only used for rendering local tracks
         var captureOptions: VideoCaptureOptions? = nil
@@ -177,7 +184,8 @@ public class VideoView: NativeView, Loggable {
 
     // MARK: - Private
 
-    private var _nativeRenderer: NativeRendererView?
+    private var _primaryRenderer: NativeRendererView?
+    private var _secondaryRenderer: NativeRendererView?
     private var _debugTextView: TextView?
 
     // used for stats timer
@@ -185,6 +193,8 @@ public class VideoView: NativeView, Loggable {
     private let _fpsTimer = AsyncTimer(interval: 1)
     private var _currentFPS: Int = 0
     private var _frameCount: Int = 0
+
+    private var _swapTimer: Timer?
 
     override public init(frame: CGRect = .zero) {
         // initial state
@@ -224,17 +234,21 @@ public class VideoView: NativeView, Loggable {
                         if let track = oldState.track as? VideoTrack {
                             track.remove(videoRenderer: self)
 
-                            if let nr = self._nativeRenderer {
-                                self.log("removing nativeRenderer")
-                                nr.removeFromSuperview()
-                                self._nativeRenderer = nil
+                            if let r = self._primaryRenderer {
+                                r.removeFromSuperview()
+                                self._primaryRenderer = nil
+                            }
+
+                            if let r = self._secondaryRenderer {
+                                r.removeFromSuperview()
+                                self._secondaryRenderer = nil
                             }
                         }
 
                         // set new track
                         if let track = newState.track as? VideoTrack, newState.shouldRender {
                             // re-create renderer on main thread
-                            let nr = self.reCreateNativeRenderer(for: newState.renderMode)
+                            let nr = self.recreatePrimaryRenderer(for: newState.renderMode)
                             didReCreateNativeRenderer = true
 
                             track.add(videoRenderer: self)
@@ -248,7 +262,7 @@ public class VideoView: NativeView, Loggable {
                     }
 
                     if renderModeDidUpdate, !didReCreateNativeRenderer {
-                        self.reCreateNativeRenderer(for: newState.renderMode)
+                        self.recreatePrimaryRenderer(for: newState.renderMode)
                     }
                 }
             }
@@ -368,6 +382,7 @@ public class VideoView: NativeView, Loggable {
             debugView.layer!.borderColor = (state.shouldRender ? NSColor.green : NSColor.red).withAlphaComponent(0.5).cgColor
             debugView.layer!.borderWidth = 3
             #endif
+            bringSubviewToFront(debugView)
         } else {
             if let debugView = _debugTextView {
                 debugView.removeFromSuperview()
@@ -408,23 +423,24 @@ public class VideoView: NativeView, Loggable {
             _state.mutate { $0.rendererSize = rendererFrame.size }
         }
 
-        // nativeRenderer.wantsLayer = true
-        // nativeRenderer.layer!.borderColor = NSColor.red.cgColor
-        // nativeRenderer.layer!.borderWidth = 3
+        if let _primaryRenderer {
+            _primaryRenderer.frame = rendererFrame
 
-        guard let _nativeRenderer else { return }
+            if let mtlVideoView = _primaryRenderer as? LKRTCMTLVideoView {
+                if let rotationOverride = state.rotationOverride {
+                    mtlVideoView.rotationOverride = NSNumber(value: rotationOverride.rawValue)
+                } else {
+                    mtlVideoView.rotationOverride = nil
+                }
+            }
 
-        _nativeRenderer.frame = rendererFrame
-
-        if let mtlVideoView = _nativeRenderer as? LKRTCMTLVideoView {
-            if let rotationOverride = state.rotationOverride {
-                mtlVideoView.rotationOverride = NSNumber(value: rotationOverride.rawValue)
+            if let _secondaryRenderer {
+                _secondaryRenderer.frame = rendererFrame
+                _secondaryRenderer.set(mirrored: _shouldMirror())
             } else {
-                mtlVideoView.rotationOverride = nil
+                _primaryRenderer.set(mirrored: _shouldMirror())
             }
         }
-
-        _nativeRenderer.set(mirrored: _shouldMirror())
     }
 }
 
@@ -440,18 +456,16 @@ private extension VideoView {
     }
 
     @discardableResult
-    func reCreateNativeRenderer(for renderMode: VideoView.RenderMode) -> NativeRendererView {
-        if !Thread.current.isMainThread {
-            log("Must be called on main thread", .error)
-        }
+    func recreatePrimaryRenderer(for renderMode: VideoView.RenderMode) -> NativeRendererView {
+        if !Thread.current.isMainThread { log("Must be called on main thread", .error) }
 
         // create a new rendererView
         let newView = VideoView.createNativeRendererView(for: renderMode)
         addSubview(newView)
 
         // keep the old rendererView
-        let oldView = _nativeRenderer
-        _nativeRenderer = newView
+        let oldView = _primaryRenderer
+        _primaryRenderer = newView
 
         if let oldView {
             // copy frame from old renderer
@@ -460,10 +474,35 @@ private extension VideoView {
             oldView.removeFromSuperview()
         }
 
-        // ensure debug info is most front
-        if let view = _debugTextView {
-            bringSubviewToFront(view)
+        if let r = _secondaryRenderer {
+            r.removeFromSuperview()
+            _secondaryRenderer = nil
         }
+
+        return newView
+    }
+
+    @discardableResult
+    func ensureSecondaryRenderer() -> NativeRendererView? {
+        if !Thread.current.isMainThread { log("Must be called on main thread", .error) }
+
+        if let _secondaryRenderer { return _secondaryRenderer }
+
+        guard let _primaryRenderer else { return nil }
+
+        // Create a new rendererView
+        let newView = VideoView.createNativeRendererView(for: _state.renderMode)
+        insertSubview(newView, belowSubview: _primaryRenderer)
+
+        if let _secondaryRenderer {
+            // Remove old if existed
+            _secondaryRenderer.removeFromSuperview()
+        }
+
+        _secondaryRenderer = newView
+
+        // Copy frame from primary renderer
+        newView.frame = _primaryRenderer.frame
 
         return newView
     }
@@ -490,7 +529,7 @@ extension VideoView: VideoRenderer {
 
     public func set(size: CGSize) {
         DispatchQueue.main.async { [weak self] in
-            guard let self, let nr = self._nativeRenderer else { return }
+            guard let self, let nr = self._primaryRenderer else { return }
             nr.setSize(size)
         }
     }
@@ -499,7 +538,7 @@ extension VideoView: VideoRenderer {
         let state = _state.copy()
 
         // prevent any extra rendering if already !isEnabled etc.
-        guard state.shouldRender, let nr = _nativeRenderer else {
+        guard state.shouldRender, let pr = _primaryRenderer else {
             log("canRender is false, skipping render...")
             return
         }
@@ -526,17 +565,57 @@ extension VideoView: VideoRenderer {
             _needsLayout = true
         }
 
-        nr.renderFrame(frame.toRTCType())
+        let newState = _state.mutate {
+            // Keep previous capture position
+            let oldCaptureDevicePosition = $0.captureDevice?.position
 
-        // cache last rendered frame
-        track?.set(videoFrame: frame)
-
-        _state.mutate {
             $0.captureDevice = captureDevice
             $0.captureOptions = captureOptions
             $0.didRenderFirstFrame = true
             $0.isRendering = true
             $0.renderDate = Date()
+
+            // Update renderTarget if capture position changes
+            if let oldCaptureDevicePosition,
+               oldCaptureDevicePosition != captureDevice?.position
+            {
+                $0.renderTarget = .secondary
+            }
+
+            return $0
+        }
+
+        switch newState.renderTarget {
+        case .primary:
+            pr.renderFrame(frame.toRTCType())
+            // Cache last rendered frame
+            track?.set(videoFrame: frame)
+
+        case .secondary:
+            if let sr = _secondaryRenderer {
+                sr.renderFrame(frame.toRTCType())
+
+                if !_state.isSwapping {
+                    _state.mutate { $0.isSwapping = true }
+
+                    Task.detached { @MainActor in
+                        // Swap views
+                        self._swapRendererViews()
+                        // Swap completed, back to primary rendering
+                        self._state.mutate {
+                            $0.renderTarget = .primary
+                            $0.isSwapping = false
+                        }
+                    }
+                }
+            } else {
+                Task.detached { @MainActor in
+                    // Create secondary renderer and render first frame
+                    if let sr = self.ensureSecondaryRenderer() {
+                        sr.renderFrame(frame.toRTCType())
+                    }
+                }
+            }
         }
 
         if _state.isDebugMode {
@@ -544,6 +623,29 @@ extension VideoView: VideoRenderer {
                 self._frameCount += 1
             }
         }
+    }
+
+    private func _swapRendererViews() {
+        if !Thread.current.isMainThread { log("Must be called on main thread", .error) }
+
+        // Ensure secondary renderer exists
+        guard let secondaryView = _secondaryRenderer else {
+            return
+        }
+
+        _secondaryRenderer = nil
+
+        UIView.transition(with: self, duration: 0.3, options: .transitionCrossDissolve, animations: {
+            // Remove the secondary view from its superview
+            secondaryView.removeFromSuperview()
+            // Swap the references
+            self._primaryRenderer = secondaryView
+            // Add the new primary view to the superview
+            if let newPrimaryView = self._primaryRenderer {
+                self.addSubview(newPrimaryView)
+            }
+
+        }, completion: nil)
     }
 }
 

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -633,9 +633,7 @@ extension VideoView: VideoRenderer {
             return
         }
 
-        _secondaryRenderer = nil
-
-        UIView.transition(with: self, duration: 0.3, options: .transitionCrossDissolve, animations: {
+        let block = {
             // Remove the secondary view from its superview
             secondaryView.removeFromSuperview()
             // Swap the references
@@ -644,8 +642,14 @@ extension VideoView: VideoRenderer {
             if let newPrimaryView = self._primaryRenderer {
                 self.addSubview(newPrimaryView)
             }
+            self._secondaryRenderer = nil
+        }
 
-        }, completion: nil)
+        #if os(iOS)
+        UIView.transition(with: self, duration: 0.3, options: .transitionCrossDissolve, animations: block, completion: nil)
+        #else
+        block()
+        #endif
     }
 }
 

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -194,8 +194,6 @@ public class VideoView: NativeView, Loggable {
     private var _currentFPS: Int = 0
     private var _frameCount: Int = 0
 
-    private var _swapTimer: Timer?
-
     override public init(frame: CGRect = .zero) {
         // initial state
         _state = StateSync(State(viewSize: frame.size))


### PR DESCRIPTION
When capture position update is detected:
1. Creates a secondary renderer view in the back of primary renderer
2. Renders some frames (2 frames) on secondary renderer
3. Executes animated primary secondary renderer swap
4. Sets rendering back to primary renderer

- [x] Ensure clean up
- [x] Add animation preference properties

<table>
    <thead>
        <tr>
            <th align="center">Before this PR</th>
            <th align="center">CrossDissolve</th>
            <th align="center">Flip</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td align="left"><video src="https://github.com/livekit/client-sdk-swift/assets/548776/fc2a95c1-c77a-4e67-a798-97e77867f8d7" controls="controls" style="max-width: 730px;"></video></td>
            <td align="center"><video src="https://github.com/livekit/client-sdk-swift/assets/548776/4c025cbe-028c-46f3-9154-8349e3c35224" controls="controls" style="max-width: 730px;"></video></td>
            <td align="right"><video src="https://github.com/livekit/client-sdk-swift/assets/548776/20914b2e-ffa2-4420-8307-2a33b61d463f" controls="controls" style="max-width: 730px;"></video></td>
        </tr>
    </tbody>
</table>
