### PR TITLE
Improve handling of bundle settings

### DIFF
--- a/Sources/LiveKit/Broadcast/BundleInfo.swift
+++ b/Sources/LiveKit/Broadcast/BundleInfo.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 LiveKit
+ * Copyright 2025 LiveKit
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/LiveKit/Broadcast/BundleInfo.swift
+++ b/Sources/LiveKit/Broadcast/BundleInfo.swift
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// A property wrapper type that reflects a value from a bundle's info dictionary.
+@propertyWrapper
+struct BundleInfo<Value>: Sendable {
+    private let key: String
+    private let bundle: Bundle
+
+    init(_ key: String, bundle: Bundle = .main) {
+        self.key = key
+        self.bundle = bundle
+    }
+
+    var wrappedValue: Value? {
+        guard let value = bundle.infoDictionary?[key] as? Value else {
+            logger.warning("Missing bundle property with key `\(key)`")
+            return nil
+        }
+        return value
+    }
+}

--- a/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
+++ b/Sources/LiveKit/Broadcast/Uploader/LKSampleHandler.swift
@@ -27,24 +27,14 @@ open class LKSampleHandler: RPBroadcastSampleHandler {
     private var clientConnection: BroadcastUploadSocketConnection?
     private var uploader: SampleUploader?
 
-    public var appGroupIdentifier: String? {
-        Bundle.main.infoDictionary?[BroadcastScreenCapturer.kAppGroupIdentifierKey] as? String
-    }
-
-    public var socketFilePath: String {
-        guard let appGroupIdentifier,
-              let sharedContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)
-        else {
-            return ""
-        }
-
-        return sharedContainer.appendingPathComponent(BroadcastScreenCapturer.kRTCScreensharingSocketFD).path
-    }
-
     override public init() {
         super.init()
 
-        if let connection = BroadcastUploadSocketConnection(filePath: socketFilePath) {
+        let socketPath = BroadcastScreenCapturer.socketPath
+        if socketPath == nil {
+            logger.error("Bundle settings improperly configured for screen capture")
+        }
+        if let connection = BroadcastUploadSocketConnection(filePath: socketPath ?? "") {
             clientConnection = connection
             setupConnection()
 

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -337,8 +337,10 @@ public extension LocalParticipant {
                     let localTrack: LocalVideoTrack
                     let options = (captureOptions as? ScreenShareCaptureOptions) ?? room._state.roomOptions.defaultScreenShareCaptureOptions
                     if options.useBroadcastExtension {
-                        let screenShareExtensionId = Bundle.main.infoDictionary?[BroadcastScreenCapturer.kRTCScreenSharingExtension] as? String
-                        await RPSystemBroadcastPickerView.show(for: screenShareExtensionId, showsMicrophoneButton: false)
+                        await RPSystemBroadcastPickerView.show(
+                            for: BroadcastScreenCapturer.screenSharingExtension,
+                            showsMicrophoneButton: false
+                        )
                         localTrack = LocalVideoTrack.createBroadcastScreenCapturerTrack(options: options)
                     } else {
                         localTrack = LocalVideoTrack.createInAppScreenShareTrack(options: options)


### PR DESCRIPTION
Summary of changes:
- Report error when required bundle settings are not in place for broadcast screen capture.
- Introduce `BundleInfo` property wrapper to reduce code duplication.