### PR TITLE
publish lkobjchelpers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     products: [
         .library(
             name: "LiveKit",
-            targets: ["LiveKit"]
+            targets: ["LiveKit", "LKObjCHelpers"]
         ),
     ],
     dependencies: [

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -15,7 +15,7 @@ let package = Package(
     products: [
         .library(
             name: "LiveKit",
-            targets: ["LiveKit"]
+            targets: ["LiveKit", "LKObjCHelpers"]
         ),
     ],
     dependencies: [

--- a/Sources/LKObjCHelpers/include/module.modulemap
+++ b/Sources/LKObjCHelpers/include/module.modulemap
@@ -1,0 +1,4 @@
+module LKObjCHelpers {
+    header "LKObjCHelpers.h"
+    export *
+}


### PR DESCRIPTION
I get the error "cannot find module LKObjCHelpers" when trying to use the 2.0.19 release of this package in a broadcast extension. It works fine when using a local dependency. I think maybe the issue is here but I'm not certain.