### PR TITLE
Actually stop the track when the broadcast extension socket is closed

### DIFF
--- a/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
+++ b/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
@@ -63,8 +63,9 @@ class BroadcastScreenCapturer: BufferCapturer {
             self.capture(pixelBuffer, rotation: rotation.toLKType())
         }
         frameReader.didEnd = { [weak self] in
+            guard let self else { return }
             Task {
-                try? await self?.stopCapture()
+                try await self.stopCapture()
             }
         }
         frameReader.startCapture(with: socketConnection)

--- a/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
+++ b/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
@@ -62,6 +62,11 @@ class BroadcastScreenCapturer: BufferCapturer {
         frameReader.didCapture = { pixelBuffer, rotation in
             self.capture(pixelBuffer, rotation: rotation.toLKType())
         }
+        frameReader.didEnd = { [weak self] in
+            Task {
+                try? await self?.stopCapture()
+            }
+        }
         frameReader.startCapture(with: socketConnection)
         self.frameReader = frameReader
 

--- a/Sources/LiveKit/Broadcast/SocketConnectionFrameReader.swift
+++ b/Sources/LiveKit/Broadcast/SocketConnectionFrameReader.swift
@@ -137,6 +137,7 @@ class SocketConnectionFrameReader: NSObject {
 
     private var message: Message?
     var didCapture: ((CVPixelBuffer, RTCVideoRotation) -> Void)?
+    var didEnd: (() -> Void)?
 
     override init() {}
 
@@ -227,6 +228,7 @@ extension SocketConnectionFrameReader: StreamDelegate {
         case .endEncountered:
             logger.log(level: .debug, "server stream end encountered")
             stopCapture()
+            didEnd?()
         case .errorOccurred:
             logger.log(level: .debug, "server stream error encountered: \(aStream.streamError?.localizedDescription ?? "")")
         default:

--- a/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
+++ b/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
@@ -58,7 +58,7 @@ open class LKSampleHandler: RPBroadcastSampleHandler {
     override public func broadcastPaused() {
         // User has requested to pause the broadcast. Samples will stop being delivered.
         DarwinNotificationCenter.shared.postNotification(.broadcastStopped)
-       clientConnection?.close()
+        clientConnection?.close()
     }
 
     override public func broadcastResumed() {

--- a/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
+++ b/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
@@ -57,8 +57,6 @@ open class LKSampleHandler: RPBroadcastSampleHandler {
 
     override public func broadcastPaused() {
         // User has requested to pause the broadcast. Samples will stop being delivered.
-        DarwinNotificationCenter.shared.postNotification(.broadcastStopped)
-        clientConnection?.close()
     }
 
     override public func broadcastResumed() {

--- a/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
+++ b/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
@@ -57,6 +57,8 @@ open class LKSampleHandler: RPBroadcastSampleHandler {
 
     override public func broadcastPaused() {
         // User has requested to pause the broadcast. Samples will stop being delivered.
+        DarwinNotificationCenter.shared.postNotification(.broadcastStopped)
+       clientConnection?.close()
     }
 
     override public func broadcastResumed() {

--- a/Sources/LiveKit/TrackPublications/LocalTrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/LocalTrackPublication.swift
@@ -110,7 +110,7 @@ extension LocalTrackPublication: VideoCapturerDelegate {
         // Broadcasts can always be stopped from system UI that bypasses our normal disable & unpublish methods.
         // This check ensures that when this happens the track gets unpublished as well.
         #if os(iOS)
-        if state == .stopped && capturer is BroadcastScreenCapturer {
+        if state == .stopped, capturer is BroadcastScreenCapturer {
             Task {
                 guard let participant = try await self.requireParticipant() as? LocalParticipant else {
                     return

--- a/Sources/LiveKit/TrackPublications/LocalTrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/LocalTrackPublication.swift
@@ -109,6 +109,7 @@ extension LocalTrackPublication: VideoCapturerDelegate {
     public func capturer(_ capturer: VideoCapturer, didUpdate state: VideoCapturer.CapturerState) {
         // Broadcasts can always be stopped from system UI that bypasses our normal disable & unpublish methods.
         // This check ensures that when this happens the track gets unpublished as well.
+        #if os(iOS)
         if state == .stopped && capturer is BroadcastScreenCapturer {
             Task {
                 guard let participant = try await self.requireParticipant() as? LocalParticipant else {
@@ -118,6 +119,7 @@ extension LocalTrackPublication: VideoCapturerDelegate {
                 try await participant.unpublish(publication: self)
             }
         }
+        #endif
     }
 }
 

--- a/Sources/LiveKit/TrackPublications/LocalTrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/LocalTrackPublication.swift
@@ -105,6 +105,20 @@ extension LocalTrackPublication: VideoCapturerDelegate {
             }
         }
     }
+
+    public func capturer(_ capturer: VideoCapturer, didUpdate state: VideoCapturer.CapturerState) {
+        // Broadcasts can always be stopped from system UI that bypasses our normal disable & unpublish methods.
+        // This check ensures that when this happens the track gets unpublished as well.
+        if state == .stopped && capturer is BroadcastScreenCapturer {
+            Task {
+                guard let participant = try await self.requireParticipant() as? LocalParticipant else {
+                    return
+                }
+
+                try await participant.unpublish(publication: self)
+            }
+        }
+    }
 }
 
 extension LocalTrackPublication {


### PR DESCRIPTION
This closes https://github.com/livekit/client-sdk-swift/issues/446

Two fixes:

~1. It seems that stopping the broadcast via tapping on the system indicator and choosing "stop broadcast" calls the `broadcastPaused` method instead of the `broadcastFinished` method on the SampleHandler. The only way I could trigger `broadcastFinished` in testing was by locking my device. I could not find a way to trigger `broadcastResumed` so I just went ahead and treated "pause" as final, and close the socket (I think maybe this is vestigial from older iterations of ReplayKit? not sure, it's not an area I'm super familiar with)~
2. When the socket closes the frame reader stops but never notified the BroadcastScreenCapturer that owns it, so the track would stay published even as it stopped being updated.  This fix adds a new callback method to pass the closure up the stack and stop the track.

Not sure what happened in original testing but actually broadcastFinished _is_ called as expected, and broadcastPaused is called when you open the "stop capture" dialog, not when you finish it. I also fixed it to properly unpublish the track, not sure why initial testing showed simply ending capture to be enough.
