### PR TITLE
Exclude window ID from screen sharing

### DIFF
--- a/.changes/screenshare-exclude
+++ b/.changes/screenshare-exclude
@@ -1,0 +1,1 @@
+patch type="added" "Added the possibility to exlude macOS windows from screen sharing"

--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -71,11 +71,13 @@ public class MacOSScreenCapturer: VideoCapturer, @unchecked Sendable {
                   let content = displaySource.scContent as? SCShareableContent,
                   let nativeDisplay = displaySource.nativeType as? SCDisplay
         {
-            let excludedApps = !options.includeCurrentApplication ? content.applications.filter { app in
-                Bundle.main.bundleIdentifier == app.bundleIdentifier
-            } : []
+            let includedApps = options.includeCurrentApplication ?
+                content.applications :
+                content.applications.filter { app in Bundle.main.bundleIdentifier != app.bundleIdentifier }
 
-            filter = SCContentFilter(display: nativeDisplay, excludingApplications: excludedApps, exceptingWindows: [])
+            let excludedWindows = content.windows.filter { window in options.excludeWindowIDs.contains(window.windowID) }
+
+            filter = SCContentFilter(display: nativeDisplay, including: includedApps, exceptingWindows: excludedWindows)
         } else {
             log("Unable to resolve SCContentFilter", .error)
             throw LiveKitError(.invalidState, message: "Unable to resolve SCContentFilter")

--- a/Sources/LiveKit/Types/Options/ScreenShareCaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/ScreenShareCaptureOptions.swift
@@ -41,6 +41,10 @@ public final class ScreenShareCaptureOptions: NSObject, VideoCaptureOptions, Sen
     @objc
     public let includeCurrentApplication: Bool
 
+    /// Exclude windows by their window ID (macOS only).
+    @objc
+    public let excludeWindowIDs: [UInt32]
+
     public static let defaultToBroadcastExtension: Bool = {
         #if os(iOS)
         return BroadcastBundleInfo.hasExtension
@@ -54,7 +58,8 @@ public final class ScreenShareCaptureOptions: NSObject, VideoCaptureOptions, Sen
                 showCursor: Bool = true,
                 appAudio: Bool = false,
                 useBroadcastExtension: Bool = defaultToBroadcastExtension,
-                includeCurrentApplication: Bool = false)
+                includeCurrentApplication: Bool = false,
+                excludeWindowIDs: [UInt32] = [])
     {
         self.dimensions = dimensions
         self.fps = fps
@@ -62,6 +67,7 @@ public final class ScreenShareCaptureOptions: NSObject, VideoCaptureOptions, Sen
         self.appAudio = appAudio
         self.useBroadcastExtension = useBroadcastExtension
         self.includeCurrentApplication = includeCurrentApplication
+        self.excludeWindowIDs = excludeWindowIDs
     }
 
     // MARK: - Equal
@@ -73,7 +79,8 @@ public final class ScreenShareCaptureOptions: NSObject, VideoCaptureOptions, Sen
             showCursor == other.showCursor &&
             appAudio == other.appAudio &&
             useBroadcastExtension == other.useBroadcastExtension &&
-            includeCurrentApplication == other.includeCurrentApplication
+            includeCurrentApplication == other.includeCurrentApplication &&
+            excludeWindowIDs == other.excludeWindowIDs
     }
 
     override public var hash: Int {
@@ -84,6 +91,7 @@ public final class ScreenShareCaptureOptions: NSObject, VideoCaptureOptions, Sen
         hasher.combine(appAudio)
         hasher.combine(useBroadcastExtension)
         hasher.combine(includeCurrentApplication)
+        hasher.combine(excludeWindowIDs)
         return hasher.finalize()
     }
 }


### PR DESCRIPTION
Resolves #567 

- Inverts the logic for including apps
- Does not use the deprecated prop here https://developer.apple.com/documentation/appkit/nswindow/sharingtype-swift.enum/none, plain ID instead

<img width="991" height="627" alt="Screenshot 2025-08-12 at 1 15 06 PM" src="https://github.com/user-attachments/assets/e5fc6813-2f88-49c8-a623-cf4cfbc7c87e" />
