### PR TITLE
Relaunch screenshare ext. when re-enabling the track

### DIFF
--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -306,20 +306,14 @@ public extension LocalParticipant {
             // Try to get existing publication
             if let publication = self.getTrackPublication(source: source) as? LocalTrackPublication {
                 if enabled {
-                    #if os(iOS)
-                    if source == .screenShareVideo {
-                        let options = (captureOptions as? ScreenShareCaptureOptions) ?? room._state.roomOptions.defaultScreenShareCaptureOptions
-                        if options.useBroadcastExtension {
-                            let screenShareExtensionId = Bundle.main.infoDictionary?[BroadcastScreenCapturer.kRTCScreenSharingExtension] as? String
-                            await RPSystemBroadcastPickerView.show(for: screenShareExtensionId, showsMicrophoneButton: false)
-                        }
-                    }
-                    #endif
-
                     try await publication.unmute()
                     return publication
                 } else {
-                    try await publication.mute()
+                    if source == .camera || source == .microphone {
+                        try await publication.mute()
+                    } else {
+                        try await self.unpublish(publication: publication)
+                    }
                     return publication
                 }
             } else if enabled {

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -306,6 +306,16 @@ public extension LocalParticipant {
             // Try to get existing publication
             if let publication = self.getTrackPublication(source: source) as? LocalTrackPublication {
                 if enabled {
+                    #if os(iOS)
+                    if source == .screenShareVideo {
+                        let options = (captureOptions as? ScreenShareCaptureOptions) ?? room._state.roomOptions.defaultScreenShareCaptureOptions
+                        if options.useBroadcastExtension {
+                            let screenShareExtensionId = Bundle.main.infoDictionary?[BroadcastScreenCapturer.kRTCScreenSharingExtension] as? String
+                            await RPSystemBroadcastPickerView.show(for: screenShareExtensionId, showsMicrophoneButton: false)
+                        }
+                    }
+                    #endif
+
                     try await publication.unmute()
                     return publication
                 } else {


### PR DESCRIPTION
Unless unpublished, the screenshare ext was not re-launching when calling setScreenShare(enabled: true) in iOS causing confusion.

Related issues:
https://github.com/livekit/client-sdk-swift/issues/412
https://github.com/livekit-examples/swift-example/issues/37
https://github.com/livekit-examples/swift-example/issues/39
