### PR TITLE
Transceiver crash

### DIFF
--- a/.changes/revert-stop-transceiver
+++ b/.changes/revert-stop-transceiver
@@ -1,0 +1,1 @@
+patch type="fixed" "Fixed transceiver crash, reverting video memory leak changes"

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -323,11 +323,6 @@ extension Transport {
     }
 
     func remove(track sender: LKRTCRtpSender) throws {
-        // Stop the transceiver to release its resources and prevent memory leak
-        if let transceiver = _pc.transceivers.first(where: { $0.sender == sender }) {
-            transceiver.stopInternal()
-        }
-
         guard _pc.removeTrack(sender) else {
             throw LiveKitError(.webRTC, message: "Failed to remove track")
         }


### PR DESCRIPTION
Reverts https://github.com/livekit/client-sdk-swift/pull/751

Let's revisit transceiver pools - it requires deeper testing though.