### PR TITLE
Fix `VideoView.isHidden` crash

### DIFF
--- a/.nanpa/video-view-hidden-crash.kdl
+++ b/.nanpa/video-view-hidden-crash.kdl
@@ -1,0 +1,1 @@
+patch type="fixed" "Fixed crash in VideoView.isHidden property access"

--- a/Sources/LiveKit/Extensions/CustomStringConvertible.swift
+++ b/Sources/LiveKit/Extensions/CustomStringConvertible.swift
@@ -157,6 +157,14 @@ extension Livekit_SignalResponse: CustomStringConvertible {
     }
 }
 
+// MARK: - NativeView
+
+public extension VideoView {
+    override var description: String {
+        "VideoView(track: \(String(describing: track)))"
+    }
+}
+
 extension VideoView.RenderMode: CustomStringConvertible {
     public var description: String {
         switch self {
@@ -166,6 +174,20 @@ extension VideoView.RenderMode: CustomStringConvertible {
         }
     }
 }
+
+extension SampleBufferVideoRenderer {
+    override var description: String {
+        "SampleBufferVideoRenderer"
+    }
+}
+
+extension TextView {
+    override var description: String {
+        "TextView"
+    }
+}
+
+// MARK: - LKRTC
 
 extension LKRTCRtpEncodingParameters {
     func toDebugString() -> String {

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -120,11 +120,13 @@ public class VideoView: NativeView, Loggable {
     }
 
     @objc
-    override public var isHidden: Bool {
+    override public nonisolated var isHidden: Bool {
         get { _state.isHidden }
         set {
             _state.mutate { $0.isHidden = newValue }
-            super.isHidden = newValue
+            Task { @MainActor in
+                super.isHidden = newValue
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #678 

Follow-up of https://github.com/livekit/client-sdk-swift/pull/679

I managed to reproduce the issue, steps:
- open example app on iPhone (non-sample buffer mode)
- join from e.g. macOS
- publish/unpublish camera track on mac

The diagnosis was correct - logs are coming via unsafe `UIView`/`NSObject` territory, so main actor isolated props are listed from bg threads. The last one was `isHidden`.

I also overrode the `description` string, just in case... for every descendant of `NativeView` (that may inherit the description).

<img width="1483" alt="Screenshot 2025-04-22 at 10 40 14 AM" src="https://github.com/user-attachments/assets/441d9bd8-6ecd-4b45-93b0-34517c6dab2b" />
