### PR TITLE
Remove unnecessary logs from streams

### DIFF
--- a/.nanpa/remove-stream-logs.kdl
+++ b/.nanpa/remove-stream-logs.kdl
@@ -1,0 +1,1 @@
+patch type="removed" "Removed unnecessary logs from stream handlers"

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -28,6 +28,8 @@ actor IncomingStreamManager: Loggable {
 
     /// Mapping between stream ID and descriptor for open streams.
     private var openStreams: [String: Descriptor] = [:]
+    /// Stream topics without a registered handler.
+    private var failedToOpenStreams: Set<String> = []
 
     private var byteStreamHandlers: [String: ByteStreamHandler] = [:]
     private var textStreamHandlers: [String: TextStreamHandler] = [:]
@@ -73,7 +75,11 @@ actor IncomingStreamManager: Loggable {
             return
         }
         guard let handler = handler(for: info) else {
-            logger.warning("Unable to find handler for stream '\(info.id)' from '\(identity)'")
+            let topic = info.topic
+            if !failedToOpenStreams.contains(topic) {
+                logger.warning("Unable to find handler for incoming stream: \(info.id), topic: \(topic), opened by: \(identity)")
+                failedToOpenStreams.insert(topic)
+            }
             return
         }
 

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -73,7 +73,7 @@ actor IncomingStreamManager: Loggable {
             return
         }
         guard let handler = handler(for: info) else {
-            log("Unable to find handler for stream '\(info.id)'", .warning)
+            logger.warning("Unable to find handler for stream '\(info.id)' from '\(identity)'")
             return
         }
 

--- a/Sources/LiveKit/DataStream/Outgoing/OutgoingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Outgoing/OutgoingStreamManager.swift
@@ -167,8 +167,6 @@ actor OutgoingStreamManager: Loggable {
 
         let descriptor = Descriptor(info: info)
         openStreams[info.id] = descriptor
-
-        log("Opened stream '\(info.id)'", .debug)
     }
 
     private func send(_ data: some StreamData, to id: String) async throws {
@@ -210,8 +208,6 @@ actor OutgoingStreamManager: Loggable {
 
         try await packetHandler(packet)
         openStreams[id] = nil
-
-        log("Closed stream '\(id)'", .debug)
     }
 
     // MARK: - Destination


### PR DESCRIPTION
In some cases these were the only form of error propagation (although not public), so we need to be careful with that 👍 