### PR TITLE
Add local participant identity to all outgoing data packets

### DIFF
--- a/.nanpa/data-packet-identity.kdl
+++ b/.nanpa/data-packet-identity.kdl
@@ -1,0 +1,1 @@
+minor type="fixed" "Outgoing data packets missing local participant identity"

--- a/Sources/LiveKit/Core/Room+Engine.swift
+++ b/Sources/LiveKit/Core/Room+Engine.swift
@@ -101,6 +101,11 @@ extension Room {
         if !dataChannelIsOpen {
             log("publisher data channel is not .open", .error)
         }
+        
+        var packet = packet
+        if let identity = localParticipant.identity?.stringValue {
+            packet.participantIdentity = identity
+        }
 
         // Should return true if successful
         try publisherDataChannel.send(dataPacket: packet)

--- a/Sources/LiveKit/Core/Room+Engine.swift
+++ b/Sources/LiveKit/Core/Room+Engine.swift
@@ -101,7 +101,7 @@ extension Room {
         if !dataChannelIsOpen {
             log("publisher data channel is not .open", .error)
         }
-        
+
         var packet = packet
         if let identity = localParticipant.identity?.stringValue {
             packet.participantIdentity = identity

--- a/Tests/LiveKitTests/Broadcast/IPCChannelTests.swift
+++ b/Tests/LiveKitTests/Broadcast/IPCChannelTests.swift
@@ -93,6 +93,7 @@ final class IPCChannelTests: LKTestCase {
         await fulfillment(of: [cancelThrowsError], timeout: 5.0)
     }
 
+    // swiftformat:disable redundantSelf hoistAwait
     func testConnectorCancelDuringInit() async throws {
         try await assertInitCancellationThrows(
             await IPCChannel(connectingTo: self.socketPath)
@@ -104,6 +105,8 @@ final class IPCChannelTests: LKTestCase {
             await IPCChannel(acceptingOn: self.socketPath)
         )
     }
+
+    // swiftformat:enable all
 
     private struct TestHeader: Codable, Equatable {
         let someField: Int

--- a/Tests/LiveKitTests/RoomTests.swift
+++ b/Tests/LiveKitTests/RoomTests.swift
@@ -22,22 +22,40 @@ class RoomTests: XCTestCase {
         try await withRooms([RoomTestingOptions()]) { rooms in
             // Alias to Room
             let room1 = rooms[0]
-
+            
             // SID
             let sid = try await room1.sid()
             print("Room.sid(): \(String(describing: sid))")
             XCTAssert(sid.stringValue.starts(with: "RM_"))
-
+            
             // creationTime
             XCTAssert(room1.creationTime != nil)
             print("Room.creationTime: \(String(describing: room1.creationTime))")
         }
     }
-
+    
     func testParticipantCleanUp() async throws {
         // Create 2 Rooms
         try await withRooms([RoomTestingOptions(delegate: self), RoomTestingOptions(delegate: self)]) { _ in
             // Nothing to do here
+        }
+    }
+    
+    func testSendDataPacket() async throws {
+        try await withRooms([RoomTestingOptions()]) { rooms in
+            let room = rooms[0]
+            
+            let expectDataPacket = self.expectation(description: "Should send data packet")
+            
+            let mockDataChannel = MockDataChannelPair { packet in
+                XCTAssertEqual(packet.participantIdentity, room.localParticipant.identity?.stringValue ?? "")
+                expectDataPacket.fulfill()
+            }
+            room.publisherDataChannel = mockDataChannel
+            
+            try await room.send(dataPacket: Livekit_DataPacket())
+            
+            await self.fulfillment(of: [expectDataPacket], timeout: 5)
         }
     }
 }

--- a/Tests/LiveKitTests/RoomTests.swift
+++ b/Tests/LiveKitTests/RoomTests.swift
@@ -22,39 +22,39 @@ class RoomTests: LKTestCase {
         try await withRooms([RoomTestingOptions()]) { rooms in
             // Alias to Room
             let room1 = rooms[0]
-            
+
             // SID
             let sid = try await room1.sid()
             print("Room.sid(): \(String(describing: sid))")
             XCTAssert(sid.stringValue.starts(with: "RM_"))
-            
+
             // creationTime
             XCTAssert(room1.creationTime != nil)
             print("Room.creationTime: \(String(describing: room1.creationTime))")
         }
     }
-    
+
     func testParticipantCleanUp() async throws {
         // Create 2 Rooms
         try await withRooms([RoomTestingOptions(delegate: self), RoomTestingOptions(delegate: self)]) { _ in
             // Nothing to do here
         }
     }
-    
+
     func testSendDataPacket() async throws {
         try await withRooms([RoomTestingOptions()]) { rooms in
             let room = rooms[0]
-            
+
             let expectDataPacket = self.expectation(description: "Should send data packet")
-            
+
             let mockDataChannel = MockDataChannelPair { packet in
                 XCTAssertEqual(packet.participantIdentity, room.localParticipant.identity?.stringValue ?? "")
                 expectDataPacket.fulfill()
             }
             room.publisherDataChannel = mockDataChannel
-            
+
             try await room.send(dataPacket: Livekit_DataPacket())
-            
+
             await self.fulfillment(of: [expectDataPacket], timeout: 5)
         }
     }

--- a/Tests/LiveKitTests/RpcTests.swift
+++ b/Tests/LiveKitTests/RpcTests.swift
@@ -16,6 +16,7 @@
 
 @testable import LiveKit
 import XCTest
+
 class RpcTests: LKTestCase {
     // Test performing RPC calls and verifying outgoing packets
     func testPerformRpc() async throws {

--- a/Tests/LiveKitTests/RpcTests.swift
+++ b/Tests/LiveKitTests/RpcTests.swift
@@ -18,18 +18,6 @@
 import XCTest
 
 class RpcTests: XCTestCase {
-    // Mock DataChannelPair to intercept outgoing packets
-    class MockDataChannelPair: DataChannelPair {
-        var packetHandler: (Livekit_DataPacket) -> Void
-
-        init(packetHandler: @escaping (Livekit_DataPacket) -> Void) {
-            self.packetHandler = packetHandler
-        }
-
-        override func send(dataPacket packet: Livekit_DataPacket) throws {
-            packetHandler(packet)
-        }
-    }
 
     // Test performing RPC calls and verifying outgoing packets
     func testPerformRpc() async throws {

--- a/Tests/LiveKitTests/Support/MockDataChannelPair.swift
+++ b/Tests/LiveKitTests/Support/MockDataChannelPair.swift
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+
+/// Mock ``DataChannelPair`` to intercept outgoing packets.
+class MockDataChannelPair: DataChannelPair {
+    var packetHandler: (Livekit_DataPacket) -> Void
+
+    init(packetHandler: @escaping (Livekit_DataPacket) -> Void) {
+        self.packetHandler = packetHandler
+    }
+
+    override func send(dataPacket packet: Livekit_DataPacket) throws {
+        packetHandler(packet)
+    }
+}


### PR DESCRIPTION
Fixes #601 