### PR TITLE
Nanpa fix

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -10,8 +10,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v3
-        with:
-          ssh-key: ${{ secrets.NANPA_KEY }}
       - uses: nbsp/ilo@v1
         with:
           packages: ${{ env.PACKAGE_NAME }}

--- a/.nanparc
+++ b/.nanparc
@@ -1,3 +1,3 @@
-version 2.2.0
+version 2.2.1
 name client-sdk-swift
 custom ./scripts/replace_version.sh


### PR DESCRIPTION
- Set `NANPA_WORKFLOW` repo variable to `bump.yaml` (not apart of this PR)
- Remove SSH key argument for clone step
- Manually bump version number prior to next release 