### PR TITLE
Expose init from string for Participant.Identity

### DIFF
--- a/Sources/LiveKit/Types/Participant+Types.swift
+++ b/Sources/LiveKit/Types/Participant+Types.swift
@@ -47,7 +47,7 @@ public extension Participant {
         @objc
         public let stringValue: String
 
-        init(from stringValue: String) {
+        public init(from stringValue: String) {
             self.stringValue = stringValue
         }
 


### PR DESCRIPTION
Since we have RoomOptions and it contains [DataPublishOptions](https://docs.livekit.io/client-sdk-swift/documentation/livekit/datapublishoptions) with [destinationIdentities](https://docs.livekit.io/client-sdk-swift/documentation/livekit/datapublishoptions/destinationidentities) with type `Participant.Identity`.
I think it will be more convenient if we change the access level to public. ❤️ 