### PR TITLE
Remove problematic KeyPath conformance to Sendable

### DIFF
--- a/Sources/LiveKit/Extensions/Sendable.swift
+++ b/Sources/LiveKit/Extensions/Sendable.swift
@@ -47,10 +47,6 @@ extension LKRTCVideoFrame: @unchecked Swift.Sendable {}
 extension LKRTCConfiguration: @unchecked Swift.Sendable {}
 extension LKRTCVideoCapturer: @unchecked Swift.Sendable {}
 
-// MARK: Foundation
-
-extension KeyPath: @unchecked Swift.Sendable where Root: Sendable, Value: Sendable {}
-
 // MARK: Collections
 
 extension NSHashTable: @unchecked Swift.Sendable {} // cannot specify Obj-C generics


### PR DESCRIPTION
This is no longer needed and may introduce conflicts with newer Foundation APIs - where the conformance is explicitly introduced.

Resolves #700 