### PR TITLE
Concurrent publish support

### DIFF
--- a/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
@@ -42,6 +42,11 @@ extension Room: SignalClientDelegate {
                 log("Failed calling startReconnect, error: \(error)", .error)
             }
         }
+
+        if connectionState != oldState, connectionState == .disconnected {
+            // Disconnected, so reset completer
+            signalClientConnectedCompleter.reset()
+        }
     }
 
     func signalClient(_: SignalClient, didReceiveLeave canReconnect: Bool, reason: Livekit_DisconnectReason) async {
@@ -327,7 +332,7 @@ extension Room: SignalClientDelegate {
 
     func signalClient(_: SignalClient, didReceiveAnswer answer: LKRTCSessionDescription) async {
         do {
-            let publisher = try requirePublisher()
+            let publisher = try await requirePublisher()
             try await publisher.set(remoteDescription: answer)
         } catch {
             log("Failed to set remote description, error: \(error)", .error)

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -103,6 +103,9 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
 
     let primaryTransportConnectedCompleter = AsyncCompleter<Void>(label: "Primary transport connect", defaultTimeout: .defaultTransportState)
     let publisherTransportConnectedCompleter = AsyncCompleter<Void>(label: "Publisher transport connect", defaultTimeout: .defaultTransportState)
+    // Completes when transports are instantiated and configured. Does not wait for state changes.
+    let transportsCompleter = AsyncCompleter<(Transport, Transport)>(label: "Transports configured", defaultTimeout: .defaultTransportState)
+    let signalClientConnectedCompleter = AsyncCompleter<SignalClient>(label: "Signal client connected", defaultTimeout: .defaultTransportState)
 
     let signalClient = SignalClient()
 
@@ -395,6 +398,7 @@ extension Room {
         _sidCompleter.reset()
         primaryTransportConnectedCompleter.reset()
         publisherTransportConnectedCompleter.reset()
+        signalClientConnectedCompleter.reset()
 
         await signalClient.cleanUp(withError: disconnectError)
         await cleanUpRTC()

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -281,7 +281,7 @@ private extension SignalClient {
         switch message {
         case let .join(joinResponse):
             _state.mutate { $0.lastJoinResponse = joinResponse }
-            _delegate.notifyDetached { await $0.signalClient(self, didReceiveConnectResponse: .join(joinResponse)) }
+            await _delegate.notifyAsync { await $0.signalClient(self, didReceiveConnectResponse: .join(joinResponse)) }
             _connectResponseCompleter.resume(returning: .join(joinResponse))
             await _restartPingTimer()
 

--- a/Sources/LiveKit/Support/AsyncSerialDelegate.swift
+++ b/Sources/LiveKit/Support/AsyncSerialDelegate.swift
@@ -28,10 +28,10 @@ final class AsyncSerialDelegate<T: Sendable>: Sendable {
         _state.mutate { $0.delegate = delegate as AnyObject }
     }
 
-    public func notifyAsync(_ fnc: @Sendable @escaping (T) async -> Void) async throws {
+    public func notifyAsync(_ fnc: @Sendable @escaping (T) async throws -> Void) async rethrows {
         guard let delegate = _state.read({ $0.delegate }) as? T else { return }
         try await _serialRunner.run {
-            await fnc(delegate)
+            try await fnc(delegate)
         }
     }
 

--- a/Sources/LiveKit/Support/SerialRunnerActor.swift
+++ b/Sources/LiveKit/Support/SerialRunnerActor.swift
@@ -19,7 +19,7 @@ import Foundation
 actor SerialRunnerActor<Value: Sendable> {
     private var previousTask: Task<Value, Error>?
 
-    func run(block: @Sendable @escaping () async throws -> Value) async throws -> Value {
+    func run(block: @Sendable @escaping () async throws -> Value) async rethrows -> Value {
         let task = Task { [previousTask] in
             // Wait for the previous task to complete, but cancel it if needed
             if let previousTask, !Task.isCancelled {

--- a/Sources/LiveKit/Types/ParticipantPermissions.swift
+++ b/Sources/LiveKit/Types/ParticipantPermissions.swift
@@ -91,3 +91,13 @@ extension Livekit_ParticipantPermission {
                                recorder: recorder)
     }
 }
+
+public extension ParticipantPermissions {
+    override var description: String {
+        "ParticipantPermissions(canSubscribe: \(canSubscribe), " +
+            "canPublish: \(canPublish), " +
+            "canPublishData: \(canPublishData), " +
+            "canPublishSources: \(canPublishSources), " +
+            "hidden: \(hidden), " + "recorder: \(recorder))"
+    }
+}

--- a/Tests/LiveKitTests/Experimental/PublishDeviceOptimization.swift
+++ b/Tests/LiveKitTests/Experimental/PublishDeviceOptimization.swift
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+import XCTest
+
+class PublishDeviceOptimizationTests: LKTestCase {
+    // Default publish flow
+    func testDefaultMicPublish() async throws {
+        var sw = Stopwatch(label: "Test: Normal publish sequence")
+
+        try await withRooms([RoomTestingOptions(canPublish: true)]) { rooms in
+            sw.split(label: "Connected to room")
+            // Alias to Rooms
+            let room1 = rooms[0]
+            try await room1.localParticipant.setMicrophone(enabled: true)
+            sw.split(label: "Did publish mic")
+        }
+        sw.split(label: "Sequence complete")
+        print(sw)
+
+        print("Total time: \(sw.total())")
+    }
+
+    // No-VP publish flow
+    func testNoVpMicPublish() async throws {
+        // Turn off Apple's VP
+        try! AudioManager.shared.setVoiceProcessingEnabled(false)
+
+        var sw = Stopwatch(label: "Test: No-VP publish sequence")
+
+        try await withRooms([RoomTestingOptions(canPublish: true)]) { rooms in
+            sw.split(label: "Connected to room")
+            // Alias to Rooms
+            let room1 = rooms[0]
+            try await room1.localParticipant.setMicrophone(enabled: true)
+            sw.split(label: "Did publish mic")
+        }
+        sw.split(label: "Sequence complete")
+        print(sw)
+
+        print("Total time: \(sw.total())")
+    }
+
+    // Concurrent device acquisition publish flow
+    func testConcurrentMicPublish() async throws {
+        var swAll = Stopwatch(label: "Test: Concurrent publish sequence")
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+
+            group.addTask {
+                var swAdm = Stopwatch(label: "Test: Start local recording")
+                try AudioManager.shared.startLocalRecording()
+                swAdm.split(label: "Start local recording complete")
+                print(swAdm)
+            }
+
+            group.addTask {
+                var swConnect = Stopwatch(label: "Test: Connect & publish mic")
+                try await self.withRooms([RoomTestingOptions(canPublish: true)]) { rooms in
+                    swConnect.split(label: "Connected to room")
+                    // Alias to Rooms
+                    let room1 = rooms[0]
+                    try await room1.localParticipant.setMicrophone(enabled: true)
+                    swConnect.split(label: "Mic publish completed")
+                }
+                print(swConnect)
+            }
+
+            try await group.waitForAll()
+        }
+
+        swAll.split(label: "Sequence complete")
+        print(swAll)
+
+        print("Total time: \(swAll.total())")
+    }
+}

--- a/Tests/LiveKitTests/Experimental/PublishDeviceOptimization.swift
+++ b/Tests/LiveKitTests/Experimental/PublishDeviceOptimization.swift
@@ -88,4 +88,23 @@ class PublishDeviceOptimizationTests: LKTestCase {
 
         print("Total time: \(swAll.total())")
     }
+
+    // Concurrent device acquisition publish flow (New)
+    func testConcurrentMicPublish2() async throws {
+        var swAll = Stopwatch(label: "Test: Concurrent publish sequence")
+
+        let testRoom = try createRoomForTesting(options: RoomTestingOptions(canPublish: true))
+
+        swAll.split(label: "Create async connect")
+        async let connectAsync: () = testRoom.room.connect(url: testRoom.url, token: testRoom.token)
+        async let enableMicAsync = testRoom.room.localParticipant.setMicrophone(enabled: true)
+
+        swAll.split(label: "Start connecting")
+        try await _ = (connectAsync, enableMicAsync)
+
+        swAll.split(label: "Connect complete")
+        print(swAll)
+
+        print("Total time: \(swAll.total())")
+    }
 }

--- a/Tests/LiveKitTests/Support/Room.swift
+++ b/Tests/LiveKitTests/Support/Room.swift
@@ -74,6 +74,27 @@ extension LKTestCase {
         return try tokenGenerator.sign()
     }
 
+    func createRoomForTesting(options: RoomTestingOptions = RoomTestingOptions(),
+                              sharedKey: String = UUID().uuidString) throws -> (room: Room, url: String, token: String)
+    {
+        let e2eeOptions = E2EEOptions(keyProvider: BaseKeyProvider(isSharedKey: true, sharedKey: sharedKey))
+
+        // Turn on stats
+        let roomOptions = RoomOptions(e2eeOptions: e2eeOptions, reportRemoteTrackStatistics: true)
+
+        let roomName = UUID().uuidString
+        let identity = "identity-\(UUID().uuidString)"
+        let token = try liveKitServerToken(for: roomName,
+                                           identity: identity,
+                                           canPublish: options.canPublish,
+                                           canPublishData: options.canPublishData,
+                                           canPublishSources: options.canPublishSources,
+                                           canSubscribe: options.canSubscribe)
+        print("Token: \(token) for room: \(roomName)")
+
+        return (Room(roomOptions: roomOptions), liveKitServerUrl(), token)
+    }
+
     // Set up variable number of Rooms
     func withRooms(_ options: [RoomTestingOptions] = [],
                    sharedKey: String = UUID().uuidString,


### PR DESCRIPTION
Allows the concurrent publish syntax:
```swift
async let connectAsync: () = testRoom.room.connect(url: "", token: "")
async let enableMicAsync = testRoom.room.localParticipant.setMicrophone(enabled: true)
try await _ = (connectAsync, enableMicAsync)
````

Device initialization (track.start) runs concurrently.
NOTE: Still needs to wait for dimensions from `VideoCapturer`.