### PR TITLE
chore(docs): relocate docc to /reference/client-sdk-swift base path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,7 +159,7 @@ jobs:
             --output-dir docs \
             --additional-symbol-graph-dir symbol-graphs \
             --transform-for-static-hosting \
-            --hosting-base-path client-sdk-swift/
+            --hosting-base-path /reference/client-sdk-swift/
 
       - name: Archive
         run: zip -r docs.zip docs


### PR DESCRIPTION
See: https://github.com/livekit/web/pull/1054