### PR TITLE
Add OrderedCollections as Cocoapods dependency

### DIFF
--- a/.nanpa/ordered-collections-podfix.kdl
+++ b/.nanpa/ordered-collections-podfix.kdl
@@ -1,0 +1,1 @@
+patch type="fixed" "Add OrderedCollections as Cocoapods dependency"

--- a/LiveKitClient.podspec
+++ b/LiveKitClient.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |spec|
   spec.dependency("SwiftProtobuf")
   spec.dependency("Logging", "= 1.5.4")
   spec.dependency("DequeModule", "= 1.1.4")
+  spec.dependency("OrderedCollections", " = 1.1.4")
 
   spec.resource_bundles = {"Privacy" => ["Sources/LiveKit/PrivacyInfo.xcprivacy"]}
 


### PR DESCRIPTION
`OrderedCollections` was added as an SPM dependency in v2.5.0 but not included in the Podspec.