### PR TITLE
VideoRenderer protocol related fixes

### DIFF
--- a/Sources/LiveKit/Protocols/VideoRenderer.swift
+++ b/Sources/LiveKit/Protocols/VideoRenderer.swift
@@ -37,10 +37,11 @@ public protocol VideoRenderer {
     @objc optional
     func set(size: CGSize)
 
+    /// A ``VideoFrame`` is ready and should be processed.
     @objc optional
     func render(frame: VideoFrame)
 
-    // Only invoked for local tracks, provides additional capture time options
+    /// In addition to ``VideoFrame``, provide capture-time information if available.
     @objc optional
     func render(frame: VideoFrame, captureDevice: AVCaptureDevice?, captureOptions: VideoCaptureOptions?)
 }

--- a/Sources/LiveKit/Protocols/VideoRenderer.swift
+++ b/Sources/LiveKit/Protocols/VideoRenderer.swift
@@ -47,11 +47,9 @@ public protocol VideoRenderer {
 
 class VideoRendererAdapter: NSObject, LKRTCVideoRenderer {
     private weak var target: VideoRenderer?
-    private weak var localVideoTrack: LocalVideoTrack?
 
-    init(target: VideoRenderer, localVideoTrack: LocalVideoTrack?) {
+    init(target: VideoRenderer) {
         self.target = target
-        self.localVideoTrack = localVideoTrack
     }
 
     func setSize(_ size: CGSize) {
@@ -61,9 +59,7 @@ class VideoRendererAdapter: NSObject, LKRTCVideoRenderer {
     func renderFrame(_ frame: LKRTCVideoFrame?) {
         guard let frame = frame?.toLKType() else { return }
         target?.render?(frame: frame)
-
-        let cameraCapturer = localVideoTrack?.capturer as? CameraCapturer
-        target?.render?(frame: frame, captureDevice: cameraCapturer?.device, captureOptions: cameraCapturer?.options)
+        target?.render?(frame: frame, captureDevice: nil, captureOptions: nil)
     }
 
     // Proxy the equality operators

--- a/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
@@ -231,6 +231,7 @@ extension VideoCapturer {
         if rendererDelegates.isDelegatesNotEmpty {
             if let lkVideoFrame = frame.toLKType() {
                 rendererDelegates.notify { renderer in
+                    renderer.render?(frame: lkVideoFrame)
                     renderer.render?(frame: lkVideoFrame, captureDevice: device, captureOptions: options)
                 }
             }

--- a/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
@@ -23,7 +23,7 @@ internal import LiveKitWebRTC
 #endif
 
 @objc
-public class LocalVideoTrack: Track, LocalTrack, VideoTrack {
+public class LocalVideoTrack: Track, LocalTrack {
     @objc
     public internal(set) var capturer: VideoCapturer
 
@@ -67,12 +67,14 @@ public class LocalVideoTrack: Track, LocalTrack, VideoTrack {
     }
 }
 
-public extension LocalVideoTrack {
-    func add(videoRenderer: VideoRenderer) {
+// MARK: - VideoTrack Protocol
+
+extension LocalVideoTrack: VideoTrack {
+    public func add(videoRenderer: VideoRenderer) {
         capturer.rendererDelegates.add(delegate: videoRenderer)
     }
 
-    func remove(videoRenderer: VideoRenderer) {
+    public func remove(videoRenderer: VideoRenderer) {
         capturer.rendererDelegates.remove(delegate: videoRenderer)
     }
 }

--- a/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
@@ -21,7 +21,7 @@ internal import LiveKitWebRTC
 #endif
 
 @objc
-public class RemoteVideoTrack: Track, RemoteTrack, VideoTrack {
+public class RemoteVideoTrack: Track, RemoteTrack {
     init(name: String,
          source: Track.Source,
          track: LKRTCMediaStreamTrack,
@@ -35,12 +35,32 @@ public class RemoteVideoTrack: Track, RemoteTrack, VideoTrack {
     }
 }
 
-public extension RemoteVideoTrack {
-    func add(videoRenderer: VideoRenderer) {
-        super._add(videoRenderer: videoRenderer)
+// MARK: - VideoTrack Protocol
+
+extension RemoteVideoTrack: VideoTrack {
+    public func add(videoRenderer: VideoRenderer) {
+        guard let rtcVideoTrack = mediaTrack as? LKRTCVideoTrack else {
+            log("mediaTrack is not a RTCVideoTrack", .error)
+            return
+        }
+
+        _state.mutate {
+            $0.videoRenderers.add(videoRenderer)
+        }
+
+        rtcVideoTrack.add(VideoRendererAdapter(target: videoRenderer))
     }
 
-    func remove(videoRenderer: VideoRenderer) {
-        super._remove(videoRenderer: videoRenderer)
+    public func remove(videoRenderer: VideoRenderer) {
+        guard let rtcVideoTrack = mediaTrack as? LKRTCVideoTrack else {
+            log("mediaTrack is not a RTCVideoTrack", .error)
+            return
+        }
+
+        _state.mutate {
+            $0.videoRenderers.remove(videoRenderer)
+        }
+
+        rtcVideoTrack.remove(VideoRendererAdapter(target: videoRenderer))
     }
 }

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -357,39 +357,6 @@ extension Track {
     }
 }
 
-// MARK: - VideoTrack
-
-// workaround for error:
-// @objc can only be used with members of classes, @objc protocols, and concrete extensions of classes
-//
-extension Track {
-    func _add(videoRenderer: VideoRenderer) {
-        guard self is VideoTrack, let rtcVideoTrack = mediaTrack as? LKRTCVideoTrack else {
-            log("mediaTrack is not a RTCVideoTrack", .error)
-            return
-        }
-
-        _state.mutate {
-            $0.videoRenderers.add(videoRenderer)
-        }
-
-        rtcVideoTrack.add(VideoRendererAdapter(target: videoRenderer, localVideoTrack: self as? LocalVideoTrack))
-    }
-
-    func _remove(videoRenderer: VideoRenderer) {
-        guard self is VideoTrack, let rtcVideoTrack = mediaTrack as? LKRTCVideoTrack else {
-            log("mediaTrack is not a RTCVideoTrack", .error)
-            return
-        }
-
-        _state.mutate {
-            $0.videoRenderers.remove(videoRenderer)
-        }
-
-        rtcVideoTrack.remove(VideoRendererAdapter(target: videoRenderer, localVideoTrack: self as? LocalVideoTrack))
-    }
-}
-
 // MARK: - Identifiable (SwiftUI)
 
 extension Track: Identifiable {


### PR DESCRIPTION
* Remove unnecessary code.
* Always invoke both `render(frame:)` and `render(frame:captureDevice:captureOptions:)`.