### PR TITLE
Doc publish fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,16 +161,12 @@ jobs:
             --transform-for-static-hosting \
             --hosting-base-path client-sdk-swift/
 
-      - name: Sanitize Ref Name
-        id: sanitize-ref
-        run: echo "ref_name=$(echo ${{ github.ref_name }} | sed 's/\//-/g')" >> $GITHUB_OUTPUT
-
       - name: Archive
-        run: zip -r docs@${{ steps.sanitize-ref.outputs.ref_name }}.zip docs
+        run: zip -r docs.zip docs
 
       - name: Upload Archive
         uses: actions/upload-artifact@v4
         with:
-          name: docs@${{ steps.sanitize-ref.outputs.ref_name }}
-          path: docs@${{ steps.sanitize-ref.outputs.ref_name }}.zip
+          name: docs
+          path: docs.zip
           retention-days: 1

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -22,7 +22,6 @@ jobs:
         with:
           workflow: ci.yaml
           workflow_search: false
-          workflow_conclusion: success
           branch: main
           name: docs@${{ steps.sanitize-ref.outputs.ref_name }}
 

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           workflow: ci.yaml
           workflow_search: false
-          branch: main
+          # branch: main
           name: docs
 
       - name: Unzip Archive

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -13,20 +13,16 @@ jobs:
     name: Publish Docs
     runs-on: ubuntu-latest
     steps:
-      - name: Sanitize Ref Name
-        id: sanitize-ref
-        run: echo "ref_name=$(echo ${{ github.ref_name }} | sed 's/\//-/g')" >> $GITHUB_OUTPUT
-
       - name: Download Archive
         uses: dawidd6/action-download-artifact@v9
         with:
           workflow: ci.yaml
           workflow_search: false
           branch: main
-          name: docs@${{ steps.sanitize-ref.outputs.ref_name }}
+          name: docs
 
       - name: Unzip Archive
-        run: unzip docs@${{ steps.sanitize-ref.outputs.ref_name }}.zip
+        run: unzip docs.zip
 
       - name: List Files
         run: ls -la docs

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,6 +1,11 @@
 name: Publish Docs
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Dry run (only list files, don't upload)
+        default: true
+        type: boolean
   release:
     types: [published]
 jobs:
@@ -24,7 +29,11 @@ jobs:
       - name: Unzip Archive
         run: unzip docs@${{ steps.sanitize-ref.outputs.ref_name }}.zip
 
+      - name: List Files
+        run: ls -la docs
+
       - name: S3 Upload
+        if: inputs.dry_run != true
         run: aws s3 cp docs/ s3://livekit-docs/client-sdk-swift --recursive
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_DEPLOY_AWS_ACCESS_KEY }}
@@ -32,6 +41,7 @@ jobs:
           AWS_DEFAULT_REGION: "us-east-1"
 
       - name: Invalidate cache
+        if: inputs.dry_run != true
         run: aws cloudfront create-invalidation --distribution-id EJJ40KLJ3TRY9 --paths "/*"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_DEPLOY_AWS_ACCESS_KEY }}

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           workflow: ci.yaml
           workflow_search: false
-          # branch: main
+          branch: main
           name: docs
 
       - name: Unzip Archive


### PR DESCRIPTION
The documentation archive generated by the CI run cannot be found if some checks did not pass. Solution: search for artifacts regardless of workflow conclusion.