### PR TITLE
Bump WebRTC lib to 125.6422.26

### DIFF
--- a/LiveKitClient.podspec
+++ b/LiveKitClient.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |spec|
 
   spec.source_files = "Sources/**/*"
 
-  spec.dependency("LiveKitWebRTC", "= 125.6422.25")
+  spec.dependency("LiveKitWebRTC", "= 125.6422.26")
   spec.dependency("SwiftProtobuf")
   spec.dependency("Logging", "= 1.5.4")
   spec.dependency("DequeModule", "= 1.1.4")

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "125.6422.25"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "125.6422.26"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.26.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "125.6422.25"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "125.6422.26"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.26.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"), // 1.6.x requires Swift >=5.8
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),

--- a/Sources/LiveKit/Track/AudioManager.swift
+++ b/Sources/LiveKit/Track/AudioManager.swift
@@ -303,7 +303,12 @@ public class AudioManager: Loggable {
     /// Normally, you do not need to set this manually since it will be handled automatically.
     public var isMicrophoneMuted: Bool {
         get { RTC.audioDeviceModule.isMicrophoneMuted }
-        set { RTC.audioDeviceModule.isMicrophoneMuted = newValue }
+        set {
+            let result = RTC.audioDeviceModule.setMicrophoneMuted(newValue)
+            if result != 0 {
+                log("Failed to set microphone muted: \(result)", .error)
+            }
+        }
     }
 
     // MARK: - For testing


### PR DESCRIPTION
Bump lib to https://github.com/livekit/webrtc-xcframework/releases/tag/125.6422.26
Fixes `StopRecording()` to fail in some cases due to an invalid state check.
