### PR TITLE
Add Sendable for internal callbacks

### DIFF
--- a/.nanpa/sendable-callbacks.kdl
+++ b/.nanpa/sendable-callbacks.kdl
@@ -1,0 +1,1 @@
+patch type="fixed" "Sendable requirement for internal callbacks"

--- a/Sources/LiveKit/Audio/Manager/AudioManager.swift
+++ b/Sources/LiveKit/Audio/Manager/AudioManager.swift
@@ -39,9 +39,9 @@ public class AudioManager: Loggable {
         _ = shared
     }
 
-    public typealias OnDevicesDidUpdate = (_ audioManager: AudioManager) -> Void
+    public typealias OnDevicesDidUpdate = @Sendable (_ audioManager: AudioManager) -> Void
 
-    public typealias OnSpeechActivity = (_ audioManager: AudioManager, _ event: SpeechActivityEvent) -> Void
+    public typealias OnSpeechActivity = @Sendable (_ audioManager: AudioManager, _ event: SpeechActivityEvent) -> Void
 
     #if os(iOS) || os(visionOS) || os(tvOS)
 

--- a/Sources/LiveKit/Core/Room+Engine.swift
+++ b/Sources/LiveKit/Core/Room+Engine.swift
@@ -37,7 +37,7 @@ extension Room {
     struct ConditionalExecutionEntry {
         let executeCondition: ConditionEvalFunc
         let removeCondition: ConditionEvalFunc
-        let block: () -> Void
+        let block: @Sendable () -> Void
     }
 
     // Resets state of transports

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -25,7 +25,7 @@ internal import LiveKitWebRTC
 actor Transport: NSObject, Loggable {
     // MARK: - Types
 
-    typealias OnOfferBlock = (LKRTCSessionDescription) async throws -> Void
+    typealias OnOfferBlock = @Sendable (LKRTCSessionDescription) async throws -> Void
 
     // MARK: - Public
 

--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -20,8 +20,6 @@ internal import LiveKitWebRTC
 @_implementationOnly import LiveKitWebRTC
 #endif
 
-typealias DebouncFunc = () -> Void
-
 enum OS {
     case macOS
     case iOS

--- a/Sources/LiveKit/Track/Metrics/MetricsManager.swift
+++ b/Sources/LiveKit/Track/Metrics/MetricsManager.swift
@@ -54,7 +54,7 @@ extension MetricsManager: TrackDelegate {
 
 /// An actor that converts track statistics into metrics and sends them to the server as data packets.
 actor MetricsManager: Loggable {
-    private typealias Transport = (Livekit_DataPacket) async throws -> Void
+    private typealias Transport = @Sendable (Livekit_DataPacket) async throws -> Void
     private struct TrackProperties {
         let identity: LocalParticipant.Identity?
         let transport: Transport


### PR DESCRIPTION
So that consumers like:

```swift
AudioManager.shared.onDeviceUpdate = { [weak self] _ in
            guard let self else { return }
            // force UI update for outputDevice / inputDevice
            Task { @MainActor [weak self] in
```

have proper isolation.