### PR TITLE
VideoView

### DIFF
--- a/.nanpa/swift-6-video-view.kdl
+++ b/.nanpa/swift-6-video-view.kdl
@@ -1,0 +1,1 @@
+patch type="fixed" "Swift 6: Fixed warnings in VideoView and SwiftUIVideoView"

--- a/Sources/LiveKit/Protocols/AudioCustomProcessingDelegate.swift
+++ b/Sources/LiveKit/Protocols/AudioCustomProcessingDelegate.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@preconcurrency import AVFoundation
 import Foundation
 
 #if swift(>=5.9)

--- a/Sources/LiveKit/Protocols/AudioRenderer.swift
+++ b/Sources/LiveKit/Protocols/AudioRenderer.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import AVFoundation
+@preconcurrency import AVFoundation
 import CoreMedia
 
 #if swift(>=5.9)

--- a/Sources/LiveKit/Protocols/Mirrorable.swift
+++ b/Sources/LiveKit/Protocols/Mirrorable.swift
@@ -17,6 +17,7 @@
 import Foundation
 
 // Internal only
+@MainActor
 protocol Mirrorable {
     func set(isMirrored: Bool)
 }

--- a/Sources/LiveKit/Protocols/VideoRenderer.swift
+++ b/Sources/LiveKit/Protocols/VideoRenderer.swift
@@ -27,23 +27,23 @@ public protocol VideoRenderer: Sendable {
     /// Whether this ``VideoRenderer`` should be considered visible or not for AdaptiveStream.
     /// This will be invoked on the .main thread.
     @objc
-    var isAdaptiveStreamEnabled: Bool { get }
+    @MainActor var isAdaptiveStreamEnabled: Bool { get }
     /// The size used for AdaptiveStream computation. Return .zero if size is unknown yet.
     /// This will be invoked on the .main thread.
     @objc
-    var adaptiveStreamSize: CGSize { get }
+    @MainActor var adaptiveStreamSize: CGSize { get }
 
     /// Size of the frame.
     @objc optional
-    func set(size: CGSize)
+    nonisolated func set(size: CGSize)
 
     /// A ``VideoFrame`` is ready and should be processed.
     @objc optional
-    func render(frame: VideoFrame)
+    nonisolated func render(frame: VideoFrame)
 
     /// In addition to ``VideoFrame``, provide capture-time information if available.
     @objc optional
-    func render(frame: VideoFrame, captureDevice: AVCaptureDevice?, captureOptions: VideoCaptureOptions?)
+    nonisolated func render(frame: VideoFrame, captureDevice: AVCaptureDevice?, captureOptions: VideoCaptureOptions?)
 }
 
 class VideoRendererAdapter: NSObject, LKRTCVideoRenderer {

--- a/Sources/LiveKit/Support/AudioMixRecorder.swift
+++ b/Sources/LiveKit/Support/AudioMixRecorder.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import AVFAudio
+@preconcurrency import AVFAudio
 import Foundation
 
 /// `AudioMixRecorder` provides real-time audio recording capabilities using AVAudioEngine.

--- a/Sources/LiveKit/SwiftUI/SwiftUIVideoView.swift
+++ b/Sources/LiveKit/SwiftUI/SwiftUIVideoView.swift
@@ -68,7 +68,7 @@ public struct SwiftUIVideoView: NativeViewRepresentable {
         videoView.pinchToZoomOptions = pinchToZoomOptions
         videoView.isDebugMode = isDebugMode
 
-        Task.detached { @MainActor in
+        Task { @MainActor in
             videoView.add(delegate: videoViewDelegateReceiver)
             videoViewDelegateReceiver.isRendering = videoView.isRendering
         }
@@ -80,6 +80,7 @@ public struct SwiftUIVideoView: NativeViewRepresentable {
 }
 
 /// This class receives ``VideoViewDelegate`` events since a struct can't be used for a delegate
+@MainActor
 class VideoViewDelegateReceiver: VideoViewDelegate, Loggable {
     @Binding var isRendering: Bool
 
@@ -91,7 +92,7 @@ class VideoViewDelegateReceiver: VideoViewDelegate, Loggable {
         }
     }
 
-    func videoView(_: VideoView, didUpdate isRendering: Bool) {
+    nonisolated func videoView(_: VideoView, didUpdate isRendering: Bool) {
         DispatchQueue.main.async {
             self.isRendering = isRendering
         }

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@preconcurrency import AVFoundation
 import Foundation
 
 #if canImport(ReplayKit)

--- a/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@preconcurrency import AVFoundation
 import Foundation
 
 #if swift(>=5.9)

--- a/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
@@ -24,7 +24,7 @@ internal import LiveKitWebRTC
 #endif
 
 @objc
-public class LocalAudioTrack: Track, LocalTrack, AudioTrack {
+public class LocalAudioTrack: Track, LocalTrack, AudioTrack, @unchecked Sendable {
     /// ``AudioCaptureOptions`` used to create this track.
     let captureOptions: AudioCaptureOptions
 

--- a/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalVideoTrack.swift
@@ -23,7 +23,7 @@ internal import LiveKitWebRTC
 #endif
 
 @objc
-public class LocalVideoTrack: Track, LocalTrack {
+public class LocalVideoTrack: Track, LocalTrack, @unchecked Sendable {
     @objc
     public internal(set) var capturer: VideoCapturer
 

--- a/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
@@ -24,7 +24,7 @@ internal import LiveKitWebRTC
 #endif
 
 @objc
-public class RemoteAudioTrack: Track, RemoteTrack, AudioTrack {
+public class RemoteAudioTrack: Track, RemoteTrack, AudioTrack, @unchecked Sendable {
     /// Volume with range 0.0 - 1.0
     public var volume: Double {
         get {

--- a/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteVideoTrack.swift
@@ -21,7 +21,7 @@ internal import LiveKitWebRTC
 #endif
 
 @objc
-public class RemoteVideoTrack: Track, RemoteTrack {
+public class RemoteVideoTrack: Track, RemoteTrack, @unchecked Sendable {
     init(name: String,
          source: Track.Source,
          track: LKRTCMediaStreamTrack,

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -23,7 +23,7 @@ internal import LiveKitWebRTC
 #endif
 
 @objc
-public class Track: NSObject, Loggable {
+public class Track: NSObject, @unchecked Sendable, Loggable {
     // MARK: - Static constants
 
     @objc

--- a/Sources/LiveKit/TrackPublications/LocalTrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/LocalTrackPublication.swift
@@ -18,7 +18,7 @@ import Combine
 import Foundation
 
 @objc
-public class LocalTrackPublication: TrackPublication {
+public class LocalTrackPublication: TrackPublication, @unchecked Sendable {
     // indicates whether the track was suspended(muted) by the SDK
     var _suspended: Bool = false
 

--- a/Sources/LiveKit/TrackPublications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/RemoteTrackPublication.swift
@@ -305,6 +305,7 @@ extension RemoteTrackPublication {
 
 // MARK: - Adaptive Stream
 
+@MainActor
 extension Collection<VideoRenderer> {
     func containsOneOrMoreAdaptiveStreamEnabledRenderers() -> Bool {
         // not visible if no entry

--- a/Sources/LiveKit/TrackPublications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/RemoteTrackPublication.swift
@@ -28,7 +28,7 @@ public enum SubscriptionState: Int, Codable {
 }
 
 @objc
-public class RemoteTrackPublication: TrackPublication {
+public class RemoteTrackPublication: TrackPublication, @unchecked Sendable {
     // MARK: - Public
 
     @objc

--- a/Sources/LiveKit/TrackPublications/TrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/TrackPublication.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 @objc
-public class TrackPublication: NSObject, ObservableObject, Loggable {
+public class TrackPublication: NSObject, @unchecked Sendable, ObservableObject, Loggable {
     // MARK: - Public properties
 
     @objc
@@ -141,7 +141,7 @@ public class TrackPublication: NSObject, ObservableObject, Loggable {
 
     func notifyObjectWillChange() {
         // Notify UI that the object has changed
-        Task.detached { @MainActor in
+        Task { @MainActor in
             // Notify TrackPublication
             self.objectWillChange.send()
 
@@ -219,7 +219,7 @@ extension TrackPublication: TrackDelegateInternal {
 
             // TrackPublication.isMuted is a computed property depending on Track.isMuted
             // so emit event on TrackPublication when Track.isMuted updates
-            Task.detached { @MainActor in
+            Task { @MainActor in
                 self.objectWillChange.send()
             }
         }

--- a/Sources/LiveKit/Types/Options/CameraCaptureOptions+Copy.swift
+++ b/Sources/LiveKit/Types/Options/CameraCaptureOptions+Copy.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import AVFoundation
+@preconcurrency import AVFoundation
 
 public extension CameraCaptureOptions {
     func copyWith(device: ValueOrAbsent<AVCaptureDevice?> = .absent,

--- a/Sources/LiveKit/Types/Options/CameraCaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/CameraCaptureOptions.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import AVFoundation
+@preconcurrency import AVFoundation
 import Foundation
 
 @objc

--- a/Sources/LiveKit/Types/Options/PublishOptions.swift
+++ b/Sources/LiveKit/Types/Options/PublishOptions.swift
@@ -22,7 +22,7 @@ public protocol PublishOptions {}
 
 /// Base protocol for both ``VideoPublishOptions`` and ``AudioPublishOptions``.
 @objc
-public protocol TrackPublishOptions: PublishOptions {
+public protocol TrackPublishOptions: PublishOptions, Sendable {
     var name: String? { get }
     /// Set stream name for the track. Audio and video tracks with the same stream name
     /// will be placed in the same `MediaStream` and offer better synchronization.

--- a/Sources/LiveKit/Types/Options/VideoCaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/VideoCaptureOptions.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 @objc
-public protocol VideoCaptureOptions: CaptureOptions {
+public protocol VideoCaptureOptions: CaptureOptions, Sendable {
     var dimensions: Dimensions { get }
     var fps: Int { get }
 }

--- a/Sources/LiveKit/Views/SampleBufferVideoRenderer.swift
+++ b/Sources/LiveKit/Views/SampleBufferVideoRenderer.swift
@@ -62,9 +62,9 @@ class SampleBufferVideoRenderer: NativeView, Loggable {
 }
 
 extension SampleBufferVideoRenderer: LKRTCVideoRenderer {
-    func setSize(_: CGSize) {}
+    nonisolated func setSize(_: CGSize) {}
 
-    func renderFrame(_ frame: LKRTCVideoFrame?) {
+    nonisolated func renderFrame(_ frame: LKRTCVideoFrame?) {
         guard let frame else { return }
 
         var pixelBuffer: CVPixelBuffer?
@@ -92,7 +92,7 @@ extension SampleBufferVideoRenderer: LKRTCVideoRenderer {
             return result
         }
 
-        Task.detached { @MainActor in
+        Task { @MainActor in
             self.sampleBufferDisplayLayer.enqueue(sampleBuffer)
             if didUpdateRotation {
                 self.setNeedsLayout()
@@ -131,7 +131,8 @@ private extension CATransform3D {
         }
 
         if isMirrored {
-            transform = CATransform3DConcat(transform, VideoView.mirrorTransform)
+            let mirror = CATransform3DMakeScale(-1.0, 1.0, 1.0)
+            transform = CATransform3DConcat(transform, mirror)
         }
 
         return transform

--- a/Sources/LiveKit/Views/SampleBufferVideoRenderer.swift
+++ b/Sources/LiveKit/Views/SampleBufferVideoRenderer.swift
@@ -115,7 +115,9 @@ extension SampleBufferVideoRenderer: Mirrorable {
     }
 }
 
-private extension CATransform3D {
+extension CATransform3D {
+    static let mirror = CATransform3DMakeScale(-1.0, 1.0, 1.0)
+
     static func from(rotation: VideoRotation, isMirrored: Bool) -> CATransform3D {
         var transform: CATransform3D
 
@@ -131,7 +133,6 @@ private extension CATransform3D {
         }
 
         if isMirrored {
-            let mirror = CATransform3DMakeScale(-1.0, 1.0, 1.0)
             transform = CATransform3DConcat(transform, mirror)
         }
 

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -34,7 +34,7 @@ public class VideoView: NativeView, Loggable {
 
     // MARK: - Static
 
-    static let mirrorTransform = CATransform3DMakeScale(-1.0, 1.0, 1.0)
+    static let mirrorTransform = CATransform3D.mirror
     private static let _freezeDetectThreshold = 2.0
 
     /// Specifies how to render the video withing the ``VideoView``'s bounds.


### PR DESCRIPTION
- Fixes all warnings around `VideoView` + related classes
- It does NOT change the isolation of `VideoRenderer` et al. which is **clearly non-main-thread**
  - the switch still happens in `VideoView.render(frame:)`
  - however, it removes the use of `Task.detached` - IMO keeping the task priority as described [here](https://www.donnywals.com/wp-content/uploads/Screen-Shot-2021-06-08-at-18.33.50-1024x449.png) is not harmful, otherwise we should define it explicitly
- The alternative would be the opposite:
  - break the isolation of `LKRTCVideoRenderer` with `@preconcurrency`
  - then move most of this stuff to `@MainActor` - with some performance implications
  - that wasn't the intention of RTC implementers to have only sync rendering ⌚ 

⚠️ This one needs deeper testing with example apps, I did macOS + iOS with tsan/Metal warnings enabled, no assertions triggered so far 🦺 

Take your time 🧪 and feel free to break it