### PR TITLE
Reliable data channel

### DIFF
--- a/.changes/reliable-data-channel
+++ b/.changes/reliable-data-channel
@@ -1,0 +1,1 @@
+patch type="changed" "Improved reliability of the data channel"

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -404,7 +404,7 @@ extension DataChannelPair: LKRTCDataChannelDelegate {
 
         if dataChannel.kind == .reliable, dataPacket.sequence > 0, !dataPacket.participantSid.isEmpty {
             if let lastSeq = _state.reliableReceivedState[dataPacket.participantSid], dataPacket.sequence <= lastSeq {
-                log("Ignoring duplicate/out of order reliable data message", .warning)
+                log("Ignoring duplicate/out-of-order reliable data message", .warning)
                 return
             }
             _state.mutate {

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -391,7 +391,7 @@ extension DataChannelPair: LKRTCDataChannelDelegate {
 
         if dataChannel.kind == .reliable, dataPacket.sequence > 0, !dataPacket.participantSid.isEmpty {
             if let lastSeq = _state.reliableReceivedState[dataPacket.participantSid], dataPacket.sequence <= lastSeq {
-                log("Ignoring out of order reliable data message", .warning)
+                log("Ignoring duplicate/out of order reliable data message", .warning)
                 return
             }
             _state.mutate {

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -58,7 +58,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
 
     private struct SendBuffer {
         private var queue: Deque<PublishDataRequest> = []
-        var targetAmount: UInt64 = 0
+        var rtcAmount: UInt64 = 0
 
         mutating func enqueue(_ request: PublishDataRequest) {
             queue.append(request)
@@ -71,7 +71,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
         }
 
         func canSend(threshold: UInt64) -> Bool {
-            targetAmount <= threshold
+            rtcAmount <= threshold
         }
     }
 
@@ -191,7 +191,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
         kind: ChannelKind
     ) {
         while buffer.canSend(threshold: threshold), let request = buffer.dequeue() {
-            buffer.targetAmount += UInt64(request.data.data.count)
+            buffer.rtcAmount += UInt64(request.data.data.count)
 
             guard let channel = channel(for: kind) else {
                 request.continuation?.resume(
@@ -218,12 +218,12 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
         buffer: inout SendBuffer,
         newAmount: UInt64
     ) {
-        guard buffer.targetAmount >= newAmount else {
+        guard buffer.rtcAmount >= newAmount else {
             log("Unexpected buffer size detected", .error)
-            buffer.targetAmount = 0
+            buffer.rtcAmount = 0
             return
         }
-        buffer.targetAmount -= newAmount
+        buffer.rtcAmount -= newAmount
     }
 
     private func retry(

--- a/Sources/LiveKit/Core/Room+Engine.swift
+++ b/Sources/LiveKit/Core/Room+Engine.swift
@@ -195,8 +195,7 @@ extension Room {
             let (subscriber, publisher) = _state.read { ($0.subscriber, $0.publisher) }
             try await subscriber?.set(configuration: rtcConfiguration)
             try await publisher?.set(configuration: rtcConfiguration)
-
-            publisherDataChannel.resendReliable(resumingFrom: reconnectResponse.lastMessageSeq)
+            publisherDataChannel.retryReliable(lastSequence: reconnectResponse.lastMessageSeq)
         }
     }
 }

--- a/Sources/LiveKit/Core/Room+Engine.swift
+++ b/Sources/LiveKit/Core/Room+Engine.swift
@@ -102,6 +102,9 @@ extension Room {
         if let identity = localParticipant.identity?.stringValue {
             packet.participantIdentity = identity
         }
+        if let sid = localParticipant.sid?.stringValue {
+            packet.participantSid = sid
+        }
 
         try await publisherDataChannel.send(dataPacket: packet)
     }

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -528,7 +528,8 @@ extension SignalClient {
                        offer: Livekit_SessionDescription?,
                        subscription: Livekit_UpdateSubscription,
                        publishTracks: [Livekit_TrackPublishedResponse]? = nil,
-                       dataChannels: [Livekit_DataChannelInfo]? = nil) async throws
+                       dataChannels: [Livekit_DataChannelInfo]? = nil,
+                       dataChannelReceiveStates: [Livekit_DataChannelReceiveState]? = nil) async throws
     {
         let r = Livekit_SignalRequest.with {
             $0.syncState = Livekit_SyncState.with {
@@ -541,6 +542,7 @@ extension SignalClient {
                 $0.subscription = subscription
                 $0.publishTracks = publishTracks ?? []
                 $0.dataChannels = dataChannels ?? []
+                $0.datachannelReceiveStates = dataChannelReceiveStates ?? []
             }
         }
 

--- a/Tests/LiveKitTests/DataStream/DataChannelTests.swift
+++ b/Tests/LiveKitTests/DataStream/DataChannelTests.swift
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+import XCTest
+
+class DataChannelTests: LKTestCase, @unchecked Sendable {
+    var receivedExpectation: XCTestExpectation!
+    var receivedData = Data()
+
+    func testReliableRetry() async throws {
+        let testData = ["abc", "def", "ghi", "jkl", "mno", "pqr", "stu", "vwx", "yz", "🔥"].map { $0.data(using: .utf8)! }
+
+        let receivedExpectation = expectation(description: "Data received")
+        receivedExpectation.expectedFulfillmentCount = testData.count
+        receivedExpectation.assertForOverFulfill = false
+        self.receivedExpectation = receivedExpectation
+
+        try await withRooms([
+            RoomTestingOptions(delegate: self, canPublishData: true),
+            RoomTestingOptions(delegate: self, canPublishData: true),
+        ]) { rooms in
+            let room1 = rooms[0]
+            let room2 = rooms[1]
+
+            Task {
+                try await Task.sleep(nanoseconds: 250_000_000)
+                try await room1.startReconnect(reason: .debug)
+            }
+
+            for data in testData {
+                let userPacket = Livekit_UserPacket.with {
+                    $0.payload = data
+                    $0.destinationIdentities = [room2.localParticipant.identity!.stringValue]
+                }
+
+                try await room1.send(userPacket: userPacket, kind: .reliable)
+                try await Task.sleep(nanoseconds: 100_000_000)
+            }
+        }
+
+        await fulfillment(of: [receivedExpectation], timeout: 5)
+
+        let receivedString = try XCTUnwrap(String(data: receivedData, encoding: .utf8))
+        // Ignoring duplicates (prefix), participantSid is empty for the debug server, unable to disambiguate
+        XCTAssertTrue(receivedString.hasSuffix("abcdefghijklmnopqrstuvwxyz🔥"))
+    }
+}
+
+extension DataChannelTests: RoomDelegate {
+    func room(_: Room, participant _: RemoteParticipant?, didReceiveData data: Data, forTopic _: String) {
+        receivedData.append(data)
+        receivedExpectation?.fulfill()
+    }
+}


### PR DESCRIPTION
Ports basic concepts from https://github.com/livekit/client-sdk-js/pull/1546

The differences are mostly syntactic, due to how backpressure is handled via events in Swift. Thus, I decided to separate `SendBuffer` that's tightly coupled to RTC and `RetryBuffer` with slightly different semantics.