### PR TITLE
Warn if you set bypassVoiceProcessing after creation of PeerConnectionFactory

### DIFF
--- a/Sources/LiveKit/Core/RTC.swift
+++ b/Sources/LiveKit/Core/RTC.swift
@@ -50,7 +50,18 @@ private class VideoEncoderFactorySimulcast: LKRTCVideoEncoderFactorySimulcast {
 }
 
 class RTC {
-    static var bypassVoiceProcessing: Bool = false
+    private static var _bypassVoiceProcessing: Bool = false
+    private static var _peerConnectionFactoryInitialized = false
+
+    static var bypassVoiceProcessing: Bool {
+        get { _bypassVoiceProcessing }
+        set {
+            if _peerConnectionFactoryInitialized {
+                logger.log("Warning: Setting bypassVoiceProcessing after PeerConnectionFactory initialization has no effect", .warning, type: Room.self)
+            }
+            _bypassVoiceProcessing = newValue
+        }
+    }
 
     static let h264BaselineLevel5CodecInfo: LKRTCVideoCodecInfo = {
         // this should never happen
@@ -89,6 +100,7 @@ class RTC {
 
         logger.log("Initializing PeerConnectionFactory...", type: Room.self)
 
+        _peerConnectionFactoryInitialized = true
         return LKRTCPeerConnectionFactory(bypassVoiceProcessing: bypassVoiceProcessing,
                                           encoderFactory: encoderFactory,
                                           decoderFactory: decoderFactory,

--- a/Sources/LiveKit/Core/RTC.swift
+++ b/Sources/LiveKit/Core/RTC.swift
@@ -57,7 +57,7 @@ class RTC {
         get { _bypassVoiceProcessing }
         set {
             if _peerConnectionFactoryInitialized {
-                logger.log("Warning: Setting bypassVoiceProcessing after PeerConnectionFactory initialization has no effect", .warning, type: Room.self)
+                logger.log("Warning: Setting bypassVoiceProcessing after PeerConnectionFactory initialization has no effect. Set it at application launch.", .warning, type: Room.self)
             }
             _bypassVoiceProcessing = newValue
         }

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -515,6 +515,7 @@ extension Room: AppStateDelegate {
 public extension Room {
     /// Set this to true to bypass initialization of voice processing.
     /// Must be set before RTCPeerConnectionFactory gets initialized.
+    /// The most reliable place to set this is in your application's initialization process.
     @objc
     static var bypassVoiceProcessing: Bool {
         get { RTC.bypassVoiceProcessing }


### PR DESCRIPTION
This is an implementation trap as it is, since this property has no effect once the PCF is initialized, and the PCF is also a static property that gets initialized very early in app lifecycle.

In this PR I've just added a warning log, but alternatives worth considering:
- Change the API to be a throwing function and deprecate the original property
- Recreate the PCF if you change this property (implications unknown to me)