### PR TITLE
Use `AVCaptureMultiCamSession` for iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "125.6422.03"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "125.6422.04"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.26.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
         // Only used for DocC generation

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -18,7 +18,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "125.6422.03"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "125.6422.04"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.26.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
         // Only used for DocC generation

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -89,8 +89,19 @@ public class CameraCapturer: VideoCapturer {
     // Used to hide LKRTCVideoCapturerDelegate symbol
     private lazy var adapter: VideoCapturerDelegateAdapter = .init(cameraCapturer: self)
 
+    #if os(iOS)
+    private lazy var multiCamSession = AVCaptureMultiCamSession()
+    #endif
+
     // RTCCameraVideoCapturer used internally for now
-    private lazy var capturer: LKRTCCameraVideoCapturer = DispatchQueue.liveKitWebRTC.sync { LKRTCCameraVideoCapturer(delegate: adapter) }
+    private lazy var capturer: LKRTCCameraVideoCapturer = {
+        #if os(iOS)
+        let result = LKRTCCameraVideoCapturer(delegate: adapter, captureSession: multiCamSession)
+        #else
+        let result = LKRTCCameraVideoCapturer(delegate: adapter)
+        #endif
+        return result
+    }()
 
     init(delegate: LKRTCVideoCapturerDelegate, options: CameraCaptureOptions) {
         _cameraCapturerState = StateSync(State(options: options))

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -90,13 +90,13 @@ public class CameraCapturer: VideoCapturer {
     private lazy var adapter: VideoCapturerDelegateAdapter = .init(cameraCapturer: self)
 
     #if os(iOS)
-    private lazy var multiCamSession = AVCaptureMultiCamSession()
+    public static let multiCamSession = AVCaptureMultiCamSession()
     #endif
 
     // RTCCameraVideoCapturer used internally for now
     private lazy var capturer: LKRTCCameraVideoCapturer = {
         #if os(iOS)
-        let result = LKRTCCameraVideoCapturer(delegate: adapter, captureSession: multiCamSession)
+        let result = LKRTCCameraVideoCapturer(delegate: adapter, captureSession: Self.multiCamSession)
         #else
         let result = LKRTCCameraVideoCapturer(delegate: adapter)
         #endif


### PR DESCRIPTION
Allows simultaneous capturing of front and back cameras.

Related issue:
https://github.com/livekit/client-sdk-swift/issues/429
 