### PR TITLE
Fix CocoaPods error

### DIFF
--- a/Sources/LiveKit/Broadcast/LKSampleHandler.swift
+++ b/Sources/LiveKit/Broadcast/LKSampleHandler.swift
@@ -27,8 +27,11 @@ internal import Logging
 #endif
 
 import Combine
-import LKObjCHelpers
 import OSLog
+
+#if !COCOAPODS
+import LKObjCHelpers
+#endif
 
 @available(macCatalyst 13.1, *)
 open class LKSampleHandler: RPBroadcastSampleHandler {


### PR DESCRIPTION
SPM treats LKObjCHelpers as a separate internal module, whereas CocoaPods combines all source files into a single module, making import LKObjCHelpers unnecessary when building with CocoaPods.