### PR TITLE
Move RPC methods

### DIFF
--- a/.nanpa/move-rpc-methods.kdl
+++ b/.nanpa/move-rpc-methods.kdl
@@ -1,0 +1,3 @@
+minor type="changed" "RPC register method is now throwing"
+minor type="moved" "RPC registration methods moved to Room"
+patch type="deprecated" "RPC registration methods on LocalParticipant deprecated"

--- a/Sources/LiveKit/Core/Room+RPC.swift
+++ b/Sources/LiveKit/Core/Room+RPC.swift
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+public extension Room {
+ 
+    /// Establishes the participant as a receiver for calls of the specified RPC method.
+    /// Will overwrite any existing callback for the same method.
+    ///
+    /// Example:
+    /// ```swift
+    /// try await room.localParticipant.registerRpcMethod("greet") { data in
+    ///     print("Received greeting from \(data.callerIdentity): \(data.payload)")
+    ///     return "Hello, \(data.callerIdentity)!"
+    /// }
+    /// ```
+    ///
+    /// The handler receives an `RpcInvocationData` containing the following parameters:
+    /// - `requestId`: A unique identifier for this RPC request
+    /// - `callerIdentity`: The identity of the RemoteParticipant who initiated the RPC call
+    /// - `payload`: The data sent by the caller (as a string)
+    /// - `responseTimeout`: The maximum time available to return a response
+    ///
+    /// The handler should return a string.
+    /// If unable to respond within responseTimeout, the request will result in an error on the caller's side.
+    ///
+    /// You may throw errors of type RpcError with a string message in the handler,
+    /// and they will be received on the caller's side with the message intact.
+    /// Other errors thrown in your handler will not be transmitted as-is, and will instead arrive to the caller as 1500 ("Application Error").
+    ///
+    /// - Parameters:
+    ///   - method: The name of the indicated RPC method
+    ///   - handler: Will be invoked when an RPC request for this method is received
+    ///
+    func registerRpcMethod(_ method: String,
+                           handler: @escaping RpcHandler) async throws
+    {
+        try await rpcState.registerHandler(method, handler: handler)
+    }
+    
+    /// Unregisters a previously registered RPC method.
+    ///
+    /// - Parameter method: The name of the RPC method to unregister
+    ///
+    func unregisterRpcMethod(_ method: String) async {
+        await rpcState.unregisterHandler(method)
+    }
+    
+    /// Checks whether or not a handler has been registered for an RPC method.
+    ///
+    /// - Parameter method: The name of the RPC method to check.
+    /// - Returns: `true` if a handler has been registered, otherwise `false`.
+    ///
+    func isRpcMethodRegistered(_ method: String) async -> Bool {
+        await rpcState.isRpcMethodRegistered(method)
+    }
+}

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -115,6 +115,12 @@ public class Room: NSObject, ObservableObject, Loggable {
                                            qos: .default)
 
     var _queuedBlocks = [ConditionalExecutionEntry]()
+    
+    // MARK: - RPC
+    
+    let rpcState = RpcStateManager()
+    
+    // MARK: - State
 
     struct State: Equatable {
         // Options

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -35,8 +35,6 @@ public class LocalParticipant: Participant {
 
     private var trackPermissions: [ParticipantTrackPermission] = []
 
-    let rpcState = RpcStateManager()
-
     /// publish a new audio track to the Room
     @objc
     @discardableResult

--- a/Tests/LiveKitTests/RpcTests.swift
+++ b/Tests/LiveKitTests/RpcTests.swift
@@ -92,7 +92,7 @@ class RpcTests: LKTestCase {
 
             room.publisherDataChannel = mockDataChannel
 
-            await room.localParticipant.registerRpcMethod("greet") { data in
+            try await room.registerRpcMethod("greet") { data in
                 "Hello, \(data.callerIdentity)!"
             }
 
@@ -135,7 +135,7 @@ class RpcTests: LKTestCase {
 
             room.publisherDataChannel = mockDataChannel
 
-            await room.localParticipant.registerRpcMethod("failingMethod") { _ in
+            try await room.registerRpcMethod("failingMethod") { _ in
                 throw RpcError(code: 2000, message: "Custom error", data: "Additional data")
             }
 
@@ -175,11 +175,11 @@ class RpcTests: LKTestCase {
 
             room.publisherDataChannel = mockDataChannel
 
-            await room.localParticipant.registerRpcMethod("test") { _ in
+            try await room.registerRpcMethod("test") { _ in
                 "test response"
             }
 
-            await room.localParticipant.unregisterRpcMethod("test")
+            await room.unregisterRpcMethod("test")
 
             await room.localParticipant.handleIncomingRpcRequest(
                 callerIdentity: Participant.Identity(from: "test-caller"),

--- a/Tests/LiveKitTests/RpcTests.swift
+++ b/Tests/LiveKitTests/RpcTests.swift
@@ -95,6 +95,16 @@ class RpcTests: LKTestCase {
             try await room.registerRpcMethod("greet") { data in
                 "Hello, \(data.callerIdentity)!"
             }
+            
+            let isRegistered = await room.isRpcMethodRegistered("greet")
+            XCTAssertTrue(isRegistered)
+            
+            do {
+                try await room.registerRpcMethod("greet") { _ in "" }
+                XCTFail("Duplicate RPC method registration should fail.")
+            } catch {
+                XCTAssertNotNil(error as? LiveKitError)
+            }
 
             await room.localParticipant.handleIncomingRpcRequest(
                 callerIdentity: Participant.Identity(from: "test-caller"),
@@ -180,6 +190,9 @@ class RpcTests: LKTestCase {
             }
 
             await room.unregisterRpcMethod("test")
+            
+            let isRegistered = await room.isRpcMethodRegistered("test")
+            XCTAssertFalse(isRegistered)
 
             await room.localParticipant.handleIncomingRpcRequest(
                 callerIdentity: Participant.Identity(from: "test-caller"),


### PR DESCRIPTION
**Summary of changes:**
  - Move `RpcStateManager` to `Room`
  - Move RPC registration methods to `Room`
  - Deprecate existing methods on `LocalParticipant`, delegate to new methods
  - Add an additional method for checking if a handler has been registered
  - Register method now throws when a handler has already been registered
  - Unregister method now logs a warning when no handler was previously registered
  - Update tests to use moved methods and test added functionality