### PR TITLE
Remove leaked renderers appeared on camera switch

### DIFF
--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -701,17 +701,24 @@ extension VideoView: VideoRenderer {
             }
             self._secondaryRenderer = nil
         }
+        
+        let previousPrimaryRendered = self._primaryRenderer
+        let completion: (Bool) -> Void = { _ in
+            previousPrimaryRendered?.removeFromSuperview()
+        }
 
         // Currently only for iOS
         #if os(iOS)
         let (mode, duration, position) = _state.read { ($0.transitionMode, $0.transitionDuration, $0.captureDevice?.facingPosition) }
         if let transitionOption = mode.toAnimationOption(fromPosition: position) {
-            UIView.transition(with: self, duration: duration, options: transitionOption, animations: block, completion: nil)
+            UIView.transition(with: self, duration: duration, options: transitionOption, animations: block, completion: completion)
         } else {
             block()
+            completion(true)
         }
         #else
         block()
+        completion(true)
         #endif
     }
 }


### PR DESCRIPTION
Hello @hiroshihorie!

I found that inside **VideoView** on the camera switch the previous **primaryRenderer** gets leaked because it's not removed from the view's hierarchy when the transition ends. 

See:
![image](https://github.com/user-attachments/assets/b57769be-57c6-4a66-b7b6-d55aeb6bbedd)