### PR TITLE
Swift 6: Add Sendable for immutable RTC classes

### DIFF
--- a/.nanpa/swift-6-rtc.kdl
+++ b/.nanpa/swift-6-rtc.kdl
@@ -1,0 +1,1 @@
+patch type="fixed" "Swift 6: Fixed warnings for some of the internal RTC classes"

--- a/Sources/LiveKit/Extensions/Sendable.swift
+++ b/Sources/LiveKit/Extensions/Sendable.swift
@@ -23,13 +23,13 @@ internal import LiveKitWebRTC
 #endif
 
 // Immutable classes.
-extension LKRTCMediaConstraints: @unchecked @retroactive Sendable {}
-extension LKRTCSessionDescription: @unchecked @retroactive Sendable {}
-extension LKRTCVideoFrame: @unchecked @retroactive Sendable {}
-extension LKRTCStatisticsReport: @unchecked @retroactive Sendable {}
-extension LKRTCIceCandidate: @unchecked @retroactive Sendable {}
-extension LKRTCVideoCodecInfo: @unchecked @retroactive Sendable {}
-extension LKRTCFrameCryptorKeyProvider: @unchecked @retroactive Sendable {}
-extension LKRTCRtpTransceiver: @unchecked @retroactive Sendable {}
-extension LKRTCRtpTransceiverInit: @unchecked @retroactive Sendable {}
-extension LKRTCPeerConnectionFactory: @unchecked @retroactive Sendable {}
+extension LKRTCMediaConstraints: @unchecked Swift.Sendable {}
+extension LKRTCSessionDescription: @unchecked Swift.Sendable {}
+extension LKRTCVideoFrame: @unchecked Swift.Sendable {}
+extension LKRTCStatisticsReport: @unchecked Swift.Sendable {}
+extension LKRTCIceCandidate: @unchecked Swift.Sendable {}
+extension LKRTCVideoCodecInfo: @unchecked Swift.Sendable {}
+extension LKRTCFrameCryptorKeyProvider: @unchecked Swift.Sendable {}
+extension LKRTCRtpTransceiver: @unchecked Swift.Sendable {}
+extension LKRTCRtpTransceiverInit: @unchecked Swift.Sendable {}
+extension LKRTCPeerConnectionFactory: @unchecked Swift.Sendable {}

--- a/Sources/LiveKit/Extensions/Sendable.swift
+++ b/Sources/LiveKit/Extensions/Sendable.swift
@@ -23,5 +23,13 @@ internal import LiveKitWebRTC
 #endif
 
 // Immutable classes.
-extension LKRTCMediaConstraints: @unchecked Sendable {}
-extension LKRTCSessionDescription: @unchecked Sendable {}
+extension LKRTCMediaConstraints: @unchecked @retroactive Sendable {}
+extension LKRTCSessionDescription: @unchecked @retroactive Sendable {}
+extension LKRTCVideoFrame: @unchecked @retroactive Sendable {}
+extension LKRTCStatisticsReport: @unchecked @retroactive Sendable {}
+extension LKRTCIceCandidate: @unchecked @retroactive Sendable {}
+extension LKRTCVideoCodecInfo: @unchecked @retroactive Sendable {}
+extension LKRTCFrameCryptorKeyProvider: @unchecked @retroactive Sendable {}
+extension LKRTCRtpTransceiver: @unchecked @retroactive Sendable {}
+extension LKRTCRtpTransceiverInit: @unchecked @retroactive Sendable {}
+extension LKRTCPeerConnectionFactory: @unchecked @retroactive Sendable {}


### PR DESCRIPTION
This is mostly mechanical, based on `readonly` props on the Obj-C side.

There are still a couple of AV-related entities that are certainly not "DTOs".