### PR TITLE
Expose reconnect mode

### DIFF
--- a/.nanpa/expose-reconnect.kdl
+++ b/.nanpa/expose-reconnect.kdl
@@ -1,0 +1,1 @@
+patch type="added" "Exposed reconnect mode in RoomDelegate"

--- a/Sources/LiveKit/Core/Room+EngineDelegate.swift
+++ b/Sources/LiveKit/Core/Room+EngineDelegate.swift
@@ -86,6 +86,15 @@ extension Room {
             }
         }
 
+        // Notify when reconnection mode changes
+        if state.isReconnectingWithMode != oldState.isReconnectingWithMode,
+           let mode = state.isReconnectingWithMode
+        {
+            delegates.notify(label: { "room.didUpdate reconnectionMode: \(String(describing: state.isReconnectingWithMode)) oldValue: \(String(describing: oldState.isReconnectingWithMode))" }) {
+                $0.room?(self, didUpdateReconnectMode: mode)
+            }
+        }
+
         // Notify change when engine's state mutates
         Task.detached { @MainActor in
             self.objectWillChange.send()

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -36,6 +36,7 @@ public protocol RoomDelegate: AnyObject {
     // MARK: - Connection Events
 
     /// ``Room/connectionState`` has updated.
+    /// - Note: This method is not called for ``ReconnectMode/quick``, use ``RoomDelegate/room(_:didUpdateReconnectMode:)`` instead.
     @objc optional
     func room(_ room: Room, didUpdateConnectionState connectionState: ConnectionState, from oldConnectionState: ConnectionState)
 
@@ -44,12 +45,17 @@ public protocol RoomDelegate: AnyObject {
     func roomDidConnect(_ room: Room)
 
     /// Previously connected to room but re-attempting to connect due to network issues.
+    /// - Note: This method is not called for ``ReconnectMode/quick``, use ``RoomDelegate/room(_:didUpdateReconnectMode:)`` instead.
     @objc optional
     func roomIsReconnecting(_ room: Room)
 
     /// Successfully re-connected to the room.
     @objc optional
     func roomDidReconnect(_ room: Room)
+
+    /// ``Room`` reconnect mode has updated.
+    @objc optional
+    func room(_ room: Room, didUpdateReconnectMode reconnectMode: ReconnectMode)
 
     /// Could not connect to the room. Only triggered when the initial connect attempt fails.
     @objc optional

--- a/Sources/LiveKit/Types/ConnectionState.swift
+++ b/Sources/LiveKit/Types/ConnectionState.swift
@@ -18,7 +18,14 @@ import Foundation
 
 @objc
 public enum ReconnectMode: Int, Sendable {
+    /// Quick reconnection mode attempts to maintain the same session, reusing existing
+    /// transport connections and published tracks. This is faster but may not succeed
+    /// in all network conditions.
     case quick
+
+    /// Full reconnection mode performs a complete new connection to the LiveKit server,
+    /// closing existing connections and re-publishing all tracks. This is slower but
+    /// more reliable for recovering from severe connection issues.
     case full
 }
 


### PR DESCRIPTION
The solution is a bit awkward, as `connectionState` does not cover `.quick`, but probably the only non-breaking one.

Resolves #368 