### PR TITLE
Full reconnect on n/w path changes

### DIFF
--- a/Sources/LiveKit/Core/Room+ConnectivityListenerDelegate.swift
+++ b/Sources/LiveKit/Core/Room+ConnectivityListenerDelegate.swift
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import Network
+
+extension Room: ConnectivityListenerDelegate {
+    func connectivityListener(_: ConnectivityListener, didUpdate hasConnectivity: Bool) {
+        if !hasConnectivity {
+            _state.mutate { $0.nextReconnectMode = .full }
+        }
+    }
+
+    func connectivityListener(_: ConnectivityListener, didSwitch _: NWPath) {
+        _state.mutate { $0.nextReconnectMode = .full }
+    }
+}

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -232,6 +232,8 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
             AppStateListener.shared.delegates.add(delegate: self)
         }
 
+        ConnectivityListener.shared.add(delegate: self)
+
         // trigger events when state mutates
         _state.onDidMutate = { [weak self] newState, oldState in
 


### PR DESCRIPTION
This is a high-level solution - without changing any logic for the reconnect itself 🤔 

- `.quick` cannot recover from "no connectivity" state
- `ConnectivityListenerDelegate` was basically unused
- There's `StartReconnectReason.networkSwitch`, but do we need an explicit `startReconnect()` here?
  - it will be triggered anyway, either by `.websocket` or `.transport`, we'll just hit the same state twice (with an error)

At least 2 scenarios to reproduce:
- Use local server and disable wi-fi
- Use any server with ✈️ mode (this is more likely to fail)

I'm still not sure how much `ConnectOptions` (timeouts) affect this case, does it work based on a "happy configuration"?