### PR TITLE
Fix Swift 6.0 compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,5 +52,8 @@ let package = Package(
                 .product(name: "JWTKit", package: "jwt-kit"),
             ]
         ),
+    ],
+    swiftLanguageVersions: [
+        .v5
     ]
 )

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -55,5 +55,8 @@ let package = Package(
                 .product(name: "JWTKit", package: "jwt-kit"),
             ]
         ),
+    ],
+    swiftLanguageVersions: [
+        .v5
     ]
 )

--- a/Sources/LiveKit/Broadcast/Uploader/DarwinNotificationCenter.swift
+++ b/Sources/LiveKit/Broadcast/Uploader/DarwinNotificationCenter.swift
@@ -22,7 +22,11 @@ enum DarwinNotification: String {
 }
 
 class DarwinNotificationCenter {
-    static let shared = DarwinNotificationCenter()
+    #if compiler(>=6.0)
+    public nonisolated(unsafe) static let shared = DarwinNotificationCenter()
+    #else
+    public static let shared = DarwinNotificationCenter()
+    #endif
 
     private let notificationCenter: CFNotificationCenter
 

--- a/Sources/LiveKit/Support/DeviceManager.swift
+++ b/Sources/LiveKit/Support/DeviceManager.swift
@@ -20,7 +20,11 @@ import AVFoundation
 class DeviceManager: Loggable {
     // MARK: - Public
 
+    #if compiler(>=6.0)
+    public nonisolated(unsafe) static let shared = DeviceManager()
+    #else
     public static let shared = DeviceManager()
+    #endif
 
     public static func prepare() {
         // Instantiate shared instance

--- a/Sources/LiveKit/Track/AudioManager.swift
+++ b/Sources/LiveKit/Track/AudioManager.swift
@@ -99,7 +99,11 @@ class AudioCustomProcessingDelegateAdapter: NSObject, LKRTCAudioCustomProcessing
 public class AudioManager: Loggable {
     // MARK: - Public
 
+    #if compiler(>=6.0)
+    public nonisolated(unsafe) static let shared = AudioManager()
+    #else
     public static let shared = AudioManager()
+    #endif
 
     public typealias ConfigureAudioSessionFunc = (_ newState: State,
                                                   _ oldState: State) -> Void

--- a/Sources/LiveKit/Types/Dimensions.swift
+++ b/Sources/LiveKit/Types/Dimensions.swift
@@ -23,7 +23,7 @@ internal import LiveKitWebRTC
 #endif
 
 @objc
-public class Dimensions: NSObject, Loggable {
+public final class Dimensions: NSObject, Loggable, Sendable {
     @objc
     public let width: Int32
 

--- a/Sources/LiveKit/Types/VideoCodec.swift
+++ b/Sources/LiveKit/Types/VideoCodec.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 @objc
-public class VideoCodec: NSObject, Identifiable {
+public final class VideoCodec: NSObject, Identifiable, Sendable {
     public static func from(id: String) throws -> VideoCodec {
         // Try to find codec from id...
         guard let codec = all.first(where: { $0.id == id }) else {


### PR DESCRIPTION
The SDK isn't compatible with Swift 6 (and looks like it would need a lot of work to handle all warnings).

This does allow using the SDK from an app compiling with Swift 6:
![Screenshot 2024-06-21 at 08 33 43](https://github.com/livekit/client-sdk-swift/assets/685609/207e980f-20f4-4b31-90ed-e7879570ecc4)
