### PR TITLE
Don't show error dialog when broadcast stops without error (Swift unsafe cast)

### DIFF
--- a/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
+++ b/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
@@ -95,7 +95,7 @@ open class LKSampleHandler: RPBroadcastSampleHandler {
             // See https://stackoverflow.com/a/63402492 for more discussion
             let selector = #selector(RPBroadcastSampleHandler.finishBroadcastWithError)
             if let methodIMP = self.method(for: selector) {
-                typealias MethodType = @convention(c) (AnyObject, Selector, NSError?) -> Void
+                typealias MethodType = @convention(c) (AnyObject, Selector, Error?) -> Void
                 unsafeBitCast(methodIMP, to: MethodType.self)(self, selector, nil)
             }
         }


### PR DESCRIPTION
When the user calls `setScreenShare(enabled: false)`, we stop the track and close the socket. When the socket is closed without error, we are currently showing a custom error that says "Screen sharing stopped". But this is unnecessary, the user knows they ended screensharing in this scenario (and the red icon is going away). 

[This stackoverflow question](https://stackoverflow.com/questions/63389328/how-to-programatically-stop-a-replaykit-2-system-broadcast-without-rpsystembroad) shows a workaround, which is to call the `finishBroadcastWithError` method with a null error (even though the header suggests error is non-nullable). This works perfectly in testing.

Rather than compiling an objective-c extension as suggested in the SO answer, we can simply cast the method to allow a nullable argument and call that.

I also added a hook to override this behavior in case users prefer to show an error message.