### PR TITLE
Fix IPC test compile issue

### DIFF
--- a/Tests/LiveKitTests/Broadcast/IPCChannelTests.swift
+++ b/Tests/LiveKitTests/Broadcast/IPCChannelTests.swift
@@ -95,13 +95,13 @@ final class IPCChannelTests: XCTestCase {
 
     func testConnectorCancelDuringInit() async throws {
         try await assertInitCancellationThrows(
-            IPCChannel(connectingTo: socketPath)
+            await IPCChannel(connectingTo: self.socketPath)
         )
     }
 
     func testAcceptorCancelDuringInit() async throws {
         try await assertInitCancellationThrows(
-            IPCChannel(acceptingOn: socketPath)
+            await IPCChannel(acceptingOn: self.socketPath)
         )
     }
 


### PR DESCRIPTION
Swift-format breaks code in this case...
Consider using another formatter.