### PR TITLE
Send RTC metrics

### DIFF
--- a/.nanpa/rtc-metrics.kdl
+++ b/.nanpa/rtc-metrics.kdl
@@ -1,0 +1,1 @@
+patch type="added" "Added the ability to send RTC metrics"

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,7 @@ let package = Package(
                 .product(name: "LiveKitWebRTC", package: "webrtc-xcframework"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
                 .product(name: "DequeModule", package: "swift-collections"),
+                .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "Logging", package: "swift-log"),
                 "LKObjCHelpers",
             ],

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -40,6 +40,7 @@ let package = Package(
                 .product(name: "LiveKitWebRTC", package: "webrtc-xcframework"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
                 .product(name: "DequeModule", package: "swift-collections"),
+                .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "Logging", package: "swift-log"),
                 "LKObjCHelpers",
             ],

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -40,6 +40,7 @@ let package = Package(
                 .product(name: "LiveKitWebRTC", package: "webrtc-xcframework"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
                 .product(name: "DequeModule", package: "swift-collections"),
+                .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "Logging", package: "swift-log"),
                 "LKObjCHelpers",
             ],

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -297,7 +297,7 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
 
             switch newState.connectionState {
             case .connected where enableMetrics:
-                Task { await MetricsManager.shared.sendUsing { try await self.send(dataPacket: $0) } }
+                Task { await MetricsManager.shared.sendUsing { [weak self] in try await self?.send(dataPacket: $0) } }
             default:
                 Task { await MetricsManager.shared.sendUsing(nil) }
             }

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -297,9 +297,9 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
 
             switch newState.connectionState {
             case .connected where enableMetrics:
-                Task { await MetricsManager.shared.sendUsing { [weak self] in try await self?.send(dataPacket: $0) } }
+                Task { await MetricsManager.shared.sendUsing(identity: localParticipant.identity) { [weak self] in try await self?.send(dataPacket: $0) } }
             default:
-                Task { await MetricsManager.shared.sendUsing(nil) }
+                Task { await MetricsManager.shared.sendUsing(identity: nil, transport: nil) }
             }
 
             // Notify Room when state mutates

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -296,10 +296,16 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
             }
 
             switch newState.connectionState {
-            case .connected where enableMetrics:
-                Task { await MetricsManager.shared.startSending(identity: localParticipant.identity) { [weak self] in try await self?.send(dataPacket: $0) } }
+            case .connected where self.enableMetrics:
+                Task {
+                    await MetricsManager.shared.startSending(identity: self.localParticipant.identity) {
+                        try await self.send(dataPacket: $0)
+                    }
+                }
             default:
-                Task { await MetricsManager.shared.stopSending() }
+                Task {
+                    await MetricsManager.shared.stopSending()
+                }
             }
 
             // Notify Room when state mutates

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -236,7 +236,9 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
             AppStateListener.shared.delegates.add(delegate: self)
         }
 
-        add(delegate: metricsManager)
+        Task {
+            await metricsManager.register(room: self)
+        }
 
         // trigger events when state mutates
         _state.onDidMutate = { [weak self] newState, oldState in

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -297,9 +297,9 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
 
             switch newState.connectionState {
             case .connected where enableMetrics:
-                Task { await MetricsManager.shared.sendUsing(identity: localParticipant.identity) { [weak self] in try await self?.send(dataPacket: $0) } }
+                Task { await MetricsManager.shared.startSending(identity: localParticipant.identity) { [weak self] in try await self?.send(dataPacket: $0) } }
             default:
-                Task { await MetricsManager.shared.sendUsing(identity: nil, transport: nil) }
+                Task { await MetricsManager.shared.stopSending() }
             }
 
             // Notify Room when state mutates

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -22,6 +22,10 @@ import Network
 
 @objc
 public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
+    // MARK: - Metrics
+
+    private let enableMetrics = true
+
     // MARK: - MulticastDelegate
 
     public let delegates = MulticastDelegate<RoomDelegate>(label: "RoomDelegate")
@@ -289,6 +293,13 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
                     // remove this entry
                     return true
                 }
+            }
+
+            switch newState.connectionState {
+            case .connected where enableMetrics:
+                Task { await MetricsManager.shared.sendUsing { try await self.send(dataPacket: $0) } }
+            default:
+                Task { await MetricsManager.shared.sendUsing(nil) }
             }
 
             // Notify Room when state mutates

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -26,6 +26,10 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
 
     public let delegates = MulticastDelegate<RoomDelegate>(label: "RoomDelegate")
 
+    // MARK: - Metrics
+
+    private lazy var metricsManager = MetricsManager()
+
     // MARK: - Public
 
     /// Server assigned id of the Room.
@@ -232,7 +236,7 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
             AppStateListener.shared.delegates.add(delegate: self)
         }
 
-        add(delegate: MetricsManager.shared)
+        add(delegate: metricsManager)
 
         // trigger events when state mutates
         _state.onDidMutate = { [weak self] newState, oldState in

--- a/Sources/LiveKit/Support/AsyncCompleter.swift
+++ b/Sources/LiveKit/Support/AsyncCompleter.swift
@@ -147,7 +147,6 @@ final class AsyncCompleter<T: Sendable>: @unchecked Sendable, Loggable {
             // Already resolved...
             if case let .success(value) = result {
                 // resume(returning:) already called
-                log("\(label) returning existing value")
                 return value
             } else if case let .failure(error) = result {
                 // resume(throwing:) already called

--- a/Sources/LiveKit/Track/Metrics/MetricsManager.swift
+++ b/Sources/LiveKit/Track/Metrics/MetricsManager.swift
@@ -53,10 +53,7 @@ extension MetricsManager: TrackDelegate {
 // MARK: - Actor
 
 /// An actor that converts track statistics into metrics and sends them to the server as data packets.
-@globalActor
 actor MetricsManager: Loggable {
-    static let shared = MetricsManager()
-
     private typealias Transport = (Livekit_DataPacket) async throws -> Void
     private struct TrackProperties {
         let identity: Participant.Identity?
@@ -66,7 +63,7 @@ actor MetricsManager: Loggable {
 
     private var trackProperties: [Track.Sid: TrackProperties] = [:]
 
-    private init() {}
+    init() {}
 
     private func register(track: Track, in room: Room, participant: Participant) {
         guard let sid = track.sid else { return }

--- a/Sources/LiveKit/Track/Metrics/MetricsManager.swift
+++ b/Sources/LiveKit/Track/Metrics/MetricsManager.swift
@@ -119,17 +119,14 @@ private extension Livekit_MetricsBatch {
 
     mutating func addMetric(
         _ value: (some Numeric)?,
-        at timestamp: TimeInterval,
+        at timestampUs: Double,
         label: Livekit_MetricLabel,
         strings: inout [String],
         identity: Participant.Identity? = nil,
         sid: String? = nil,
         rid: String? = nil
     ) {
-        guard let floatValue = value?.floatValue else { return }
-        guard floatValue != .zero else { return }
-
-        let sample = createMetricSample(timestamp: timestamp, value: floatValue)
+        guard let sample = createSample(timestampUs: timestampUs, value: value) else { return }
         let timeSeries = createTimeSeries(
             label: label,
             strings: &strings,
@@ -141,10 +138,13 @@ private extension Livekit_MetricsBatch {
         self.timeSeries.append(timeSeries)
     }
 
-    func createMetricSample(timestamp: TimeInterval, value: Float) -> Livekit_MetricSample {
+    func createSample(timestampUs: Double, value: (some Numeric)?) -> Livekit_MetricSample? {
+        guard let floatValue = value?.floatValue else { return nil }
+        guard floatValue != .zero else { return nil }
+
         var sample = Livekit_MetricSample()
-        sample.timestampMs = Int64(timestamp * 1000)
-        sample.value = value
+        sample.timestampMs = Int64(timestampUs / 1000)
+        sample.value = floatValue
         return sample
     }
 

--- a/Sources/LiveKit/Track/Metrics/MetricsManager.swift
+++ b/Sources/LiveKit/Track/Metrics/MetricsManager.swift
@@ -65,6 +65,10 @@ actor MetricsManager: Loggable {
 
     init() {}
 
+    func register(room: Room) {
+        room.add(delegate: self)
+    }
+
     private func register(track: Track, in room: Room, localParticipant: LocalParticipant) {
         guard let sid = track.sid else { return }
         trackProperties[sid] = TrackProperties(identity: localParticipant.identity) { [weak room] in

--- a/Sources/LiveKit/Track/Metrics/MetricsManager.swift
+++ b/Sources/LiveKit/Track/Metrics/MetricsManager.swift
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+@globalActor
+actor MetricsManager: Loggable {
+    typealias Transport = @Sendable (Livekit_DataPacket) async throws -> Void
+    var transport: Transport?
+
+    static let shared = MetricsManager()
+
+    private init() {}
+
+    func sendUsing(_ transport: Transport?) {
+        self.transport = transport
+    }
+
+    private func sendMetrics(from statistics: TrackStatistics) async {
+        guard let transport else { return }
+
+        var dataPacket = Livekit_DataPacket()
+        dataPacket.kind = .reliable
+        dataPacket.metrics = Livekit_MetricsBatch(statistics: statistics)
+        do {
+            try await transport(dataPacket)
+        } catch {
+            log("Failed to send metrics: \(error)", .warning)
+        }
+    }
+}
+
+private extension Livekit_MetricsBatch {
+    init(statistics: TrackStatistics) {
+        timestampMs = Int64(Date().timeIntervalSince1970 * 1000)
+        addOutboundMetrics(from: statistics.outboundRtpStream)
+    }
+
+    mutating func addOutboundMetrics(from statistics: [OutboundRtpStreamStatistics]) {
+        for s in statistics {
+            print(s)
+        }
+    }
+
+    func createMetricSample(timestamp: TimeInterval, value: Float) -> Livekit_MetricSample {
+        var sample = Livekit_MetricSample()
+        sample.timestampMs = Int64(timestamp * 1000)
+        sample.value = value
+        return sample
+    }
+
+    func createTimeSeriesForMetric() {}
+}
+
+extension MetricsManager: TrackDelegate {
+    nonisolated func track(_: Track, didUpdateStatistics: TrackStatistics, simulcastStatistics _: [VideoCodec: TrackStatistics]) {
+        Task(priority: .low) {
+            await sendMetrics(from: didUpdateStatistics)
+        }
+    }
+}

--- a/Sources/LiveKit/Track/Metrics/MetricsManager.swift
+++ b/Sources/LiveKit/Track/Metrics/MetricsManager.swift
@@ -42,9 +42,14 @@ actor MetricsManager: Loggable {
 
     private init() {}
 
-    func sendUsing(identity: Participant.Identity?, transport: Transport?) {
+    func startSending(identity: Participant.Identity?, transport: @escaping Transport) {
         self.transport = transport
         self.identity = identity
+    }
+
+    func stopSending() {
+        transport = nil
+        identity = nil
     }
 
     private func sendMetrics(statistics: TrackStatistics) async {

--- a/Sources/LiveKit/Track/Metrics/MetricsManager.swift
+++ b/Sources/LiveKit/Track/Metrics/MetricsManager.swift
@@ -42,6 +42,7 @@ extension MetricsManager: RoomDelegate {
 }
 
 extension MetricsManager: TrackDelegate {
+    // If Track.reportStatistics is disabled, this delegate method will not be called.
     nonisolated func track(_ track: Track, didUpdateStatistics: TrackStatistics, simulcastStatistics _: [VideoCodec: TrackStatistics]) {
         Task(priority: .low) {
             await sendMetrics(track: track, statistics: didUpdateStatistics)

--- a/Sources/LiveKit/Track/Metrics/MetricsManager.swift
+++ b/Sources/LiveKit/Track/Metrics/MetricsManager.swift
@@ -16,12 +16,24 @@
 
 import Foundation
 
+// MARK: - Trigger
+
+extension MetricsManager: TrackDelegate {
+    nonisolated func track(_: Track, didUpdateStatistics: TrackStatistics, simulcastStatistics _: [VideoCodec: TrackStatistics]) {
+        Task(priority: .low) {
+            await sendMetrics(from: didUpdateStatistics)
+        }
+    }
+}
+
+// MARK: - Actor
+
 @globalActor
 actor MetricsManager: Loggable {
+    static let shared = MetricsManager()
+
     typealias Transport = @Sendable (Livekit_DataPacket) async throws -> Void
     var transport: Transport?
-
-    static let shared = MetricsManager()
 
     private init() {}
 
@@ -36,6 +48,7 @@ actor MetricsManager: Loggable {
         dataPacket.kind = .reliable
         dataPacket.metrics = Livekit_MetricsBatch(statistics: statistics)
         do {
+            log("Sending track metrics...", .trace)
             try await transport(dataPacket)
         } catch {
             log("Failed to send metrics: \(error)", .warning)
@@ -43,16 +56,64 @@ actor MetricsManager: Loggable {
     }
 }
 
+// MARK: - Statistics -> protobufs
+
 private extension Livekit_MetricsBatch {
     init(statistics: TrackStatistics) {
-        timestampMs = Int64(Date().timeIntervalSince1970 * 1000)
-        addOutboundMetrics(from: statistics.outboundRtpStream)
+        var strings = [String]()
+        defer { strData = strings }
+
+        addOutboundMetrics(from: statistics.outboundRtpStream, strings: &strings)
+        addInboundMetrics(from: statistics.inboundRtpStream, strings: &strings)
     }
 
-    mutating func addOutboundMetrics(from statistics: [OutboundRtpStreamStatistics]) {
-        for s in statistics {
-            print(s)
+    mutating func addOutboundMetrics(from statistics: [OutboundRtpStreamStatistics], strings: inout [String]) {
+        for stat in statistics {
+            guard stat.kind == "video" else { continue }
+
+            if let durations = stat.qualityLimitationDurations {
+                addMetricIfPresent(value: durations.cpu, label: .clientVideoPublisherQualityLimitationDurationCpu, stat: stat, strings: &strings)
+                addMetricIfPresent(value: durations.bandwidth, label: .clientVideoPublisherQualityLimitationDurationBandwidth, stat: stat, strings: &strings)
+                addMetricIfPresent(value: durations.other, label: .clientVideoPublisherQualityLimitationDurationOther, stat: stat, strings: &strings)
+            }
         }
+    }
+
+    mutating func addInboundMetrics(from statistics: [InboundRtpStreamStatistics], strings: inout [String]) {
+        for stat in statistics {
+            if stat.kind == "audio" {
+                addMetricIfPresent(value: stat.concealedSamples, label: .clientAudioSubscriberConcealedSamples, stat: stat, strings: &strings)
+                addMetricIfPresent(value: stat.concealmentEvents, label: .clientAudioSubscriberConcealmentEvents, stat: stat, strings: &strings)
+                addMetricIfPresent(value: stat.silentConcealedSamples, label: .clientAudioSubscriberSilentConcealedSamples, stat: stat, strings: &strings)
+            } else if stat.kind == "video" {
+                addMetricIfPresent(value: stat.freezeCount, label: .clientVideoSubscriberFreezeCount, stat: stat, strings: &strings)
+                addMetricIfPresent(value: stat.totalFreezesDuration, label: .clientVideoSubscriberTotalFreezeDuration, stat: stat, strings: &strings)
+                addMetricIfPresent(value: stat.pauseCount, label: .clientVideoSubscriberPauseCount, stat: stat, strings: &strings)
+                addMetricIfPresent(value: stat.totalPausesDuration, label: .clientVideoSubscriberTotalPausesDuration, stat: stat, strings: &strings)
+            }
+
+            // Common metrics
+            addMetricIfPresent(value: stat.jitterBufferDelay, label: .clientSubscriberJitterBufferDelay, stat: stat, strings: &strings)
+            addMetricIfPresent(value: stat.jitterBufferEmittedCount, label: .clientSubscriberJitterBufferEmittedCount, stat: stat, strings: &strings)
+        }
+    }
+
+    mutating func addMetricIfPresent(
+        value: (some Numeric)?,
+        label: Livekit_MetricLabel,
+        stat: RtpStreamStatistics,
+        strings: inout [String]
+    ) {
+        guard let floatValue = value?.floatValue else { return }
+
+        let sample = createMetricSample(timestamp: stat.timestamp, value: floatValue)
+        let timeSeries = createTimeSeries(
+            label: label,
+            strings: &strings,
+            samples: [sample],
+            trackSid: stat.id
+        )
+        self.timeSeries.append(timeSeries)
     }
 
     func createMetricSample(timestamp: TimeInterval, value: Float) -> Livekit_MetricSample {
@@ -62,13 +123,53 @@ private extension Livekit_MetricsBatch {
         return sample
     }
 
-    func createTimeSeriesForMetric() {}
+    func createTimeSeries(
+        label: Livekit_MetricLabel,
+        strings: inout [String],
+        samples: [Livekit_MetricSample],
+        trackSid: String? = nil,
+        rid: String? = nil
+    ) -> Livekit_TimeSeriesMetric {
+        var timeSeries = Livekit_TimeSeriesMetric()
+        timeSeries.label = UInt32(label.rawValue)
+
+        if let trackSid {
+            timeSeries.trackSid = UInt32(getOrCreateIndex(in: &strings, string: trackSid))
+        }
+
+        if let rid {
+            timeSeries.rid = UInt32(getOrCreateIndex(in: &strings, string: rid))
+        }
+
+        timeSeries.samples = samples
+        return timeSeries
+    }
+
+    func getOrCreateIndex(in array: inout [String], string: String) -> Int {
+        let offset = Livekit_MetricLabel.predefinedMaxValue.rawValue
+        if let index = array.firstIndex(of: string) {
+            return index + offset
+        }
+        array.append(string)
+        return array.count - 1 + offset
+    }
 }
 
-extension MetricsManager: TrackDelegate {
-    nonisolated func track(_: Track, didUpdateStatistics: TrackStatistics, simulcastStatistics _: [VideoCodec: TrackStatistics]) {
-        Task(priority: .low) {
-            await sendMetrics(from: didUpdateStatistics)
+// MARK: - Extensions
+
+private extension Numeric {
+    var floatValue: Float? {
+        if let floatValue = self as? Float {
+            return floatValue
+        } else if let doubleValue = self as? Double {
+            return Float(doubleValue)
+        } else if let uint64Value = self as? UInt64 {
+            return Float(uint64Value)
+        } else if let uintValue = self as? UInt {
+            return Float(uintValue)
+        } else {
+            assertionFailure("Cannot convert Numeric \(Self.self)")
+            return nil
         }
     }
 }

--- a/Sources/LiveKit/Track/Metrics/MetricsManager.swift
+++ b/Sources/LiveKit/Track/Metrics/MetricsManager.swift
@@ -30,9 +30,9 @@ extension MetricsManager: RoomDelegate {
         Task { await unregister(track: track) }
     }
 
-    nonisolated func room(_ room: Room, participant: RemoteParticipant, didSubscribeTrack publication: RemoteTrackPublication) {
+    nonisolated func room(_ room: Room, participant _: RemoteParticipant, didSubscribeTrack publication: RemoteTrackPublication) {
         guard let track = publication.track else { return }
-        Task { await register(track: track, in: room, participant: participant) }
+        Task { await register(track: track, in: room, participant: room.localParticipant) } // send from local participant
     }
 
     nonisolated func room(_: Room, participant _: RemoteParticipant, didUnsubscribeTrack publication: RemoteTrackPublication) {

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -181,6 +181,8 @@ public class Track: NSObject, @unchecked Sendable, Loggable {
                 self.delegates.notify { $0.track?(self, didUpdateStatistics: statistics, simulcastStatistics: newState.simulcastStatistics) }
             }
         }
+
+        delegates.add(delegate: MetricsManager.shared)
     }
 
     func set(transport: Transport?, rtpSender: LKRTCRtpSender?) async {

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -181,8 +181,6 @@ public class Track: NSObject, @unchecked Sendable, Loggable {
                 self.delegates.notify { $0.track?(self, didUpdateStatistics: statistics, simulcastStatistics: newState.simulcastStatistics) }
             }
         }
-
-        delegates.add(delegate: MetricsManager.shared)
     }
 
     func set(transport: Transport?, rtpSender: LKRTCRtpSender?) async {


### PR DESCRIPTION
- Ports [RTCMetricsManager.kt](https://github.com/livekit/client-sdk-android/blob/81335436ae62828086e6da4f25a187e0f3647e76/livekit-android-sdk/src/main/java/io/livekit/android/room/metrics/RTCMetricsManager.kt) to Swift
  - it does not query/filter the RTC output directly, just pulls it from the existing `TrackStatistics` (structured) API
  - 1s timer, etc. was already handled in `TrackDelegate`

### Sample

```
LiveKit.Livekit_DataPacket:
metrics {
  str_data: "ios"
  str_data: "f"
  str_data: "h"
  str_data: "q"
  time_series {
    label: 14
    participant_identity: 4096
    samples {
      timestamp_ms: 1744366455240
      value: 1.207
    }
    rid: 4097
  }
  time_series {
    label: 14
    participant_identity: 4096
    samples {
      timestamp_ms: 1744366455240
      value: 1.207
    }
    rid: 4098
  }
  time_series {
    label: 14
    participant_identity: 4096
    samples {
      timestamp_ms: 1744366455240
      value: 1.207
    }
    rid: 4099
  }
  time_series {
    label: 19
    participant_identity: 4096
    samples {
      timestamp_ms: 1744366454589
      value: 0.09816
    }
  }
  time_series {
    label: 19
    participant_identity: 4096
    samples {
      timestamp_ms: 1744366455021
      value: 0.10466
    }
  }
  time_series {
    label: 19
    participant_identity: 4096
    samples {
      timestamp_ms: 1744366454796
      value: 0.096024
    }
  }
``` 