### PR TITLE
Check participant permissions before publishing

### DIFF
--- a/Sources/LiveKit/Errors.swift
+++ b/Sources/LiveKit/Errors.swift
@@ -42,6 +42,7 @@ public enum LiveKitErrorType: Int, Sendable {
     case roomDeleted = 503
     case stateMismatch = 504
     case joinFailure = 505
+    case noPermissions = 506
 
     //
     case serverPingTimedOut = 601

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -502,6 +502,10 @@ private extension LocalParticipant {
     private func _publish(track: LocalTrack, options: TrackPublishOptions? = nil) async throws -> LocalTrackPublication {
         log("[publish] \(track) options: \(String(describing: options ?? nil))...", .info)
 
+        guard permissions.canPublish else {
+            throw LiveKitError(.noPermissions, message: "Participant does not have permission to publish")
+        }
+
         let room = try requireRoom()
         let publisher = try room.requirePublisher()
 

--- a/Tests/LiveKitTests/PublishTrackTests.swift
+++ b/Tests/LiveKitTests/PublishTrackTests.swift
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+import XCTest
+
+class PublishTrackTests: LKTestCase {
+    func testPublishWithoutPermissions() async throws {
+        try await withRooms([RoomTestingOptions(canPublish: false)]) { rooms in
+            let room = rooms[0]
+            let audioTrack = LocalAudioTrack.createTrack()
+
+            do {
+                try await room.localParticipant.publish(audioTrack: audioTrack)
+                XCTFail("Publishing without permissions should throw an error")
+            } catch let error as LiveKitError {
+                XCTAssertEqual(error.type, .noPermissions)
+                XCTAssertEqual(error.message, "Participant does not have permission to publish")
+            } catch {
+                XCTFail("Expected LiveKitError but got \(error)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a new error code `.noPermissions` to handle this scenario.