### PR TITLE
Remove lazy init for incoming streams

### DIFF
--- a/.changes/concurrent-streams
+++ b/.changes/concurrent-streams
@@ -1,0 +1,1 @@
+patch type="fixed" "Fixed concurrent registration for text/byte streams"

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -117,7 +117,7 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
     lazy var subscriberDataChannel = DataChannelPair(delegate: self)
     lazy var publisherDataChannel = DataChannelPair(delegate: self)
 
-    lazy var incomingStreamManager = IncomingStreamManager()
+    let incomingStreamManager = IncomingStreamManager()
     lazy var outgoingStreamManager = OutgoingStreamManager { [weak self] packet in
         try await self?.send(dataPacket: packet)
     }


### PR DESCRIPTION
It may return a brand-new instance of `IncomingStreamManager` when run concurrently:

```
// Before:
self 0x0000600003352b50 ["cover": (Function)]
self 0x0000600003341d40 ["now_playing": (Function)]
// After:
self 0x0000600001eb81b0 ["now_playing": (Function)]
self 0x0000600001eb81b0 ["cover": (Function), "now_playing": (Function)]
```

Thus leading to UB - missing registration (random).

TL;DR be careful with `lazy` consumed via `async` methods.