### PR TITLE
Fix test execution

### DIFF
--- a/Tests/LiveKitTests/AVAudioPCMRingBufferTests.swift
+++ b/Tests/LiveKitTests/AVAudioPCMRingBufferTests.swift
@@ -23,7 +23,7 @@ import XCTest
 import CoreAudio
 #endif
 
-final class AVAudioPCMRingBufferTests: XCTestCase {
+final class AVAudioPCMRingBufferTests: LKTestCase {
     var format: AVAudioFormat!
 
     override func setUp() {

--- a/Tests/LiveKitTests/AsyncRetryTests.swift
+++ b/Tests/LiveKitTests/AsyncRetryTests.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class AsyncRetryTests: XCTestCase {
+class AsyncRetryTests: LKTestCase {
     override func setUpWithError() throws {}
 
     override func tearDown() async throws {}

--- a/Tests/LiveKitTests/AudioConverterTests.swift
+++ b/Tests/LiveKitTests/AudioConverterTests.swift
@@ -18,7 +18,7 @@ import AVFAudio
 @testable import LiveKit
 import XCTest
 
-class AudioConverterTests: XCTestCase {
+class AudioConverterTests: LKTestCase {
     func testConvertFormat() async throws {
         // Sample audio
         let audioDownloadUrl = URL(string: "https://github.com/rafaelreis-hotmart/Audio-Sample-files/raw/refs/heads/master/sample.wav")!

--- a/Tests/LiveKitTests/AudioEngineTests.swift
+++ b/Tests/LiveKitTests/AudioEngineTests.swift
@@ -19,12 +19,7 @@
 import LiveKitWebRTC
 import XCTest
 
-class AudioEngineTests: XCTestCase {
-    override class func setUp() {
-        LiveKitSDK.setLoggerStandardOutput()
-        RTCSetMinDebugLogLevel(.info)
-    }
-
+class AudioEngineTests: LKTestCase {
     override func tearDown() async throws {}
 
     #if !targetEnvironment(simulator)

--- a/Tests/LiveKitTests/AudioProcessingTests.swift
+++ b/Tests/LiveKitTests/AudioProcessingTests.swift
@@ -22,7 +22,7 @@ import LiveKitWebRTC
 @testable import LiveKit
 import XCTest
 
-class AudioProcessingTests: XCTestCase, AudioCustomProcessingDelegate {
+class AudioProcessingTests: LKTestCase, AudioCustomProcessingDelegate {
     var _initSampleRate: Double = 0.0
     var _initChannels: Int = 0
 

--- a/Tests/LiveKitTests/Broadcast/BroadcastImageCodecTests.swift
+++ b/Tests/LiveKitTests/Broadcast/BroadcastImageCodecTests.swift
@@ -19,7 +19,7 @@
 @testable import LiveKit
 import XCTest
 
-final class BroadcastImageCodecTests: XCTestCase {
+final class BroadcastImageCodecTests: LKTestCase {
     private var codec: BroadcastImageCodec!
 
     override func setUpWithError() throws {

--- a/Tests/LiveKitTests/Broadcast/IPCChannelTests.swift
+++ b/Tests/LiveKitTests/Broadcast/IPCChannelTests.swift
@@ -20,7 +20,7 @@
 import Network
 import XCTest
 
-final class IPCChannelTests: XCTestCase {
+final class IPCChannelTests: LKTestCase {
     private var socketPath: SocketPath!
 
     enum TestSetupError: Error {

--- a/Tests/LiveKitTests/Broadcast/SocketPathTests.swift
+++ b/Tests/LiveKitTests/Broadcast/SocketPathTests.swift
@@ -19,7 +19,7 @@
 @testable import LiveKit
 import XCTest
 
-final class SocketPathTests: XCTestCase {
+final class SocketPathTests: LKTestCase {
     func testValid() throws {
         let path = "/tmp/a.sock"
         let socketPath = try XCTUnwrap(SocketPath(path))

--- a/Tests/LiveKitTests/BroadcastManagerTests.swift
+++ b/Tests/LiveKitTests/BroadcastManagerTests.swift
@@ -20,7 +20,7 @@ import Combine
 @testable import LiveKit
 import XCTest
 
-class BroadcastManagerTests: XCTestCase {
+class BroadcastManagerTests: LKTestCase {
     private var manager: BroadcastManager!
 
     override func setUp() {

--- a/Tests/LiveKitTests/CompleterTests.swift
+++ b/Tests/LiveKitTests/CompleterTests.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class CompleterTests: XCTestCase {
+class CompleterTests: LKTestCase {
     override func setUpWithError() throws {}
 
     override func tearDown() async throws {}

--- a/Tests/LiveKitTests/DarwinNotificationCenterTests.swift
+++ b/Tests/LiveKitTests/DarwinNotificationCenterTests.swift
@@ -18,7 +18,7 @@ import Combine
 @testable import LiveKit
 import XCTest
 
-class DarwinNotificationCenterTests: XCTestCase {
+class DarwinNotificationCenterTests: LKTestCase {
     func testPublisher() throws {
         let receiveFirst = XCTestExpectation(description: "Receive from 1st subscriber")
         let receiveSecond = XCTestExpectation(description: "Receive from 2nd subscriber")

--- a/Tests/LiveKitTests/DeviceManager.swift
+++ b/Tests/LiveKitTests/DeviceManager.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class DeviceManagerTests: XCTestCase {
+class DeviceManagerTests: LKTestCase {
     func testListDevices() async throws {
         let devices = try await DeviceManager.shared.devices()
         print("Devices: \(devices.map { "(facingPosition: \(String(describing: $0.facingPosition)))" }.joined(separator: ", "))")

--- a/Tests/LiveKitTests/E2EE/Thread.swift
+++ b/Tests/LiveKitTests/E2EE/Thread.swift
@@ -18,7 +18,7 @@
 import LiveKitWebRTC
 import XCTest
 
-class E2EEThreadTests: XCTestCase {
+class E2EEThreadTests: LKTestCase {
     // Attempt to crash LKRTCFrameCryptor initialization
     func testCreateFrameCryptor() async throws {
         // Create peerConnection

--- a/Tests/LiveKitTests/Extensions/AVAudioPCMBufferTests.swift
+++ b/Tests/LiveKitTests/Extensions/AVAudioPCMBufferTests.swift
@@ -18,7 +18,7 @@ import AVFoundation
 @testable import LiveKit
 import XCTest
 
-class AVAudioPCMBufferTests: XCTestCase {
+class AVAudioPCMBufferTests: LKTestCase {
     func testResample() {
         // Test case 1: Resample to a higher sample rate
         testResampleHelper(fromSampleRate: 44100, toSampleRate: 48000, expectedSuccess: true)

--- a/Tests/LiveKitTests/Extensions/StringTests.swift
+++ b/Tests/LiveKitTests/Extensions/StringTests.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-final class StringTests: XCTestCase {
+final class StringTests: LKTestCase {
     func testByteLength() {
         // ASCII characters (1 byte each)
         XCTAssertEqual("hello".byteLength, 5)

--- a/Tests/LiveKitTests/FunctionTests.swift
+++ b/Tests/LiveKitTests/FunctionTests.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class FunctionTests: XCTestCase {
+class FunctionTests: LKTestCase {
     func testRangeMerge() async throws {
         let range1 = 10 ... 20
         let range2 = 5 ... 15

--- a/Tests/LiveKitTests/LKTestCase.swift
+++ b/Tests/LiveKitTests/LKTestCase.swift
@@ -15,23 +15,19 @@
  */
 
 @testable import LiveKit
+import LiveKitWebRTC
 import XCTest
 
-class QueueActorTests: LKTestCase {
-    private lazy var queue = QueueActor<String> { print($0) }
+/// Subclass of XCTestCase that performs global initialization.
+class LKTestCase: XCTestCase {
+    private static let _globalSetup: Bool = {
+        LiveKitSDK.setLoggerStandardOutput()
+        RTCSetMinDebugLogLevel(.info)
+        return true
+    }()
 
-    override func setUpWithError() throws {}
-
-    override func tearDown() async throws {}
-
-    func testQueueActor01() async throws {
-        await queue.processIfResumed("Value 0")
-        await queue.suspend()
-        await queue.processIfResumed("Value 1")
-        await queue.processIfResumed("Value 2")
-        await queue.processIfResumed("Value 3")
-        await print("Count: \(queue.count)")
-        await queue.resume()
-        await print("Count: \(queue.count)")
+    override func setUp() {
+        assert(Self._globalSetup, "Global initialization failed")
+        super.setUp()
     }
 }

--- a/Tests/LiveKitTests/MuteTests.swift
+++ b/Tests/LiveKitTests/MuteTests.swift
@@ -153,7 +153,7 @@ let muteEngineSteps: [TestEngineStep] = [
     TestEngineStep(transition: .init(outputEnabled: .value(false)), assert: .init(engineRunning: false)),
 ]
 
-class MuteTests: XCTestCase {
+class MuteTests: LKTestCase {
     override func setUp() {
         super.setUp()
         continueAfterFailure = false

--- a/Tests/LiveKitTests/ObjCHelpersTests.swift
+++ b/Tests/LiveKitTests/ObjCHelpersTests.swift
@@ -17,7 +17,7 @@
 import LKObjCHelpers
 import XCTest
 
-class ObjCHelperTests: XCTestCase {
+class ObjCHelperTests: LKTestCase {
     func testHelper() {
         LKObjCHelpers.finishBroadcastWithoutError(nil)
     }

--- a/Tests/LiveKitTests/ParticipantTests.swift
+++ b/Tests/LiveKitTests/ParticipantTests.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class ParticipantTests: XCTestCase {
+class ParticipantTests: LKTestCase {
     func testLocalParticipantIdentity() async throws {
         try await withRooms([RoomTestingOptions()]) { rooms in
             // Alias to Room

--- a/Tests/LiveKitTests/PublishBufferCapturerTests.swift
+++ b/Tests/LiveKitTests/PublishBufferCapturerTests.swift
@@ -18,7 +18,7 @@ import AVFoundation
 @testable import LiveKit
 import XCTest
 
-class PublishBufferCapturerTests: XCTestCase {
+class PublishBufferCapturerTests: LKTestCase {
     func testPublishBufferTrack() async throws {
         try await withRooms([RoomTestingOptions(canPublish: true), RoomTestingOptions(canSubscribe: true)]) { rooms in
             // Alias to Rooms

--- a/Tests/LiveKitTests/PublishDataTests.swift
+++ b/Tests/LiveKitTests/PublishDataTests.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class PublishDataTests: XCTestCase {
+class PublishDataTests: LKTestCase {
     // Test with canSubscribe: true
     func testPublishDataReceiverCanSubscribe() async throws {
         try await _publishDataTest(receiverRoomOptions: RoomTestingOptions(canSubscribe: true))

--- a/Tests/LiveKitTests/PublishMicrophoneTests.swift
+++ b/Tests/LiveKitTests/PublishMicrophoneTests.swift
@@ -19,7 +19,7 @@ import CoreMedia
 @testable import LiveKit
 import XCTest
 
-class PublishMicrophoneTests: XCTestCase {
+class PublishMicrophoneTests: LKTestCase {
     func testConcurrentMicPublish() async throws {
         try await withRooms([RoomTestingOptions(canPublish: true)]) { rooms in
             // Alias to Room

--- a/Tests/LiveKitTests/RoomTests.swift
+++ b/Tests/LiveKitTests/RoomTests.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class RoomTests: XCTestCase {
+class RoomTests: LKTestCase {
     func testRoomProperties() async throws {
         try await withRooms([RoomTestingOptions()]) { rooms in
             // Alias to Room

--- a/Tests/LiveKitTests/RpcTests.swift
+++ b/Tests/LiveKitTests/RpcTests.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class RpcTests: XCTestCase {
+class RpcTests: LKTestCase {
     // Mock DataChannelPair to intercept outgoing packets
     class MockDataChannelPair: DataChannelPair {
         var packetHandler: (Livekit_DataPacket) -> Void

--- a/Tests/LiveKitTests/SDKTests.swift
+++ b/Tests/LiveKitTests/SDKTests.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class SDKTests: XCTestCase {
+class SDKTests: LKTestCase {
     func testReadVersion() {
         print("LiveKitSDK.version: \(LiveKitSDK.version)")
     }

--- a/Tests/LiveKitTests/SerialRunnerActor.swift
+++ b/Tests/LiveKitTests/SerialRunnerActor.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class SerialRunnerActorTests: XCTestCase {
+class SerialRunnerActorTests: LKTestCase {
     let serialRunner = SerialRunnerActor<Void>()
     var counterValue: Int = 0
     var resultValues: [String] = []

--- a/Tests/LiveKitTests/Support/Room.swift
+++ b/Tests/LiveKitTests/Support/Room.swift
@@ -35,7 +35,7 @@ struct RoomTestingOptions {
     }
 }
 
-extension XCTestCase {
+extension LKTestCase {
     private func readEnvironmentString(for key: String, defaultValue: String) -> String {
         if let string = ProcessInfo.processInfo.environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines), !string.isEmpty {
             return string

--- a/Tests/LiveKitTests/Support/Tracks.swift
+++ b/Tests/LiveKitTests/Support/Tracks.swift
@@ -18,7 +18,7 @@ import AVFoundation
 @testable import LiveKit
 import XCTest
 
-extension XCTestCase {
+extension LKTestCase {
     // Creates a LocalVideoTrack with BufferCapturer, generates frames for approx 30 seconds
     func createSampleVideoTrack(targetFps: Int = 30, _ onCapture: @escaping (CMSampleBuffer) -> Void) async throws -> (Task<Void, any Error>) {
         // Sample video

--- a/Tests/LiveKitTests/Support/Xcode14.2Backport.swift
+++ b/Tests/LiveKitTests/Support/Xcode14.2Backport.swift
@@ -41,7 +41,7 @@ public extension URLSession {
 
 // Support for Xcode 14.2
 #if !compiler(>=5.8)
-extension XCTestCase {
+extension LKTestCase {
     func fulfillment(of expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false) async {
         await withCheckedContinuation { continuation in
             // This function operates by blocking a background thread instead of one owned by libdispatch or by the

--- a/Tests/LiveKitTests/ThreadSafetyTests.swift
+++ b/Tests/LiveKitTests/ThreadSafetyTests.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class ThreadSafetyTests: XCTestCase {
+class ThreadSafetyTests: LKTestCase {
     struct TestState: Equatable {
         var dictionary = [String: String]()
         var counter = 0

--- a/Tests/LiveKitTests/TrackTests.swift
+++ b/Tests/LiveKitTests/TrackTests.swift
@@ -36,7 +36,7 @@ class TestTrack: LocalAudioTrack {
     }
 }
 
-class TrackTests: XCTestCase {
+class TrackTests: LKTestCase {
     #if os(iOS) || os(visionOS) || os(tvOS)
     func testConcurrentStartStop() async throws {
         // Set config func to watch state changes.

--- a/Tests/LiveKitTests/VideoViewTests.swift
+++ b/Tests/LiveKitTests/VideoViewTests.swift
@@ -17,11 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class VideoViewTests: XCTestCase {
-    override class func setUp() {
-        LiveKitSDK.setLoggerStandardOutput()
-    }
-
+class VideoViewTests: LKTestCase {
     /// Test if avSampleBufferDisplayLayer is available immediately after creating VideoView.
     @MainActor
     func testAVSampleBufferDisplayLayer() {


### PR DESCRIPTION
Test execution currently fails due to logging being bootstrapped both in `AudioEngineTests` and `VideoViewTests`. This PR defines `LKTestCase`, a subclass of `XCTestCase`, which performs global initialization once per execution. All existing test cases now use this as their superclass.