### PR TITLE
Don't show error dialog when broadcast stops without error (Obj-C bridge)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,11 +28,16 @@ let package = Package(
     ],
     targets: [
         .target(
+            name: "LKObjCHelpers",
+            publicHeadersPath: "include"
+        ),
+        .target(
             name: "LiveKit",
             dependencies: [
                 .product(name: "LiveKitWebRTC", package: "webrtc-xcframework"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
                 .product(name: "Logging", package: "swift-log"),
+                "LKObjCHelpers",
             ],
             resources: [
                 .process("PrivacyInfo.xcprivacy"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -30,11 +30,16 @@ let package = Package(
     ],
     targets: [
         .target(
+            name: "LKObjCHelpers",
+            publicHeadersPath: "include"
+        ),
+        .target(
             name: "LiveKit",
             dependencies: [
                 .product(name: "LiveKitWebRTC", package: "webrtc-xcframework"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
                 .product(name: "Logging", package: "swift-log"),
+                "LKObjCHelpers",
             ],
             resources: [
                 .process("PrivacyInfo.xcprivacy"),

--- a/Sources/LKObjCHelpers/LKObjcCHelpers.m
+++ b/Sources/LKObjCHelpers/LKObjcCHelpers.m
@@ -1,0 +1,19 @@
+#import "LKObjcHelpers.h"
+
+@implementation LKObjCHelpers
+
+NS_ASSUME_NONNULL_BEGIN
+
++ (void)finishBroadcastWithoutError:(RPBroadcastSampleHandler *)handler API_AVAILABLE(macos(11.0), ios(10.0), visionos(1.0), tvos(10.0)) {
+    // Call finishBroadcastWithError with nil error, which ends the broadcast without an error popup
+    // This is unsupported/undocumented but appears to work and is preferable to an error dialog with a cryptic default message
+    // See https://stackoverflow.com/a/63402492 for more discussion
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wnonnull"
+    [handler finishBroadcastWithError:nil];
+    #pragma clang diagnostic pop
+}
+
+NS_ASSUME_NONNULL_END
+
+@end

--- a/Sources/LKObjCHelpers/LKObjcCHelpers.m
+++ b/Sources/LKObjCHelpers/LKObjcCHelpers.m
@@ -4,7 +4,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-+ (void)finishBroadcastWithoutError:(RPBroadcastSampleHandler *)handler API_AVAILABLE(macos(11.0), ios(10.0), visionos(1.0), tvos(10.0)) {
++ (void)finishBroadcastWithoutError:(RPBroadcastSampleHandler *)handler API_AVAILABLE(macos(11.0)) {
     // Call finishBroadcastWithError with nil error, which ends the broadcast without an error popup
     // This is unsupported/undocumented but appears to work and is preferable to an error dialog with a cryptic default message
     // See https://stackoverflow.com/a/63402492 for more discussion

--- a/Sources/LKObjCHelpers/include/LKObjcHelpers.h
+++ b/Sources/LKObjCHelpers/include/LKObjcHelpers.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+#import <ReplayKit/ReplayKit.h>
+
+@interface LKObjCHelpers : NSObject
+
++ (void)finishBroadcastWithoutError:(RPBroadcastSampleHandler *)handler API_AVAILABLE(macos(11.0), ios(10.0), visionos(1.0), tvos(10.0));
+
+@end

--- a/Sources/LKObjCHelpers/include/LKObjcHelpers.h
+++ b/Sources/LKObjCHelpers/include/LKObjcHelpers.h
@@ -3,6 +3,6 @@
 
 @interface LKObjCHelpers : NSObject
 
-+ (void)finishBroadcastWithoutError:(RPBroadcastSampleHandler *)handler API_AVAILABLE(macos(11.0), ios(10.0), visionos(1.0), tvos(10.0));
++ (void)finishBroadcastWithoutError:(RPBroadcastSampleHandler *)handler API_AVAILABLE(macos(11.0));
 
 @end

--- a/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
+++ b/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
@@ -57,6 +57,14 @@ open class LKSampleHandler: RPBroadcastSampleHandler {
         openConnection()
     }
 
+    override public func broadcastPaused() {
+        // User has requested to pause the broadcast. Samples will stop being delivered.
+    }
+
+    override public func broadcastResumed() {
+        // User has requested to resume the broadcast. Samples delivery will resume.
+    }
+
     override public func broadcastFinished() {
         // User has requested to finish the broadcast.
         DarwinNotificationCenter.shared.postNotification(.broadcastStopped)

--- a/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
+++ b/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
@@ -20,7 +20,7 @@
 import ReplayKit
 #endif
 
-import ObjectiveC.runtime
+import LKObjCHelpers
 
 open class LKSampleHandler: RPBroadcastSampleHandler {
     private var clientConnection: BroadcastUploadSocketConnection?
@@ -90,14 +90,7 @@ open class LKSampleHandler: RPBroadcastSampleHandler {
         if let error {
             self.finishBroadcastWithError(error)
         } else {
-            // Call finishBroadcastWithError with nil error, which ends the broadcast without an error popup
-            // This is unsupported/undocumented but appears to work and is preferable to a cryptic default LiveKit error message
-            // See https://stackoverflow.com/a/63402492 for more discussion
-            let selector = #selector(RPBroadcastSampleHandler.finishBroadcastWithError)
-            if let methodIMP = self.method(for: selector) {
-                typealias MethodType = @convention(c) (AnyObject, Selector, Error?) -> Void
-                unsafeBitCast(methodIMP, to: MethodType.self)(self, selector, nil)
-            }
+            LKObjCHelpers.finishBroadcastWithoutError(self)
         }
     }
 

--- a/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
+++ b/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
@@ -95,7 +95,7 @@ open class LKSampleHandler: RPBroadcastSampleHandler {
             // See https://stackoverflow.com/a/63402492 for more discussion
             let selector = #selector(RPBroadcastSampleHandler.finishBroadcastWithError)
             if let methodIMP = self.method(for: selector) {
-                typealias MethodType = @convention(c) (AnyObject, Selector, NSError?) -> Void
+                typealias MethodType = @convention(c) (AnyObject, Selector, Error?) -> Void
                 unsafeBitCast(methodIMP, to: MethodType.self)(self, selector, nil)
             }
         }


### PR DESCRIPTION
This is an alternative to #517 that uses the same Objective-C bridge as [used in Telegram](https://github.com/TelegramMessenger/Telegram-iOS/blob/9a46522b431782147cc1d95304180d91d398dd82/submodules/BroadcastUploadHelpers/Sources/BroadcastUploadHelpers.m), instead of some selector and IMP casting magic in Swift 

