### PR TITLE
Sync access to web socket continuations

### DIFF
--- a/.nanpa/socket-continuation.kdl
+++ b/.nanpa/socket-continuation.kdl
@@ -1,0 +1,1 @@
+patch type="fixed" "Race condition in WebSocket impl"


### PR DESCRIPTION
Resolves https://github.com/livekit/client-sdk-swift/issues/528

Turning `WebSocket` into an `actor` would do more harm than good (nonisolated `deinit`, nonisolated requirements). Nullifying in the critical section is the only way to prevent double `resume()`.