### PR TITLE
Add timestamps to TranscriptionSegment

### DIFF
--- a/Sources/LiveKit/Core/Room+EngineDelegate.swift
+++ b/Sources/LiveKit/Core/Room+EngineDelegate.swift
@@ -207,6 +207,11 @@ extension Room {
             return
         }
 
+        guard !packet.segments.isEmpty else {
+            log("[Transcription] Received segments are empty", .warning)
+            return
+        }
+
         let segments = packet.segments.map { segment in
             TranscriptionSegment(id: segment.id,
                                  text: segment.text,
@@ -216,14 +221,13 @@ extension Room {
                                  isFinal: segment.final)
         }
 
-        guard !segments.isEmpty else {
-            log("[Transcription] Received segments are empty", .warning)
-            return
-        }
-
         _state.mutate { state in
             for segment in segments {
-                state.transcriptionReceivedTimes[segment.id] = segment.firstReceivedTime
+                if segment.isFinal {
+                    state.transcriptionReceivedTimes.removeValue(forKey: segment.id)
+                } else {
+                    state.transcriptionReceivedTimes[segment.id] = segment.firstReceivedTime
+                }
             }
         }
 

--- a/Sources/LiveKit/Core/Room+EngineDelegate.swift
+++ b/Sources/LiveKit/Core/Room+EngineDelegate.swift
@@ -207,11 +207,24 @@ extension Room {
             return
         }
 
-        let segments = packet.segments.map { $0.toLKType() }
+        let segments = packet.segments.map { segment in
+            TranscriptionSegment(id: segment.id,
+                                 text: segment.text,
+                                 language: segment.language,
+                                 firstReceivedTime: _state.receivedTranscriptionSegments[segment.id]?.firstReceivedTime ?? Date(),
+                                 lastReceivedTime: Date(),
+                                 isFinal: segment.final)
+        }
 
         guard !segments.isEmpty else {
             log("[Transcription] Received segments are empty", .warning)
             return
+        }
+
+        _state.mutate { state in
+            for segment in segments {
+                state.receivedTranscriptionSegments[segment.id] = segment
+            }
         }
 
         delegates.notify {

--- a/Sources/LiveKit/Core/Room+EngineDelegate.swift
+++ b/Sources/LiveKit/Core/Room+EngineDelegate.swift
@@ -211,7 +211,7 @@ extension Room {
             TranscriptionSegment(id: segment.id,
                                  text: segment.text,
                                  language: segment.language,
-                                 firstReceivedTime: _state.receivedTranscriptionSegments[segment.id]?.firstReceivedTime ?? Date(),
+                                 firstReceivedTime: _state.transcriptionReceivedTimes[segment.id] ?? Date(),
                                  lastReceivedTime: Date(),
                                  isFinal: segment.final)
         }
@@ -223,7 +223,7 @@ extension Room {
 
         _state.mutate { state in
             for segment in segments {
-                state.receivedTranscriptionSegments[segment.id] = segment
+                state.transcriptionReceivedTimes[segment.id] = segment.firstReceivedTime
             }
         }
 

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -147,6 +147,9 @@ public class Room: NSObject, ObservableObject, Loggable {
         var publisher: Transport?
         var subscriber: Transport?
         var isSubscriberPrimary: Bool = false
+        
+        // Agents
+        var receivedTranscriptionSegments: [String: TranscriptionSegment] = [:]
 
         @discardableResult
         mutating func updateRemoteParticipant(info: Livekit_ParticipantInfo, room: Room) -> RemoteParticipant {

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -149,7 +149,7 @@ public class Room: NSObject, ObservableObject, Loggable {
         var isSubscriberPrimary: Bool = false
         
         // Agents
-        var receivedTranscriptionSegments: [String: TranscriptionSegment] = [:]
+        var transcriptionReceivedTimes: [String: Date] = [:]
 
         @discardableResult
         mutating func updateRemoteParticipant(info: Livekit_ParticipantInfo, room: Room) -> RemoteParticipant {

--- a/Sources/LiveKit/Types/TranscriptionSegment.swift
+++ b/Sources/LiveKit/Types/TranscriptionSegment.swift
@@ -21,22 +21,22 @@ public class TranscriptionSegment: NSObject {
     public let id: String
     public let text: String
     public let language: String
-    public let startTime: UInt64
-    public let endTime: UInt64
+    public let firstReceivedTime: Date
+    public let lastReceivedTime: Date
     public let isFinal: Bool
 
     init(id: String,
          text: String,
          language: String,
-         startTime: UInt64,
-         endTime: UInt64,
+         firstReceivedTime: Date,
+         lastReceivedTime: Date,
          isFinal: Bool)
     {
         self.id = id
         self.text = text
         self.language = language
-        self.startTime = startTime
-        self.endTime = endTime
+        self.firstReceivedTime = firstReceivedTime
+        self.lastReceivedTime = lastReceivedTime
         self.isFinal = isFinal
     }
 
@@ -51,18 +51,5 @@ public class TranscriptionSegment: NSObject {
         var hasher = Hasher()
         hasher.combine(id)
         return hasher.finalize()
-    }
-}
-
-// MARK: - Internal
-
-extension Livekit_TranscriptionSegment {
-    func toLKType() -> TranscriptionSegment {
-        TranscriptionSegment(id: id,
-                             text: text,
-                             language: language,
-                             startTime: startTime,
-                             endTime: endTime,
-                             isFinal: final)
     }
 }


### PR DESCRIPTION
This adds tracking of transcription receipt times which simplifies the consumption of this feature. I also removed startTime and endTime from the version we expose, since neither is used yet at the protocol level.

The new fields are `firstReceivedTime` and `lastReceivedTime`.

I tried this out in my sample project and it really simplified things. Now I can implement a very basic real-time chat thread without needing multiple data structures or new types. The only thing that still requires extra bookkeeping is tracking participant name, etc, since TranscriptionSegment lives under TrackPublication and Participant, and we don't denormalize the Participant id down the chain.

See the [associated commit in my docs PR](https://github.com/livekit/web/pull/315/commits/0076c753c9bb62b0bbe743f85c6a51f372fcd06b) for a visual of how this simplifies basic uses