### PR TITLE
Main thread isolation in VideoView

### DIFF
--- a/.nanpa/swift-6-video-view-crash.kdl
+++ b/.nanpa/swift-6-video-view-crash.kdl
@@ -1,0 +1,1 @@
+patch type="fixed" "Swift 6: Fixed crash in VideoView with .v6 language mode"

--- a/Sources/LiveKit/Support/StateSync.swift
+++ b/Sources/LiveKit/Support/StateSync.swift
@@ -21,7 +21,7 @@ import Foundation
 public final class StateSync<State>: @unchecked Sendable {
     // MARK: - Types
 
-    public typealias OnDidMutate = (_ newState: State, _ oldState: State) -> Void
+    public typealias OnDidMutate = @Sendable (_ newState: State, _ oldState: State) -> Void
 
     // MARK: - Public
 

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -862,6 +862,7 @@ extension LKRTCMTLVideoView: Mirrorable {
 #endif
 
 private extension VideoView {
+    #if compiler(>=5.9)
     nonisolated func mainSyncOrAsync(operation: @MainActor @escaping () -> Void) {
         if Thread.current.isMainThread {
             MainActor.assumeIsolated(operation)
@@ -871,6 +872,17 @@ private extension VideoView {
             }
         }
     }
+    #else
+    nonisolated func mainSyncOrAsync(operation: @escaping () -> Void) {
+        if Thread.current.isMainThread {
+            operation()
+        } else {
+            Task { @MainActor in
+                operation()
+            }
+        }
+    }
+    #endif
 }
 
 #if os(iOS)

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -862,9 +862,9 @@ extension LKRTCMTLVideoView: Mirrorable {
 #endif
 
 private extension VideoView {
-    func mainSyncOrAsync(operation: @escaping () -> Void) {
+    nonisolated func mainSyncOrAsync(operation: @MainActor @escaping () -> Void) {
         if Thread.current.isMainThread {
-            operation()
+            MainActor.assumeIsolated(operation)
         } else {
             Task { @MainActor in
                 operation()

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -285,7 +285,7 @@ public class VideoView: NativeView, Loggable {
 
             // Enter .main only if UI updates are required
             if trackDidUpdate || shouldRenderDidUpdate || renderModeDidUpdate {
-                self.mainSyncOrAsync {
+                self.mainSyncOrAsync { @MainActor in
                     var didReCreateNativeRenderer = false
 
                     if trackDidUpdate || shouldRenderDidUpdate {


### PR DESCRIPTION
This is a tiny change, but prevents a crash in `.v6` mode by fixing an important inconsistency.

- `OnDidMutate` is called within the critical section - so from _any_ thread
- for `Sendable` classes, it doesn't make much difference though
- for `@MainActor` methods like `mainSyncOrAsync` it does, as they:
  - were still `@MainActor` isolated
  - were called from bg threads - which is checked at runtime [now](https://forums.swift.org/t/crash-when-running-in-swift-6-language-mode/72431/2)

So the idea is `mainSyncOrAsync` signature now reflects what *really* happens here:
- it must be `nonisolated` itself as it's called from a `@Sendable` `OnDidMutate` 💚 
- the body is compile-time `@MainActor` 💚 
- the "switch" happens inside the method, not "accidentally outside"

The crash will happen during video track publication, the stack trace is pretty clear:

![Screenshot 2025-04-04 at 11 18 53 AM](https://github.com/user-attachments/assets/b9e3e6f9-ec2f-49d6-906d-9fbab9f45e66)
