### PR TITLE
fix visionOS compilation in Xcode 15

### DIFF
--- a/Sources/LiveKit/Track/Capturers/ARCameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/ARCameraCapturer.swift
@@ -18,7 +18,11 @@
 import ARKit
 import Foundation
 
+#if swift(>=5.9)
 internal import LiveKitWebRTC
+#else
+@_implementationOnly import LiveKitWebRTC
+#endif
 
 @available(visionOS 2.0, *)
 public class ARCameraCapturer: VideoCapturer {

--- a/Sources/LiveKit/Track/Capturers/ARCameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/ARCameraCapturer.swift
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-#if os(visionOS)
+#if os(visionOS) && compiler(>=6.0)
 import ARKit
 import Foundation
 
-#if swift(>=5.9)
 internal import LiveKitWebRTC
-#else
-@_implementationOnly import LiveKitWebRTC
-#endif
 
 @available(visionOS 2.0, *)
 public class ARCameraCapturer: VideoCapturer {

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -780,11 +780,13 @@ extension VideoView {
 
 // MARK: - Access MTKView
 
+#if !os(visionOS) || compiler(>=6.0)
 extension NativeViewType {
     func findMTKView() -> MTKView? {
         subviews.compactMap { $0 as? MTKView }.first
     }
 }
+#endif
 
 #if os(macOS)
 extension NSView {


### PR DESCRIPTION
I found that the client SDK won't compile when using Xcode 15 (the current production version of Xcode) targeting visionOS 1:

-`MTKView` is compatible with visionOS 1, but only when built with Xcode 16. 
-`CameraFrameProvider` is wholly new in visionOS 2.

I'm not sure if there's a more correct way to hide these pieces from Xcode 15 but `compiler(>=6.0)` seems to work for me.