### PR TITLE
Ensure AudioManager is prepared

### DIFF
--- a/.nanpa/fix-audiomanager-init.kdl
+++ b/.nanpa/fix-audiomanager-init.kdl
@@ -1,0 +1,1 @@
+patch type="fixed" "Explicit AudioManager initialization"

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -207,7 +207,9 @@ public class Room: NSObject, ObservableObject, Loggable {
                 connectOptions: ConnectOptions? = nil,
                 roomOptions: RoomOptions? = nil)
     {
+        // Ensure manager shared objects are instantiated
         DeviceManager.prepare()
+        AudioManager.prepare()
 
         _state = StateSync(State(connectOptions: connectOptions ?? ConnectOptions(),
                                  roomOptions: roomOptions ?? RoomOptions()))

--- a/Sources/LiveKit/Track/AudioManager.swift
+++ b/Sources/LiveKit/Track/AudioManager.swift
@@ -34,6 +34,11 @@ public class AudioManager: Loggable {
     public static let shared = AudioManager()
     #endif
 
+    public static func prepare() {
+        // Instantiate shared instance
+        _ = shared
+    }
+
     public typealias OnDevicesDidUpdate = (_ audioManager: AudioManager) -> Void
 
     public typealias OnSpeechActivity = (_ audioManager: AudioManager, _ event: SpeechActivityEvent) -> Void


### PR DESCRIPTION
The lazy initialization of `AudioManager` was causing inconsistencies in the `AudioEngineObserver` event lifecycle.
`AVAudioNode` instances were being connected without being attached, which could lead to crashes.
Ensure that the shared instance of `AudioManager` is ready whenever any Room object is instantiated.

Related: https://github.com/livekit/client-sdk-swift/issues/636
