### PR TITLE
Fix race condition during remote track deinit

### DIFF
--- a/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
@@ -69,10 +69,5 @@ public class RemoteAudioTrack: Track, RemoteTrack, AudioTrack, @unchecked Sendab
 
     public func remove(audioRenderer: AudioRenderer) {
         _adapter.remove(delegate: audioRenderer)
-        // Remove adapter only if there are no more delegates
-        if _adapter.countDelegates == 0 {
-            guard let audioTrack = mediaTrack as? LKRTCAudioTrack else { return }
-            audioTrack.remove(_adapter)
-        }
     }
 }

--- a/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
+++ b/Sources/LiveKit/Track/Remote/RemoteAudioTrack.swift
@@ -49,22 +49,20 @@ public class RemoteAudioTrack: Track, RemoteTrack, AudioTrack, @unchecked Sendab
                    source: source,
                    track: track,
                    reportStatistics: reportStatistics)
+
+        if let audioTrack = mediaTrack as? LKRTCAudioTrack {
+            audioTrack.add(_adapter)
+        }
     }
 
     deinit {
-        // Directly remove the adapter without unnecessary checks
-        guard let audioTrack = mediaTrack as? LKRTCAudioTrack else { return }
-        audioTrack.remove(_adapter)
+        if let audioTrack = mediaTrack as? LKRTCAudioTrack {
+            audioTrack.remove(_adapter)
+        }
     }
 
     public func add(audioRenderer: AudioRenderer) {
-        let wasEmpty = _adapter.countDelegates == 0
         _adapter.add(delegate: audioRenderer)
-        // Attach adapter only if it wasn't attached before
-        if wasEmpty {
-            guard let audioTrack = mediaTrack as? LKRTCAudioTrack else { return }
-            audioTrack.add(_adapter)
-        }
     }
 
     public func remove(audioRenderer: AudioRenderer) {


### PR DESCRIPTION
Resolves #704 

Removes a mini-optimization while holding empty delegates, simplifying the delegate chain a bit.

- `deinit` is `nonisolated`
- operations on `LKRTCAudioTrack` are not thread-safe
- removing "the last delegate" can happen from an arbitrary thread (e.g. SwiftUI main if I'm the visualizer)
- `deinit` may run concurrently, e.g. when a whole remote track is destroyed during disconnection
- in the worst-case scenario, a deadlock may occur inside rtc, around:
```
frame #0: 0x0000000103140014 libsystem_kernel.dylib`__psynch_cvwait + 8
frame #1: 0x000000010302aab8 libsystem_pthread.dylib`_pthread_cond_wait + 976
frame #2: 0x00000001048442b4 LiveKitWebRTC`___lldb_unnamed_symbol9036 + 528
frame #3: 0x0000000104841920 LiveKitWebRTC`rtc::Thread::BlockingCallImpl(rtc::FunctionView<void ()>, webrtc::Location const&) + 384
frame #4: 0x00000001047e7bdc LiveKitWebRTC`___lldb_unnamed_symbol7471 + 284
frame #5: 0x00000001061c2dd4 LiveKitExample.debug.dylib`RemoteAudioTrack.remove(audioRenderer=(object = 0x000060000177dd40 -> 0x000000010677cc18 type metadata for LiveKitComponents.AudioProcessor)) at RemoteAudioTrack.swift:75:24
frame #7: 0x00000001065f49a4 LiveKitExample.debug.dylib`AudioProcessor.deinit() at AudioProcessor.swift:47:16
```