### PR TITLE
Input mixer mute mode

### DIFF
--- a/.nanpa/new-mic-mute-mode.kdl
+++ b/.nanpa/new-mic-mute-mode.kdl
@@ -1,0 +1,1 @@
+patch type="added" "New mic mute mode"

--- a/LiveKitClient.podspec
+++ b/LiveKitClient.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |spec|
 
   spec.source_files = "Sources/**/*"
 
-  spec.dependency("LiveKitWebRTC", "= 125.6422.28")
+  spec.dependency("LiveKitWebRTC", "= 125.6422.29")
   spec.dependency("SwiftProtobuf")
   spec.dependency("Logging", "= 1.5.4")
   spec.dependency("DequeModule", "= 1.1.4")

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "125.6422.28"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "125.6422.29"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.26.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "125.6422.28"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "125.6422.29"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.26.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"), // 1.6.x requires Swift >=5.8
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "125.6422.28"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "125.6422.29"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.26.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"), // 1.6.x requires Swift >=5.8
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),

--- a/Sources/LiveKit/Audio/Manager/AudioManager+MuteMode.swift
+++ b/Sources/LiveKit/Audio/Manager/AudioManager+MuteMode.swift
@@ -29,6 +29,9 @@ public enum MicrophoneMuteMode {
     /// Restarts the internal `AVAudioEngine` without mic input when muted.
     /// This is slower, and muted speaker detection does not work. No sound effect is played.
     case restart
+    /// Simply mutes the output of the input mixer.
+    /// The mic indicator remains on, and the internal `AVAudioEngine` continues running without reconfiguration.
+    case inputMixer
     case unknown
 }
 
@@ -73,6 +76,7 @@ extension RTCAudioEngineMuteMode {
         switch self {
         case .voiceProcessing: return .voiceProcessing
         case .restartEngine: return .restart
+        case .inputMixer: return .inputMixer
         case .unknown: return .unknown
         @unknown default: return .unknown
         }
@@ -85,6 +89,7 @@ extension MicrophoneMuteMode {
         case .unknown: return .unknown
         case .voiceProcessing: return .voiceProcessing
         case .restart: return .restartEngine
+        case .inputMixer: return .inputMixer
         }
     }
 }


### PR DESCRIPTION
Adds new mic mute mode: inputMixer, which simply sets inputMixer's outputVolume to 0.0 .
This mute's the mic without reconfiguring input / audio session etc. Mic indicator will remain on.

Patch: https://github.com/webrtc-sdk/webrtc/commit/21ee7f0c73a179c2ac8ff7c8f2ddd5b4cafe942b