### PR TITLE
Swift 6: Room and Track state

### DIFF
--- a/.nanpa/swift-6-state.kdl
+++ b/.nanpa/swift-6-state.kdl
@@ -1,0 +1,1 @@
+patch type="fixed" "Swift 6: Fixed warnings for mutable state"

--- a/Sources/LiveKit/Broadcast/BroadcastBundleInfo.swift
+++ b/Sources/LiveKit/Broadcast/BroadcastBundleInfo.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-enum BroadcastBundleInfo {
+actor BroadcastBundleInfo {
     /// Identifier of the app group shared by the primary app and broadcast extension.
     static var groupIdentifier: String? {
         if let override = groupIdentifierOverride { return override }

--- a/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
+++ b/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
@@ -28,7 +28,7 @@ internal import LiveKitWebRTC
 @_implementationOnly import LiveKitWebRTC
 #endif
 
-class BroadcastScreenCapturer: BufferCapturer {
+class BroadcastScreenCapturer: BufferCapturer, @unchecked Sendable {
     private let appAudio: Bool
     private var receiver: BroadcastReceiver?
 

--- a/Sources/LiveKit/Broadcast/IPC/BroadcastImageCodec.swift
+++ b/Sources/LiveKit/Broadcast/IPC/BroadcastImageCodec.swift
@@ -17,10 +17,10 @@
 #if os(iOS)
 
 import AVFoundation
-import CoreImage
+@preconcurrency import CoreImage
 
 /// Encode and decode image samples for transport.
-struct BroadcastImageCodec {
+struct BroadcastImageCodec: Sendable {
     struct Metadata: Codable {
         let width: Int
         let height: Int

--- a/Sources/LiveKit/Broadcast/LKSampleHandler.swift
+++ b/Sources/LiveKit/Broadcast/LKSampleHandler.swift
@@ -120,7 +120,7 @@ open class LKSampleHandler: RPBroadcastSampleHandler, @unchecked Sendable {
             logger.error("Bundle settings improperly configured for screen capture")
             return
         }
-        Task { @Sendable in
+        Task {
             do {
                 uploader = try await BroadcastUploader(socketPath: socketPath)
                 logger.info("Uploader connected")

--- a/Sources/LiveKit/Broadcast/LKSampleHandler.swift
+++ b/Sources/LiveKit/Broadcast/LKSampleHandler.swift
@@ -34,7 +34,7 @@ import LKObjCHelpers
 #endif
 
 @available(macCatalyst 13.1, *)
-open class LKSampleHandler: RPBroadcastSampleHandler {
+open class LKSampleHandler: RPBroadcastSampleHandler, @unchecked Sendable {
     private var uploader: BroadcastUploader?
     private var cancellable = Set<AnyCancellable>()
 
@@ -120,7 +120,7 @@ open class LKSampleHandler: RPBroadcastSampleHandler {
             logger.error("Bundle settings improperly configured for screen capture")
             return
         }
-        Task {
+        Task { @Sendable in
             do {
                 uploader = try await BroadcastUploader(socketPath: socketPath)
                 logger.info("Uploader connected")

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -29,7 +29,7 @@ protocol DataChannelDelegate: Sendable {
     func dataChannel(_ dataChannelPair: DataChannelPair, didReceiveDataPacket dataPacket: Livekit_DataPacket)
 }
 
-class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
+final class DataChannelPair: NSObject, Sendable, Loggable {
     // MARK: - Public
 
     public let delegates = MulticastDelegate<DataChannelDelegate>(label: "DataChannelDelegate")
@@ -48,6 +48,8 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
             guard let lossy, let reliable else { return false }
             return reliable.readyState == .open && lossy.readyState == .open
         }
+
+        var eventContinuation: AsyncStream<ChannelEvent>.Continuation?
     }
 
     private let _state: StateSync<State>
@@ -75,8 +77,6 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
             case bufferedAmountChanged(UInt64)
         }
     }
-
-    private var eventContinuation: AsyncStream<ChannelEvent>.Continuation?
 
     private func handleEvents(
         events: AsyncStream<ChannelEvent>
@@ -175,7 +175,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
 
         Task {
             let eventStream = AsyncStream<ChannelEvent> { continuation in
-                self.eventContinuation = continuation
+                _state.mutate { $0.eventContinuation = continuation }
             }
             await handleEvents(events: eventStream)
         }
@@ -241,7 +241,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
                 channelKind: ChannelKind(packet.kind), // TODO: field is deprecated
                 detail: .publishData(request)
             )
-            eventContinuation?.yield(event)
+            _state.eventContinuation?.yield(event)
         }
     }
 
@@ -255,7 +255,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
     private static let lossyLowThreshold: UInt64 = reliableLowThreshold
 
     deinit {
-        eventContinuation?.finish()
+        _state.eventContinuation?.finish()
     }
 }
 
@@ -267,7 +267,7 @@ extension DataChannelPair: LKRTCDataChannelDelegate {
             channelKind: dataChannel.kind,
             detail: .bufferedAmountChanged(amount)
         )
-        eventContinuation?.yield(event)
+        _state.eventContinuation?.yield(event)
     }
 
     func dataChannelDidChangeState(_: LKRTCDataChannel) {

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -29,7 +29,7 @@ protocol DataChannelDelegate: Sendable {
     func dataChannel(_ dataChannelPair: DataChannelPair, didReceiveDataPacket dataPacket: Livekit_DataPacket)
 }
 
-final class DataChannelPair: NSObject, Sendable, Loggable {
+class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
     // MARK: - Public
 
     public let delegates = MulticastDelegate<DataChannelDelegate>(label: "DataChannelDelegate")

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -29,7 +29,7 @@ protocol DataChannelDelegate: Sendable {
     func dataChannel(_ dataChannelPair: DataChannelPair, didReceiveDataPacket dataPacket: Livekit_DataPacket)
 }
 
-class DataChannelPair: NSObject, Loggable {
+class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
     // MARK: - Public
 
     public let delegates = MulticastDelegate<DataChannelDelegate>(label: "DataChannelDelegate")

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -78,7 +78,7 @@ class DataChannelPair: NSObject, Loggable {
 
     private var eventContinuation: AsyncStream<ChannelEvent>.Continuation?
 
-    @Sendable private func handleEvents(
+    private func handleEvents(
         events: AsyncStream<ChannelEvent>
     ) async {
         var lossyBuffering = BufferingState()

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -61,16 +61,16 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
         var amount: UInt64 = 0
     }
 
-    private struct PublishDataRequest {
+    private struct PublishDataRequest: Sendable {
         let data: LKRTCDataBuffer
         let continuation: CheckedContinuation<Void, any Error>?
     }
 
-    private struct ChannelEvent {
+    private struct ChannelEvent: Sendable {
         let channelKind: ChannelKind
         let detail: Detail
 
-        enum Detail {
+        enum Detail: Sendable {
             case publishData(PublishDataRequest)
             case bufferedAmountChanged(UInt64)
         }

--- a/Sources/LiveKit/Core/RPC.swift
+++ b/Sources/LiveKit/Core/RPC.swift
@@ -120,7 +120,7 @@ let MAX_RPC_PAYLOAD_BYTES = 15360 // 15 KB
 /// Throwing an `RpcError` will send the error back to the requester.
 ///
 /// - SeeAlso: `LocalParticipant.registerRpcMethod`
-public typealias RpcHandler = (RpcInvocationData) async throws -> String
+public typealias RpcHandler = @Sendable (RpcInvocationData) async throws -> String
 
 public struct RpcInvocationData {
     /// A unique identifier for this RPC request
@@ -136,9 +136,9 @@ public struct RpcInvocationData {
     public let responseTimeout: TimeInterval
 }
 
-struct PendingRpcResponse {
+struct PendingRpcResponse: Sendable {
     let participantIdentity: Participant.Identity
-    let onResolve: (_ payload: String?, _ error: RpcError?) -> Void
+    let onResolve: @Sendable (_ payload: String?, _ error: RpcError?) -> Void
 }
 
 actor RpcStateManager: Loggable {

--- a/Sources/LiveKit/Core/Room+Engine.swift
+++ b/Sources/LiveKit/Core/Room+Engine.swift
@@ -30,7 +30,7 @@ internal import LiveKitWebRTC
 extension Room {
     // MARK: - Public
 
-    typealias ConditionEvalFunc = (_ newState: State, _ oldState: State?) -> Bool
+    typealias ConditionEvalFunc = @Sendable (_ newState: State, _ oldState: State?) -> Bool
 
     // MARK: - Private
 
@@ -207,7 +207,7 @@ extension Room {
 extension Room {
     func execute(when condition: @escaping ConditionEvalFunc,
                  removeWhen removeCondition: @escaping ConditionEvalFunc,
-                 _ block: @escaping () -> Void)
+                 _ block: @Sendable @escaping () -> Void)
     {
         // already matches condition, execute immediately
         if _state.read({ condition($0, nil) }) {

--- a/Sources/LiveKit/Core/Room+EngineDelegate.swift
+++ b/Sources/LiveKit/Core/Room+EngineDelegate.swift
@@ -96,7 +96,7 @@ extension Room {
         }
 
         // Notify change when engine's state mutates
-        Task.detached { @MainActor in
+        Task { @MainActor in
             self.objectWillChange.send()
         }
     }

--- a/Sources/LiveKit/E2EE/E2EEManager.swift
+++ b/Sources/LiveKit/E2EE/E2EEManager.swift
@@ -23,7 +23,7 @@ internal import LiveKitWebRTC
 #endif
 
 @objc
-public class E2EEManager: NSObject, ObservableObject, Loggable {
+public class E2EEManager: NSObject, @unchecked Sendable, ObservableObject, Loggable {
     // Private delegate adapter to hide RTCFrameCryptorDelegate symbol
     private class DelegateAdapter: NSObject, LKRTCFrameCryptorDelegate {
         weak var target: E2EEManager?

--- a/Sources/LiveKit/Extensions/Sendable.swift
+++ b/Sources/LiveKit/Extensions/Sendable.swift
@@ -22,7 +22,8 @@ internal import LiveKitWebRTC
 @_implementationOnly import LiveKitWebRTC
 #endif
 
-// Immutable classes.
+// MARK: Immutable classes
+
 extension LKRTCMediaConstraints: @unchecked Swift.Sendable {}
 extension LKRTCSessionDescription: @unchecked Swift.Sendable {}
 extension LKRTCVideoFrame: @unchecked Swift.Sendable {}
@@ -33,3 +34,9 @@ extension LKRTCFrameCryptorKeyProvider: @unchecked Swift.Sendable {}
 extension LKRTCRtpTransceiver: @unchecked Swift.Sendable {}
 extension LKRTCRtpTransceiverInit: @unchecked Swift.Sendable {}
 extension LKRTCPeerConnectionFactory: @unchecked Swift.Sendable {}
+extension LKRTCRtpSender: @unchecked Swift.Sendable {}
+extension LKRTCRtpReceiver: @unchecked Swift.Sendable {}
+
+// MARK: Foundation classes
+
+extension NSHashTable: @unchecked Swift.Sendable {} // cannot specify Obj-C generics

--- a/Sources/LiveKit/Extensions/Sendable.swift
+++ b/Sources/LiveKit/Extensions/Sendable.swift
@@ -36,6 +36,7 @@ extension LKRTCRtpTransceiverInit: @unchecked Swift.Sendable {}
 extension LKRTCPeerConnectionFactory: @unchecked Swift.Sendable {}
 extension LKRTCRtpSender: @unchecked Swift.Sendable {}
 extension LKRTCRtpReceiver: @unchecked Swift.Sendable {}
+extension LKRTCVideoCapturer: @unchecked Swift.Sendable {}
 
 // MARK: Foundation classes
 

--- a/Sources/LiveKit/Extensions/Sendable.swift
+++ b/Sources/LiveKit/Extensions/Sendable.swift
@@ -46,4 +46,6 @@ extension LKRTCDataBuffer: @unchecked Swift.Sendable {}
 
 // MARK: Foundation classes
 
+extension KeyPath: @unchecked Swift.Sendable where Root: Sendable, Value: Sendable {}
 extension NSHashTable: @unchecked Swift.Sendable {} // cannot specify Obj-C generics
+extension Dictionary: Swift.Sendable where Key: Sendable, Value: Sendable {}

--- a/Sources/LiveKit/Extensions/Sendable.swift
+++ b/Sources/LiveKit/Extensions/Sendable.swift
@@ -41,6 +41,7 @@ extension LKRTCMediaStream: @unchecked Swift.Sendable {}
 extension LKRTCMediaStreamTrack: @unchecked Swift.Sendable {}
 extension LKRTCDataChannel: @unchecked Swift.Sendable {}
 extension LKRTCPeerConnection: @unchecked Swift.Sendable {}
+extension LKRTCConfiguration: @unchecked Swift.Sendable {}
 
 // MARK: Foundation classes
 

--- a/Sources/LiveKit/Extensions/Sendable.swift
+++ b/Sources/LiveKit/Extensions/Sendable.swift
@@ -24,28 +24,34 @@ internal import LiveKitWebRTC
 
 // MARK: Immutable classes
 
-extension LKRTCMediaConstraints: @unchecked Swift.Sendable {}
-extension LKRTCSessionDescription: @unchecked Swift.Sendable {}
-extension LKRTCVideoFrame: @unchecked Swift.Sendable {}
-extension LKRTCStatisticsReport: @unchecked Swift.Sendable {}
-extension LKRTCIceCandidate: @unchecked Swift.Sendable {}
-extension LKRTCVideoCodecInfo: @unchecked Swift.Sendable {}
+extension LKRTCDataBuffer: @unchecked Swift.Sendable {}
+extension LKRTCDataChannel: @unchecked Swift.Sendable {}
 extension LKRTCFrameCryptorKeyProvider: @unchecked Swift.Sendable {}
-extension LKRTCRtpTransceiver: @unchecked Swift.Sendable {}
-extension LKRTCRtpTransceiverInit: @unchecked Swift.Sendable {}
-extension LKRTCPeerConnectionFactory: @unchecked Swift.Sendable {}
-extension LKRTCRtpSender: @unchecked Swift.Sendable {}
-extension LKRTCRtpReceiver: @unchecked Swift.Sendable {}
-extension LKRTCVideoCapturer: @unchecked Swift.Sendable {}
+extension LKRTCIceCandidate: @unchecked Swift.Sendable {}
+extension LKRTCMediaConstraints: @unchecked Swift.Sendable {}
 extension LKRTCMediaStream: @unchecked Swift.Sendable {}
 extension LKRTCMediaStreamTrack: @unchecked Swift.Sendable {}
-extension LKRTCDataChannel: @unchecked Swift.Sendable {}
 extension LKRTCPeerConnection: @unchecked Swift.Sendable {}
-extension LKRTCConfiguration: @unchecked Swift.Sendable {}
-extension LKRTCDataBuffer: @unchecked Swift.Sendable {}
+extension LKRTCPeerConnectionFactory: @unchecked Swift.Sendable {}
+extension LKRTCRtpReceiver: @unchecked Swift.Sendable {}
+extension LKRTCRtpSender: @unchecked Swift.Sendable {}
+extension LKRTCRtpTransceiver: @unchecked Swift.Sendable {}
+extension LKRTCRtpTransceiverInit: @unchecked Swift.Sendable {}
+extension LKRTCSessionDescription: @unchecked Swift.Sendable {}
+extension LKRTCStatisticsReport: @unchecked Swift.Sendable {}
+extension LKRTCVideoCodecInfo: @unchecked Swift.Sendable {}
+extension LKRTCVideoFrame: @unchecked Swift.Sendable {}
 
-// MARK: Foundation classes
+// MARK: Mutable classes - to be validated
+
+extension LKRTCConfiguration: @unchecked Swift.Sendable {}
+extension LKRTCVideoCapturer: @unchecked Swift.Sendable {}
+
+// MARK: Foundation
 
 extension KeyPath: @unchecked Swift.Sendable where Root: Sendable, Value: Sendable {}
+
+// MARK: Collections
+
 extension NSHashTable: @unchecked Swift.Sendable {} // cannot specify Obj-C generics
 extension Dictionary: Swift.Sendable where Key: Sendable, Value: Sendable {}

--- a/Sources/LiveKit/Extensions/Sendable.swift
+++ b/Sources/LiveKit/Extensions/Sendable.swift
@@ -42,6 +42,7 @@ extension LKRTCMediaStreamTrack: @unchecked Swift.Sendable {}
 extension LKRTCDataChannel: @unchecked Swift.Sendable {}
 extension LKRTCPeerConnection: @unchecked Swift.Sendable {}
 extension LKRTCConfiguration: @unchecked Swift.Sendable {}
+extension LKRTCDataBuffer: @unchecked Swift.Sendable {}
 
 // MARK: Foundation classes
 

--- a/Sources/LiveKit/Extensions/Sendable.swift
+++ b/Sources/LiveKit/Extensions/Sendable.swift
@@ -37,6 +37,10 @@ extension LKRTCPeerConnectionFactory: @unchecked Swift.Sendable {}
 extension LKRTCRtpSender: @unchecked Swift.Sendable {}
 extension LKRTCRtpReceiver: @unchecked Swift.Sendable {}
 extension LKRTCVideoCapturer: @unchecked Swift.Sendable {}
+extension LKRTCMediaStream: @unchecked Swift.Sendable {}
+extension LKRTCMediaStreamTrack: @unchecked Swift.Sendable {}
+extension LKRTCDataChannel: @unchecked Swift.Sendable {}
+extension LKRTCPeerConnection: @unchecked Swift.Sendable {}
 
 // MARK: Foundation classes
 

--- a/Sources/LiveKit/Participant/Participant+Kind.swift
+++ b/Sources/LiveKit/Participant/Participant+Kind.swift
@@ -18,7 +18,7 @@
 
 public extension Participant {
     @objc
-    enum Kind: Int {
+    enum Kind: Int, Sendable {
         case unknown
         /// Standard participants, e.g. web clients.
         case standard

--- a/Sources/LiveKit/Participant/Participant.swift
+++ b/Sources/LiveKit/Participant/Participant.swift
@@ -90,7 +90,7 @@ public class Participant: NSObject, @unchecked Sendable, ObservableObject, Logga
 
     // MARK: - Internal
 
-    struct State: Equatable, Hashable {
+    struct State: Equatable, Hashable, Sendable {
         var sid: Sid?
         var identity: Identity?
         var name: String?

--- a/Sources/LiveKit/Support/AsyncCompleter.swift
+++ b/Sources/LiveKit/Support/AsyncCompleter.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /// Manages a map of AsyncCompleters
-actor CompleterMapActor<T> {
+actor CompleterMapActor<T: Sendable> {
     // MARK: - Public
 
     public nonisolated let label: String
@@ -63,7 +63,7 @@ actor CompleterMapActor<T> {
     }
 }
 
-class AsyncCompleter<T>: Loggable {
+class AsyncCompleter<T: Sendable>: @unchecked Sendable, Loggable {
     //
     struct WaitEntry {
         let continuation: UnsafeContinuation<T, Error>

--- a/Sources/LiveKit/Support/AsyncCompleter.swift
+++ b/Sources/LiveKit/Support/AsyncCompleter.swift
@@ -63,7 +63,7 @@ actor CompleterMapActor<T: Sendable> {
     }
 }
 
-class AsyncCompleter<T: Sendable>: @unchecked Sendable, Loggable {
+final class AsyncCompleter<T: Sendable>: @unchecked Sendable, Loggable {
     //
     struct WaitEntry {
         let continuation: UnsafeContinuation<T, Error>

--- a/Sources/LiveKit/Support/AsyncDebounce.swift
+++ b/Sources/LiveKit/Support/AsyncDebounce.swift
@@ -32,7 +32,7 @@ actor Debounce {
         _task?.cancel()
     }
 
-    func schedule(_ action: @escaping () async throws -> Void) {
+    func schedule(_ action: @Sendable @escaping () async throws -> Void) {
         _task?.cancel()
         _task = Task.detached(priority: .utility) {
             try? await Task.sleep(nanoseconds: UInt64(self._delay * 1_000_000_000))

--- a/Sources/LiveKit/Support/AsyncRetry.swift
+++ b/Sources/LiveKit/Support/AsyncRetry.swift
@@ -21,7 +21,7 @@ extension Task where Failure == Error {
         priority: TaskPriority? = nil,
         totalAttempts: Int = 3,
         retryDelay: TimeInterval = 1,
-        @_implicitSelfCapture operation: @escaping (_ currentAttempt: Int, _ totalAttempts: Int) async throws -> Success
+        @_implicitSelfCapture operation: @Sendable @escaping (_ currentAttempt: Int, _ totalAttempts: Int) async throws -> Success
     ) -> Task {
         Task(priority: priority) {
             for currentAttempt in 1 ..< max(1, totalAttempts) {

--- a/Sources/LiveKit/Support/AsyncTimer.swift
+++ b/Sources/LiveKit/Support/AsyncTimer.swift
@@ -16,14 +16,14 @@
 
 import Foundation
 
-class AsyncTimer: Loggable {
+final class AsyncTimer: Sendable, Loggable {
     // MARK: - Public types
 
-    typealias TimerBlock = () async throws -> Void
+    typealias TimerBlock = @Sendable () async throws -> Void
 
     // MARK: - Private
 
-    struct State {
+    struct State: Sendable {
         var isStarted: Bool = false
         var interval: TimeInterval
         var task: Task<Void, Never>?

--- a/Sources/LiveKit/Support/AudioMixRecorder.swift
+++ b/Sources/LiveKit/Support/AudioMixRecorder.swift
@@ -243,7 +243,7 @@ public class AudioMixRecorder: Loggable {
     }
 }
 
-public class AudioMixRecorderSource: Loggable, AudioRenderer {
+public class AudioMixRecorderSource: Loggable, AudioRenderer, @unchecked Sendable {
     public let processingFormat: AVAudioFormat
     let playerNode = AVAudioPlayerNode()
 

--- a/Sources/LiveKit/Support/AudioMixRecorder.swift
+++ b/Sources/LiveKit/Support/AudioMixRecorder.swift
@@ -65,7 +65,7 @@ import Foundation
 /// Audio sources can be added or removed at any time, including while recording is active.
 /// When no audio is being provided by any source, the recorder will capture silence.
 
-public class AudioMixRecorder: Loggable {
+public class AudioMixRecorder: Loggable, @unchecked Sendable {
     // MARK: - Public
 
     /// The format used internally by engine & recorder.

--- a/Sources/LiveKit/Support/DeviceManager.swift
+++ b/Sources/LiveKit/Support/DeviceManager.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import AVFoundation
+@preconcurrency import AVFoundation
 
 // Internal-only for now
 class DeviceManager: @unchecked Sendable, Loggable {

--- a/Sources/LiveKit/Support/DeviceManager.swift
+++ b/Sources/LiveKit/Support/DeviceManager.swift
@@ -17,14 +17,10 @@
 import AVFoundation
 
 // Internal-only for now
-class DeviceManager: Loggable {
+class DeviceManager: @unchecked Sendable, Loggable {
     // MARK: - Public
 
-    #if compiler(>=6.0)
-    public nonisolated(unsafe) static let shared = DeviceManager()
-    #else
     public static let shared = DeviceManager()
-    #endif
 
     public static func prepare() {
         // Instantiate shared instance

--- a/Sources/LiveKit/Support/QueueActor.swift
+++ b/Sources/LiveKit/Support/QueueActor.swift
@@ -16,8 +16,8 @@
 
 import Foundation
 
-actor QueueActor<T>: Loggable {
-    typealias OnProcess = (T) async -> Void
+actor QueueActor<T: Sendable>: Loggable {
+    typealias OnProcess = @Sendable (T) async -> Void
 
     // MARK: - Public
 

--- a/Sources/LiveKit/Support/Stopwatch.swift
+++ b/Sources/LiveKit/Support/Stopwatch.swift
@@ -16,8 +16,8 @@
 
 import Foundation
 
-public struct Stopwatch {
-    public struct Entry: Equatable {
+public struct Stopwatch: Sendable {
+    public struct Entry: Equatable, Sendable {
         let label: String
         let time: TimeInterval
     }

--- a/Sources/LiveKit/Support/UnfairLock.swift
+++ b/Sources/LiveKit/Support/UnfairLock.swift
@@ -19,7 +19,7 @@ import Foundation
 //
 // Read http://www.russbishop.net/the-law for more information on why this is necessary
 //
-class UnfairLock {
+final class UnfairLock {
     private var _lock: UnsafeMutablePointer<os_unfair_lock>
 
     init() {

--- a/Sources/LiveKit/Support/WebSocket.swift
+++ b/Sources/LiveKit/Support/WebSocket.swift
@@ -18,7 +18,7 @@ import Foundation
 
 typealias WebSocketStream = AsyncThrowingStream<URLSessionWebSocketTask.Message, Error>
 
-class WebSocket: NSObject, @unchecked Sendable, Loggable, AsyncSequence, URLSessionWebSocketDelegate {
+final class WebSocket: NSObject, @unchecked Sendable, Loggable, AsyncSequence, URLSessionWebSocketDelegate {
     typealias AsyncIterator = WebSocketStream.Iterator
     typealias Element = URLSessionWebSocketTask.Message
 

--- a/Sources/LiveKit/Support/WebSocket.swift
+++ b/Sources/LiveKit/Support/WebSocket.swift
@@ -18,7 +18,7 @@ import Foundation
 
 typealias WebSocketStream = AsyncThrowingStream<URLSessionWebSocketTask.Message, Error>
 
-class WebSocket: NSObject, Loggable, AsyncSequence, URLSessionWebSocketDelegate {
+class WebSocket: NSObject, @unchecked Sendable, Loggable, AsyncSequence, URLSessionWebSocketDelegate {
     typealias AsyncIterator = WebSocketStream.Iterator
     typealias Element = URLSessionWebSocketTask.Message
 

--- a/Sources/LiveKit/SwiftUI/TrackDelegateObserver.swift
+++ b/Sources/LiveKit/SwiftUI/TrackDelegateObserver.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /// Helper class to observer ``TrackDelegate`` from Swift UI.
-public class TrackDelegateObserver: ObservableObject, TrackDelegate {
+public class TrackDelegateObserver: ObservableObject, TrackDelegate, @unchecked Sendable {
     private let track: Track
 
     @Published public var dimensions: Dimensions?
@@ -46,13 +46,13 @@ public class TrackDelegateObserver: ObservableObject, TrackDelegate {
     // MARK: - TrackDelegate
 
     public func track(_: VideoTrack, didUpdateDimensions dimensions: Dimensions?) {
-        Task.detached { @MainActor in
+        Task { @MainActor in
             self.dimensions = dimensions
         }
     }
 
     public func track(_: Track, didUpdateStatistics statistics: TrackStatistics, simulcastStatistics: [VideoCodec: TrackStatistics]) {
-        Task.detached { @MainActor in
+        Task { @MainActor in
             self.statistics = statistics
             self.simulcastStatistics = simulcastStatistics
         }

--- a/Sources/LiveKit/Track/Capturers/BufferCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/BufferCapturer.swift
@@ -32,7 +32,7 @@ internal import LiveKitWebRTC
 /// > Note: At least one frame must be captured before publishing the track or the publish will timeout,
 /// since dimensions must be resolved at the time of publishing (to compute video parameters).
 ///
-public class BufferCapturer: VideoCapturer {
+public class BufferCapturer: VideoCapturer, @unchecked Sendable {
     private let capturer = RTC.createVideoCapturer()
 
     /// The ``BufferCaptureOptions`` used for this capturer.

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -27,7 +27,7 @@ internal import LiveKitWebRTC
 @_implementationOnly import LiveKitWebRTC
 #endif
 
-public class CameraCapturer: VideoCapturer {
+public class CameraCapturer: VideoCapturer, @unchecked Sendable {
     /// Current device used for capturing
     @objc
     public var device: AVCaptureDevice? { _cameraCapturerState.device }

--- a/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
@@ -27,7 +27,7 @@ internal import LiveKitWebRTC
 #endif
 
 @available(macOS 11.0, iOS 11.0, *)
-public class InAppScreenCapturer: VideoCapturer {
+public class InAppScreenCapturer: VideoCapturer, @unchecked Sendable {
     private let capturer = RTC.createVideoCapturer()
     private let options: ScreenShareCaptureOptions
 

--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -30,7 +30,7 @@ internal import LiveKitWebRTC
 #if os(macOS)
 
 @available(macOS 12.3, *)
-public class MacOSScreenCapturer: VideoCapturer {
+public class MacOSScreenCapturer: VideoCapturer, @unchecked Sendable {
     private let capturer = RTC.createVideoCapturer()
 
     // TODO: Make it possible to change dynamically

--- a/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/VideoCapturer.swift
@@ -45,7 +45,7 @@ public protocol VideoCapturerDelegate: AnyObject, Sendable {
 }
 
 // Intended to be a base class for video capturers
-public class VideoCapturer: NSObject, Loggable, VideoCapturerProtocol {
+public class VideoCapturer: NSObject, @unchecked Sendable, Loggable, VideoCapturerProtocol {
     // MARK: - MulticastDelegate
 
     public let delegates = MulticastDelegate<VideoCapturerDelegate>(label: "VideoCapturerDelegate")

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -107,7 +107,7 @@ public class Track: NSObject, @unchecked Sendable, Loggable {
 
     let mediaTrack: LKRTCMediaStreamTrack
 
-    struct State {
+    struct State: Sendable {
         let name: String
         let kind: Kind
         let source: Source

--- a/Sources/LiveKit/Types/ConnectionQuality.swift
+++ b/Sources/LiveKit/Types/ConnectionQuality.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 @objc
-public enum ConnectionQuality: Int {
+public enum ConnectionQuality: Int, Sendable {
     case unknown
     /// Indicates that a participant has temporarily (or permanently) lost connection to LiveKit.
     /// For permanent disconnection, ``RoomDelegate/room(_:participantDidLeave:)`` will be invoked after a timeout.

--- a/Sources/LiveKit/Types/Options/CaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/CaptureOptions.swift
@@ -17,4 +17,4 @@
 import Foundation
 
 @objc
-public protocol CaptureOptions {}
+public protocol CaptureOptions: Sendable {}

--- a/Sources/LiveKit/Types/ParticipantPermissions.swift
+++ b/Sources/LiveKit/Types/ParticipantPermissions.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 @objc
-public class ParticipantPermissions: NSObject {
+public class ParticipantPermissions: NSObject, @unchecked Sendable {
     /// ``Participant`` can subscribe to tracks in the room
     @objc
     public let canSubscribe: Bool

--- a/Sources/LiveKit/Types/Room+Types.swift
+++ b/Sources/LiveKit/Types/Room+Types.swift
@@ -18,7 +18,7 @@ import Foundation
 
 public extension Room {
     @objc(RoomSid)
-    class Sid: NSObject, Codable {
+    class Sid: NSObject, @unchecked Sendable, Codable {
         @objc
         public let stringValue: String
 

--- a/Sources/LiveKit/Types/TrackStatistics.swift
+++ b/Sources/LiveKit/Types/TrackStatistics.swift
@@ -23,7 +23,7 @@ internal import LiveKitWebRTC
 #endif
 
 @objc
-public class TrackStatistics: NSObject, Loggable {
+public class TrackStatistics: NSObject, @unchecked Sendable, Loggable {
     public let codec: [CodecStatistics]
     public let transportStats: TransportStatistics?
     public let videoSource: [VideoSourceStatistics]

--- a/Sources/LiveKit/Types/VideoFrame.swift
+++ b/Sources/LiveKit/Types/VideoFrame.swift
@@ -78,7 +78,7 @@ public struct I420VideoBuffer: VideoBuffer, RTCCompatibleVideoBuffer {
     public var strideV: Int32 { _rtcType.strideV }
 }
 
-public class VideoFrame: NSObject {
+public class VideoFrame: NSObject, @unchecked Sendable {
     public let dimensions: Dimensions
     public let rotation: VideoRotation
     public let timeStampNs: Int64

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -395,7 +395,7 @@ public class VideoView: NativeView, Loggable {
 
             if self._state.isRendering, let renderDate = self._state.renderDate {
                 let diff = Date().timeIntervalSince(renderDate)
-                if diff >= Self._freezeDetectThreshold {
+                if await diff >= Self._freezeDetectThreshold {
                     self._state.mutate { $0.isRendering = false }
                 }
             }

--- a/Tests/LiveKitTests/AudioEngineTests.swift
+++ b/Tests/LiveKitTests/AudioEngineTests.swift
@@ -19,7 +19,7 @@
 import LiveKitWebRTC
 import XCTest
 
-class AudioEngineTests: LKTestCase {
+class AudioEngineTests: LKTestCase, @unchecked Sendable {
     override func tearDown() async throws {}
 
     #if !targetEnvironment(simulator)
@@ -355,7 +355,7 @@ class AudioEngineTests: LKTestCase {
     }
 }
 
-final class FailingEngineObserver: AudioEngineObserver {
+final class FailingEngineObserver: AudioEngineObserver, @unchecked Sendable {
     var next: (any LiveKit.AudioEngineObserver)?
 
     func engineWillEnable(_: AVAudioEngine, isPlayoutEnabled _: Bool, isRecordingEnabled _: Bool) -> Int {
@@ -364,7 +364,7 @@ final class FailingEngineObserver: AudioEngineObserver {
     }
 }
 
-final class SineWaveNodeHook: AudioEngineObserver {
+final class SineWaveNodeHook: AudioEngineObserver, @unchecked Sendable {
     var next: (any LiveKit.AudioEngineObserver)?
 
     let sineWaveNode = SineWaveSourceNode()
@@ -386,7 +386,7 @@ final class SineWaveNodeHook: AudioEngineObserver {
     }
 }
 
-final class PlayerNodeHook: AudioEngineObserver {
+final class PlayerNodeHook: AudioEngineObserver, @unchecked Sendable {
     var next: (any LiveKit.AudioEngineObserver)?
 
     public let playerNode = AVAudioPlayerNode()

--- a/Tests/LiveKitTests/Broadcast/IPCChannelTests.swift
+++ b/Tests/LiveKitTests/Broadcast/IPCChannelTests.swift
@@ -20,7 +20,7 @@
 import Network
 import XCTest
 
-final class IPCChannelTests: LKTestCase {
+final class IPCChannelTests: LKTestCase, @unchecked Sendable {
     private var socketPath: SocketPath!
 
     enum TestSetupError: Error {
@@ -75,7 +75,7 @@ final class IPCChannelTests: LKTestCase {
     }
 
     private func assertInitCancellationThrows(
-        _ initializer: @escaping @autoclosure () async throws -> IPCChannel,
+        _ initializer: @Sendable @escaping @autoclosure () async throws -> IPCChannel,
         file: StaticString = #file,
         line: UInt = #line
     ) async throws {

--- a/Tests/LiveKitTests/BroadcastManagerTests.swift
+++ b/Tests/LiveKitTests/BroadcastManagerTests.swift
@@ -20,7 +20,7 @@ import Combine
 @testable import LiveKit
 import XCTest
 
-class BroadcastManagerTests: LKTestCase {
+class BroadcastManagerTests: LKTestCase, @unchecked Sendable {
     private var manager: BroadcastManager!
 
     override func setUp() {
@@ -80,7 +80,7 @@ class BroadcastManagerTests: LKTestCase {
         )
     }
 
-    private class MockDelegate: BroadcastManagerDelegate {
+    private class MockDelegate: BroadcastManagerDelegate, @unchecked Sendable {
         var didChangeStateCalled: ((Bool) -> Void)?
 
         func broadcastManager(didChangeState isBroadcasting: Bool) {

--- a/Tests/LiveKitTests/DataStream/ByteStreamReaderTests.swift
+++ b/Tests/LiveKitTests/DataStream/ByteStreamReaderTests.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class ByteStreamReaderTests: LKTestCase {
+class ByteStreamReaderTests: LKTestCase, @unchecked Sendable {
     private var continuation: StreamReaderSource.Continuation!
     private var reader: ByteStreamReader!
 

--- a/Tests/LiveKitTests/DataStream/IncomingStreamManagerTests.swift
+++ b/Tests/LiveKitTests/DataStream/IncomingStreamManagerTests.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class IncomingStreamManagerTests: LKTestCase {
+class IncomingStreamManagerTests: LKTestCase, @unchecked Sendable {
     private var manager: IncomingStreamManager!
 
     private let topicName = "someTopic"

--- a/Tests/LiveKitTests/DataStream/TextStreamReaderTests.swift
+++ b/Tests/LiveKitTests/DataStream/TextStreamReaderTests.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class TextStreamReaderTests: LKTestCase {
+class TextStreamReaderTests: LKTestCase, @unchecked Sendable {
     private var continuation: StreamReaderSource.Continuation!
     private var reader: TextStreamReader!
 

--- a/Tests/LiveKitTests/E2EE/Thread.swift
+++ b/Tests/LiveKitTests/E2EE/Thread.swift
@@ -15,7 +15,7 @@
  */
 
 @testable import LiveKit
-import LiveKitWebRTC
+@preconcurrency import LiveKitWebRTC
 import XCTest
 
 class E2EEThreadTests: LKTestCase {

--- a/Tests/LiveKitTests/MuteTests.swift
+++ b/Tests/LiveKitTests/MuteTests.swift
@@ -51,7 +51,7 @@ struct TestEngineStep {
     let assert: TestEngineAssert
 }
 
-extension RTCAudioEngineState: CustomStringConvertible {
+extension RTCAudioEngineState: Swift.CustomStringConvertible {
     public var description: String {
         "EngineState(" +
             "outputEnabled: \(outputEnabled), " +

--- a/Tests/LiveKitTests/PreConnectAudioBufferTests.swift
+++ b/Tests/LiveKitTests/PreConnectAudioBufferTests.swift
@@ -21,7 +21,7 @@ class PreConnectAudioBufferTests: LKTestCase {
     func testRoomDidConnectSetsParticipantAttribute() async throws {
         let attributeSetExpectation = expectation(description: "Participant attribute set")
 
-        class AttributeDelegate: RoomDelegate {
+        class AttributeDelegate: RoomDelegate, @unchecked Sendable {
             let expectation: XCTestExpectation
             var attributeValue: String?
 

--- a/Tests/LiveKitTests/SerialRunnerActor.swift
+++ b/Tests/LiveKitTests/SerialRunnerActor.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class SerialRunnerActorTests: LKTestCase {
+class SerialRunnerActorTests: LKTestCase, @unchecked Sendable {
     let serialRunner = SerialRunnerActor<Void>()
     var counterValue: Int = 0
     var resultValues: [String] = []

--- a/Tests/LiveKitTests/Support/AudioRecorder.swift
+++ b/Tests/LiveKitTests/Support/AudioRecorder.swift
@@ -18,7 +18,7 @@ import AVFAudio
 @testable import LiveKit
 
 // Used to save audio data for inspecting the correct format, etc.
-class AudioRecorder {
+class AudioRecorder: @unchecked Sendable {
     public let sampleRate: Double
     public let filePath: URL
     private var audioFile: AVAudioFile?

--- a/Tests/LiveKitTests/Support/MockDataChannelPair.swift
+++ b/Tests/LiveKitTests/Support/MockDataChannelPair.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 
 /// Mock ``DataChannelPair`` to intercept outgoing packets.
-class MockDataChannelPair: DataChannelPair {
+class MockDataChannelPair: DataChannelPair, @unchecked Sendable {
     var packetHandler: (Livekit_DataPacket) -> Void
 
     init(packetHandler: @escaping (Livekit_DataPacket) -> Void) {

--- a/Tests/LiveKitTests/Support/Room.swift
+++ b/Tests/LiveKitTests/Support/Room.swift
@@ -189,7 +189,7 @@ extension Room {
     }
 }
 
-class RoomWatcher<T: Decodable>: RoomDelegate {
+final class RoomWatcher<T: Decodable & Sendable>: RoomDelegate, Sendable {
     public let id: String
     public let didReceiveDataCompleters = CompleterMapActor<T>(label: "Data receive completer", defaultTimeout: 10)
 

--- a/Tests/LiveKitTests/Support/Tracks.swift
+++ b/Tests/LiveKitTests/Support/Tracks.swift
@@ -14,16 +14,20 @@
  * limitations under the License.
  */
 
-import AVFoundation
+@preconcurrency import AVFoundation
 @testable import LiveKit
 import XCTest
 
 extension LKTestCase {
     // Static variable to store the downloaded sample video URL
+    #if compiler(>=6.0)
+    private nonisolated(unsafe) static var cachedSampleVideoURL: URL?
+    #else
     private static var cachedSampleVideoURL: URL?
+    #endif
 
     // Creates a LocalVideoTrack with BufferCapturer, generates frames for approx 30 seconds
-    func createSampleVideoTrack(targetFps: Int = 30, _ onCapture: @escaping (CMSampleBuffer) -> Void) async throws -> (Task<Void, any Error>) {
+    func createSampleVideoTrack(targetFps: Int = 30, _ onCapture: @Sendable @escaping (CMSampleBuffer) -> Void) async throws -> (Task<Void, any Error>) {
         // Sample video
         let url = URL(string: "https://storage.unxpected.co.jp/public/sample-videos/ocean-1080p.mp4")!
         let tempLocalUrl: URL
@@ -101,7 +105,7 @@ extension LKTestCase {
 
 typealias OnDidRenderFirstFrame = (_ id: String) -> Void
 
-class VideoTrackWatcher: TrackDelegate, VideoRenderer {
+class VideoTrackWatcher: TrackDelegate, VideoRenderer, @unchecked Sendable {
     // MARK: - Public
 
     public var didRenderFirstFrame: Bool { _state.didRenderFirstFrame }
@@ -219,7 +223,7 @@ class VideoTrackWatcher: TrackDelegate, VideoRenderer {
     }
 }
 
-class AudioTrackWatcher: AudioRenderer {
+class AudioTrackWatcher: AudioRenderer, @unchecked Sendable {
     public let id: String
     public var didRenderFirstFrame: Bool { _state.didRenderFirstFrame }
 

--- a/Tests/LiveKitTests/ThreadSafetyTests.swift
+++ b/Tests/LiveKitTests/ThreadSafetyTests.swift
@@ -17,7 +17,7 @@
 @testable import LiveKit
 import XCTest
 
-class ThreadSafetyTests: LKTestCase {
+class ThreadSafetyTests: LKTestCase, @unchecked Sendable {
     struct TestState: Equatable {
         var dictionary = [String: String]()
         var counter = 0

--- a/Tests/LiveKitTests/Track/TrackTests.swift
+++ b/Tests/LiveKitTests/Track/TrackTests.swift
@@ -20,7 +20,7 @@ import Foundation
 @testable import LiveKit
 import XCTest
 
-class TestTrack: LocalAudioTrack {
+class TestTrack: LocalAudioTrack, @unchecked Sendable {
     init() {
         let source = RTC.createAudioSource(nil)
         let _track = RTC.createAudioTrack(source: source)


### PR DESCRIPTION
This is the last 🎉 portion of Swift 6 warnings, mostly around `State`.

The algorithm is still pretty simple:
- can be `final (internal)`/immutable → make it `Sendable`
- is already public/inherited → make it `@unchecked Sendable`

Unit tests are mostly `@unchecked` because of inheritance, IMO gradually moving to Swift Testing is more important.

Fortunately, for most generic/async stuff `T: Sendable` is just works (tm), just needs proper annotations.