### PR TITLE
Fix loudspeaker usage during playback only

### DIFF
--- a/Sources/LiveKit/Track/AudioManager.swift
+++ b/Sources/LiveKit/Track/AudioManager.swift
@@ -210,7 +210,7 @@ public class AudioManager: Loggable {
             #if os(iOS)
             let configureFunc = newState.customConfigureFunc ?? self.defaultConfigureAudioSessionFunc
             configureFunc(newState, oldState)
-#endif
+            #endif
         }
     }
 

--- a/Sources/LiveKit/Track/AudioManager.swift
+++ b/Sources/LiveKit/Track/AudioManager.swift
@@ -61,11 +61,11 @@ public class LKAudioBuffer: NSObject {
 public class AudioManager: Loggable {
     // MARK: - Public
 
-#if compiler(>=6.0)
+    #if compiler(>=6.0)
     public nonisolated(unsafe) static let shared = AudioManager()
-#else
+    #else
     public static let shared = AudioManager()
-#endif
+    #endif
 
     public typealias ConfigureAudioSessionFunc = (_ newState: State,
                                                   _ oldState: State) -> Void
@@ -90,8 +90,8 @@ public class AudioManager: Loggable {
         // Only consider State mutated when public vars change
         public static func == (lhs: AudioManager.State, rhs: AudioManager.State) -> Bool {
             lhs.localTracksCount == rhs.localTracksCount &&
-            lhs.remoteTracksCount == rhs.remoteTracksCount &&
-            lhs.isSpeakerOutputPreferred == rhs.isSpeakerOutputPreferred
+                lhs.remoteTracksCount == rhs.remoteTracksCount &&
+                lhs.isSpeakerOutputPreferred == rhs.isSpeakerOutputPreferred
         }
 
         // Keep this var within State so it's protected by UnfairLock
@@ -207,7 +207,7 @@ public class AudioManager: Loggable {
             guard newState != oldState else { return }
 
             self.log("\(oldState) -> \(newState)")
-#if os(iOS)
+            #if os(iOS)
             let configureFunc = newState.customConfigureFunc ?? self.defaultConfigureAudioSessionFunc
             configureFunc(newState, oldState)
 #endif
@@ -228,7 +228,7 @@ public class AudioManager: Loggable {
         }
     }
 
-#if os(iOS)
+    #if os(iOS)
     /// The default implementation when audio session configuration is requested by the SDK.
     /// Configure the `RTCAudioSession` of `WebRTC` framework.
     ///
@@ -252,11 +252,14 @@ public class AudioManager: Loggable {
                 configuration.categoryOptions = []
             } else {
                 /* .playAndRecord */
+                // Must use playAndRecord even if no mic track is active to get correct speaker usage
                 configuration.category = AVAudioSession.Category.playAndRecord.rawValue
 
                 if newState.isSpeakerOutputPreferred {
+                    // use .videoChat if speakerOutput is preferred
                     configuration.mode = AVAudioSession.Mode.videoChat.rawValue
                 } else {
+                    // use .voiceChat if speakerOutput is not preferred
                     configuration.mode = AVAudioSession.Mode.voiceChat.rawValue
                 }
 
@@ -284,7 +287,7 @@ public class AudioManager: Loggable {
             defer { session.unlockForConfiguration() }
 
             do {
-                self.log("configuring audio session category: \(configuration.category), mode: \(configuration.mode), setActive: \(String(describing: setActive))", .error)
+                self.log("configuring audio session category: \(configuration.category), mode: \(configuration.mode), setActive: \(String(describing: setActive))")
 
                 if let setActive {
                     try session.setConfiguration(configuration, active: setActive)
@@ -297,7 +300,7 @@ public class AudioManager: Loggable {
             }
         }
     }
-#endif
+    #endif
 }
 
 public extension AudioManager {


### PR DESCRIPTION
It seems that prior to https://github.com/livekit/client-sdk-swift/pull/477 a bug existed where mute/unmute would not necessarily cause audio session reconfiguring, which masked an issue with the session configuration.

To get the system to use the loudspeaker and receiver together, at max available volume, the only reliable method I have found is using the `.playAndRecord` category with the `.videoChat` mode. This was set when the microphone was unmuted, but upon mute it reverted to `.playback` with `.spokenAudio`.  That caused a significant drop in apparent audio as only the receiver would be used.

We already used `.playAndRecord` (with `.voiceChat`) in the case that you had a muted microphone but a preference to _not_ use the speaker, so it was possible to simplify things significantly here and unify the code.

I've tested it a bit but more testing and insight would be appreciated @hiroshihorie!