### PR TITLE
Expose complete reconnect mode cycle

### DIFF
--- a/Sources/LiveKit/Core/Room+EngineDelegate.swift
+++ b/Sources/LiveKit/Core/Room+EngineDelegate.swift
@@ -87,11 +87,9 @@ extension Room {
         }
 
         // Notify when reconnection mode changes
-        if state.isReconnectingWithMode != oldState.isReconnectingWithMode,
-           let mode = state.isReconnectingWithMode
-        {
+        if state.isReconnectingWithMode != oldState.isReconnectingWithMode {
             delegates.notify(label: { "room.didUpdate reconnectionMode: \(String(describing: state.isReconnectingWithMode)) oldValue: \(String(describing: oldState.isReconnectingWithMode))" }) {
-                $0.room?(self, didUpdateReconnectMode: mode)
+                $0.room?(self, didUpdateReconnectMode: state.isReconnectingWithMode)
             }
         }
 

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -162,8 +162,8 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
         var url: URL?
         var token: String?
         // preferred reconnect mode which will be used only for next attempt
-        var nextReconnectMode: ReconnectMode?
-        var isReconnectingWithMode: ReconnectMode?
+        var nextReconnectMode: ReconnectMode = .none
+        var isReconnectingWithMode: ReconnectMode = .none
         var connectionState: ConnectionState = .disconnected
         var disconnectError: LiveKitError?
         var connectStopwatch = Stopwatch(label: "connect")
@@ -269,7 +269,7 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
                 }
             }
 
-            if newState.connectionState == .reconnecting, newState.isReconnectingWithMode == nil {
+            if newState.connectionState == .reconnecting, newState.isReconnectingWithMode == .none {
                 self.log("reconnectMode should not be .none", .error)
             }
 

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -118,13 +118,13 @@ actor SignalClient: Loggable {
     func connect(_ url: URL,
                  _ token: String,
                  connectOptions: ConnectOptions? = nil,
-                 reconnectMode: ReconnectMode? = nil,
+                 reconnectMode: ReconnectMode = .none,
                  participantSid: Participant.Sid? = nil,
                  adaptiveStream: Bool) async throws -> ConnectResponse
     {
         await cleanUp()
 
-        if let reconnectMode {
+        if reconnectMode != .none {
             log("[Connect] mode: \(String(describing: reconnectMode))")
         }
 
@@ -135,13 +135,13 @@ actor SignalClient: Loggable {
                                      participantSid: participantSid,
                                      adaptiveStream: adaptiveStream)
 
-        if reconnectMode != nil {
+        if reconnectMode != .none {
             log("[Connect] with url: \(url)")
         } else {
             log("Connecting with url: \(url)")
         }
 
-        _state.mutate { $0.connectionState = (reconnectMode != nil ? .reconnecting : .connecting) }
+        _state.mutate { $0.connectionState = (reconnectMode != .none ? .reconnecting : .connecting) }
 
         do {
             let socket = try await WebSocket(url: url, connectOptions: connectOptions)
@@ -177,7 +177,7 @@ actor SignalClient: Loggable {
             }
 
             // Skip validation if reconnect mode
-            if reconnectMode != nil {
+            if reconnectMode != .none {
                 await cleanUp(withError: error)
                 throw error
             }

--- a/Sources/LiveKit/Extensions/CustomStringConvertible.swift
+++ b/Sources/LiveKit/Extensions/CustomStringConvertible.swift
@@ -145,6 +145,7 @@ extension ConnectionState: CustomStringConvertible {
 extension ReconnectMode: CustomStringConvertible {
     public var description: String {
         switch self {
+        case .none: return ".none"
         case .quick: return ".quick"
         case .full: return ".full"
         }

--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -137,7 +137,7 @@ class Utils {
         _ url: URL,
         _ token: String,
         connectOptions: ConnectOptions? = nil,
-        reconnectMode: ReconnectMode? = nil,
+        reconnectMode: ReconnectMode = .none,
         participantSid: Participant.Sid? = nil,
         adaptiveStream: Bool,
         validate: Bool = false,

--- a/Sources/LiveKit/Types/ConnectionState.swift
+++ b/Sources/LiveKit/Types/ConnectionState.swift
@@ -18,6 +18,9 @@ import Foundation
 
 @objc
 public enum ReconnectMode: Int, Sendable {
+    /// Not trying to reconnect
+    case none
+
     /// Quick reconnection mode attempts to maintain the same session, reusing existing
     /// transport connections and published tracks. This is faster but may not succeed
     /// in all network conditions.


### PR DESCRIPTION
**Issue**
@pblazej did an amazing job in https://github.com/livekit/client-sdk-swift/pull/642 with exposing reconnect mode.
But it happens to give info when SDK goes into `.quick` or `.full` reconnect but not back to normal connect state.
So with current logic there is no way to get info when SDK establishes connection back and it is time to hide reconnect UI elements.

**Solution**
Expose full cycle for `ReconnectMode`. Since SDK uses Swift optional enum `ReconnectMode?` there is no way to notify ObjC delegate with changes. Idea is to present `.none` ReconnectMode option and use it instead of optional. With such approach it is feasible to notify ObjC delegates. With such logic SDK can tell clients that reconnection process is over. Still not sure wether `.none` is the best name for such option so may be reviewers could suggest any better.


