### PR TITLE
Use new internal import instead of `@_implementationOnly`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
-// swift-tools-version:5.7
-// (Xcode14.0+)
+// swift-tools-version:5.8
+// (Xcode14.3+)
 
 import PackageDescription
 
@@ -36,6 +36,9 @@ let package = Package(
             ],
             resources: [
                 .process("PrivacyInfo.xcprivacy"),
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("AccessLevelOnImport"),
             ]
         ),
         .testTarget(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,5 +1,5 @@
-// swift-tools-version:5.7
-// (Xcode14.0+)
+// swift-tools-version:5.9
+// (Xcode15.0+)
 
 import PackageDescription
 
@@ -36,6 +36,9 @@ let package = Package(
             ],
             resources: [
                 .process("PrivacyInfo.xcprivacy"),
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("AccessLevelOnImport"),
             ]
         ),
         .testTarget(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -18,7 +18,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "114.5735.19"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "125.6422.01"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.26.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
         // Only used for DocC generation

--- a/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
+++ b/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
@@ -22,7 +22,11 @@ import Foundation
 import UIKit
 #endif
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 class BroadcastScreenCapturer: BufferCapturer {
     static let kRTCScreensharingSocketFD = "rtc_SSFD"

--- a/Sources/LiveKit/Broadcast/SocketConnectionFrameReader.swift
+++ b/Sources/LiveKit/Broadcast/SocketConnectionFrameReader.swift
@@ -18,7 +18,11 @@ import CoreImage
 import CoreVideo
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 private class Message {
     // Initializing a CIContext object is costly, so we use a singleton instead

--- a/Sources/LiveKit/Core/DataChannelPairActor.swift
+++ b/Sources/LiveKit/Core/DataChannelPairActor.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 actor DataChannelPairActor: NSObject, Loggable {
     // MARK: - Types

--- a/Sources/LiveKit/Core/Engine+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Engine+SignalClientDelegate.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 extension Engine: SignalClientDelegate {
     func signalClient(_ signalClient: SignalClient, didUpdateConnectionState connectionState: ConnectionState, oldState: ConnectionState, disconnectError: LiveKitError?) async {

--- a/Sources/LiveKit/Core/Engine+TransportDelegate.swift
+++ b/Sources/LiveKit/Core/Engine+TransportDelegate.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 extension RTCPeerConnectionState {
     var isConnected: Bool {

--- a/Sources/LiveKit/Core/Engine.swift
+++ b/Sources/LiveKit/Core/Engine.swift
@@ -20,7 +20,11 @@ import Foundation
 import Network
 #endif
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 class Engine: Loggable {
     // MARK: - Public

--- a/Sources/LiveKit/Core/RTC.swift
+++ b/Sources/LiveKit/Core/RTC.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 private extension Array where Element: LKRTCVideoCodecInfo {
     func rewriteCodecsIfNeeded() -> [LKRTCVideoCodecInfo] {

--- a/Sources/LiveKit/Core/Room+EngineDelegate.swift
+++ b/Sources/LiveKit/Core/Room+EngineDelegate.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 extension Room: EngineDelegate {
     func engine(_: Engine, didMutateState state: Engine.State, oldState: Engine.State) async {

--- a/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 extension Room: SignalClientDelegate {
     func signalClient(_: SignalClient, didReceiveLeave canReconnect: Bool, reason: Livekit_DisconnectReason) async {

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 actor SignalClient: Loggable {
     // MARK: - Types

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 actor Transport: NSObject, Loggable {
     // MARK: - Types

--- a/Sources/LiveKit/E2EE/E2EEManager.swift
+++ b/Sources/LiveKit/E2EE/E2EEManager.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public class E2EEManager: NSObject, ObservableObject, Loggable {

--- a/Sources/LiveKit/E2EE/KeyProvider.swift
+++ b/Sources/LiveKit/E2EE/KeyProvider.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 public let defaultRatchetSalt: String = "LKFrameEncryptionKey"
 public let defaultMagicBytes: String = "LK-ROCKS"

--- a/Sources/LiveKit/E2EE/State.swift
+++ b/Sources/LiveKit/E2EE/State.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public enum E2EEState: Int {

--- a/Sources/LiveKit/Errors.swift
+++ b/Sources/LiveKit/Errors.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 public enum LiveKitErrorType: Int {
     case unknown = 0

--- a/Sources/LiveKit/Extensions/CustomStringConvertible.swift
+++ b/Sources/LiveKit/Extensions/CustomStringConvertible.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 extension TrackSettings: CustomStringConvertible {
     public var description: String {

--- a/Sources/LiveKit/Extensions/LKRTCRtpSender.swift
+++ b/Sources/LiveKit/Extensions/LKRTCRtpSender.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 extension LKRTCRtpSender: Loggable {
     // ...

--- a/Sources/LiveKit/Extensions/Logger.swift
+++ b/Sources/LiveKit/Extensions/Logger.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import Logging
+#else
 @_implementationOnly import Logging
+#endif
 
 /// Allows to extend with custom `log` method which automatically captures current type (class name).
 public protocol Loggable {}

--- a/Sources/LiveKit/Extensions/RTCConfiguration.swift
+++ b/Sources/LiveKit/Extensions/RTCConfiguration.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 extension LKRTCConfiguration {
     static func liveKitDefault() -> LKRTCConfiguration {

--- a/Sources/LiveKit/Extensions/RTCDataChannel+Util.swift
+++ b/Sources/LiveKit/Extensions/RTCDataChannel+Util.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 extension LKRTCDataChannel {
     enum labels {

--- a/Sources/LiveKit/Extensions/RTCI420Buffer.swift
+++ b/Sources/LiveKit/Extensions/RTCI420Buffer.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 extension LKRTCI420Buffer {
     func toPixelBuffer() -> CVPixelBuffer? {

--- a/Sources/LiveKit/Extensions/RTCMediaConstraints.swift
+++ b/Sources/LiveKit/Extensions/RTCMediaConstraints.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 extension LKRTCMediaConstraints {
     //    static let defaultOfferConstraints = RTCMediaConstraints(

--- a/Sources/LiveKit/Extensions/RTCRtpTransceiver.swift
+++ b/Sources/LiveKit/Extensions/RTCRtpTransceiver.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 extension LKRTCRtpTransceiver: Loggable {
     /// Attempts to set preferred video codec.

--- a/Sources/LiveKit/Extensions/RTCVideoCapturerDelegate+Buffer.swift
+++ b/Sources/LiveKit/Extensions/RTCVideoCapturerDelegate+Buffer.swift
@@ -20,7 +20,11 @@ import Foundation
 import ReplayKit
 #endif
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 extension FixedWidthInteger {
     func roundUp(toMultipleOf powerOfTwo: Self) -> Self {

--- a/Sources/LiveKit/LiveKit.swift
+++ b/Sources/LiveKit/LiveKit.swift
@@ -16,8 +16,13 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+internal import Logging
+#else
 @_implementationOnly import LiveKitWebRTC
 @_implementationOnly import Logging
+#endif
 
 let logger = Logger(label: "LiveKitSDK")
 

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -20,7 +20,11 @@ import Foundation
 import ReplayKit
 #endif
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public class LocalParticipant: Participant {

--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public class Participant: NSObject, ObservableObject, Loggable {

--- a/Sources/LiveKit/Participant/RemoteParticipant.swift
+++ b/Sources/LiveKit/Participant/RemoteParticipant.swift
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import Foundation
-
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public class RemoteParticipant: Participant {

--- a/Sources/LiveKit/Protocols/AudioRenderer.swift
+++ b/Sources/LiveKit/Protocols/AudioRenderer.swift
@@ -15,9 +15,12 @@
  */
 
 import CoreMedia
-import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public protocol AudioRenderer {

--- a/Sources/LiveKit/Protocols/EngineDelegate.swift
+++ b/Sources/LiveKit/Protocols/EngineDelegate.swift
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import Foundation
-
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 protocol EngineDelegate: AnyObject {
     func engine(_ engine: Engine, didMutateState state: Engine.State, oldState: Engine.State) async

--- a/Sources/LiveKit/Protocols/SignalClientDelegate.swift
+++ b/Sources/LiveKit/Protocols/SignalClientDelegate.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 protocol SignalClientDelegate: AnyObject {
     func signalClient(_ signalClient: SignalClient, didUpdateConnectionState newState: ConnectionState, oldState: ConnectionState, disconnectError: LiveKitError?) async

--- a/Sources/LiveKit/Protocols/TrackDelegate.swift
+++ b/Sources/LiveKit/Protocols/TrackDelegate.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public protocol TrackDelegate: AnyObject {

--- a/Sources/LiveKit/Protocols/TransportDelegate.swift
+++ b/Sources/LiveKit/Protocols/TransportDelegate.swift
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import Foundation
-
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 protocol TransportDelegate: AnyObject {
     func transport(_ transport: Transport, didUpdateState state: RTCPeerConnectionState) async

--- a/Sources/LiveKit/Protocols/VideoRenderer.swift
+++ b/Sources/LiveKit/Protocols/VideoRenderer.swift
@@ -15,9 +15,12 @@
  */
 
 import AVFoundation
-import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public protocol VideoRenderer {

--- a/Sources/LiveKit/Protocols/VideoViewDelegate.swift
+++ b/Sources/LiveKit/Protocols/VideoViewDelegate.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public protocol VideoViewDelegate: AnyObject {

--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import Foundation
-
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 typealias DebouncFunc = () -> Void
 

--- a/Sources/LiveKit/SwiftUI/SwiftUIAudioRoutePickerButton.swift
+++ b/Sources/LiveKit/SwiftUI/SwiftUIAudioRoutePickerButton.swift
@@ -15,10 +15,13 @@
  */
 
 import AVKit
-import Foundation
 import SwiftUI
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 public struct SwiftUIAudioRoutePickerButton: NativeViewRepresentable {
     public init() {}

--- a/Sources/LiveKit/Track/AudioManager.swift
+++ b/Sources/LiveKit/Track/AudioManager.swift
@@ -16,9 +16,12 @@
 
 import Accelerate
 import AVFoundation
-import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 // Wrapper for LKRTCAudioBuffer
 @objc

--- a/Sources/LiveKit/Track/AudioTrack.swift
+++ b/Sources/LiveKit/Track/AudioTrack.swift
@@ -16,7 +16,5 @@
 
 import Foundation
 
-@_implementationOnly import LiveKitWebRTC
-
 @objc
 public protocol AudioTrack where Self: Track {}

--- a/Sources/LiveKit/Track/Capturers/BufferCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/BufferCapturer.swift
@@ -17,7 +17,11 @@
 import CoreMedia
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 /// A ``VideoCapturer`` that can capture ``CMSampleBuffer``s.
 ///

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -20,7 +20,11 @@ import Foundation
 import ReplayKit
 #endif
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 public class CameraCapturer: VideoCapturer {
     /// Current device used for capturing

--- a/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
@@ -20,7 +20,11 @@ import Foundation
 import ReplayKit
 #endif
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @available(macOS 11.0, iOS 11.0, *)
 public class InAppScreenCapturer: VideoCapturer {

--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -21,7 +21,11 @@ import Foundation
 import ScreenCaptureKit
 #endif
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 #if os(macOS)
 

--- a/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 protocol VideoCapturerProtocol {
     var capturer: LKRTCVideoCapturer { get }

--- a/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public class LocalAudioTrack: Track, LocalTrack, AudioTrack {

--- a/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public class LocalVideoTrack: Track, LocalTrack, VideoTrack {

--- a/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
@@ -15,9 +15,12 @@
  */
 
 import CoreMedia
-import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public class RemoteAudioTrack: Track, RemoteTrack, AudioTrack {

--- a/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import Foundation
-
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public class RemoteVideoTrack: Track, RemoteTrack, VideoTrack {

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public class Track: NSObject, Loggable {

--- a/Sources/LiveKit/Track/VideoTrack.swift
+++ b/Sources/LiveKit/Track/VideoTrack.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public protocol VideoTrack where Self: Track {

--- a/Sources/LiveKit/TrackPublications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/RemoteTrackPublication.swift
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import CoreGraphics
-import Foundation
-
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public enum SubscriptionState: Int, Codable {

--- a/Sources/LiveKit/Types/AudioDevice.swift
+++ b/Sources/LiveKit/Types/AudioDevice.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public class AudioDevice: NSObject, MediaDevice {

--- a/Sources/LiveKit/Types/AudioEncoding.swift
+++ b/Sources/LiveKit/Types/AudioEncoding.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public class AudioEncoding: NSObject, MediaEncoding {

--- a/Sources/LiveKit/Types/DegradationPreference.swift
+++ b/Sources/LiveKit/Types/DegradationPreference.swift
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public enum DegradationPreference: Int {

--- a/Sources/LiveKit/Types/Dimensions.swift
+++ b/Sources/LiveKit/Types/Dimensions.swift
@@ -15,9 +15,12 @@
  */
 
 import CoreMedia
-import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public class Dimensions: NSObject, Loggable {

--- a/Sources/LiveKit/Types/IceCandidate.swift
+++ b/Sources/LiveKit/Types/IceCandidate.swift
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import Foundation
-
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 struct IceCandidate: Codable {
     let sdp: String

--- a/Sources/LiveKit/Types/IceServer.swift
+++ b/Sources/LiveKit/Types/IceServer.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 /// Options used when establishing a connection.
 @objc

--- a/Sources/LiveKit/Types/Options/AudioCaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/AudioCaptureOptions.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public class AudioCaptureOptions: NSObject, CaptureOptions {

--- a/Sources/LiveKit/Types/Options/BufferCaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/BufferCaptureOptions.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public class BufferCaptureOptions: NSObject, VideoCaptureOptions {

--- a/Sources/LiveKit/Types/SessionDescription.swift
+++ b/Sources/LiveKit/Types/SessionDescription.swift
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import Foundation
-
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 extension LKRTCSessionDescription {
     func toPBType() -> Livekit_SessionDescription {

--- a/Sources/LiveKit/Types/TrackStatistics.swift
+++ b/Sources/LiveKit/Types/TrackStatistics.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public class TrackStatistics: NSObject, Loggable {

--- a/Sources/LiveKit/Types/TrackStreamState.swift
+++ b/Sources/LiveKit/Types/TrackStreamState.swift
@@ -16,7 +16,11 @@
 
 import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 @objc
 public enum StreamState: Int {

--- a/Sources/LiveKit/Types/VideoFrame.swift
+++ b/Sources/LiveKit/Types/VideoFrame.swift
@@ -15,9 +15,12 @@
  */
 
 import CoreMedia
-import Foundation
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 public protocol VideoBuffer {}
 

--- a/Sources/LiveKit/Types/VideoRotation.swift
+++ b/Sources/LiveKit/Types/VideoRotation.swift
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import Foundation
-
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 public enum VideoRotation: Int {
     case _0 = 0

--- a/Sources/LiveKit/Views/SampleBufferVideoRenderer.swift
+++ b/Sources/LiveKit/Views/SampleBufferVideoRenderer.swift
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import Foundation
-
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 class SampleBufferVideoRenderer: NativeView, Loggable {
     public let sampleBufferDisplayLayer: AVSampleBufferDisplayLayer

--- a/Sources/LiveKit/Views/VideoView+PinchToZoom.swift
+++ b/Sources/LiveKit/Views/VideoView+PinchToZoom.swift
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import Foundation
-
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 extension VideoView {
     static let rampRate: Float = 32.0

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -15,10 +15,13 @@
  */
 
 import AVFoundation
-import Foundation
 import MetalKit
 
+#if swift(>=5.9)
+internal import LiveKitWebRTC
+#else
 @_implementationOnly import LiveKitWebRTC
+#endif
 
 /// A ``NativeViewType`` that conforms to ``RTCVideoRenderer``.
 typealias NativeRendererView = LKRTCVideoRenderer & Mirrorable & NativeViewType


### PR DESCRIPTION
This is giving compile time warnings.

Use `Access-level modifiers on import declarations` instead of `@_implementationOnly`.
Spec: https://github.com/apple/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md

Swift 5.9+

