### PR TITLE
Reuse transceiver

### DIFF
--- a/Sources/LiveKit/Extensions/RTCRtpTransceiver.swift
+++ b/Sources/LiveKit/Extensions/RTCRtpTransceiver.swift
@@ -20,7 +20,7 @@ internal import LiveKitWebRTC
 
 extension LKRTCRtpTransceiver: Loggable {
     /// Attempts to set preferred video codec.
-    func set(preferredVideoCodec codec: VideoCodec, exceptCodec: VideoCodec? = nil) {
+    func set(preferredVideoCodec codec: VideoCodec, exceptCodec: VideoCodec? = nil) throws {
         // Get list of supported codecs...
         let allVideoCodecs = RTC.videoSenderCapabilities.codecs
 
@@ -36,7 +36,11 @@ extension LKRTCRtpTransceiver: Loggable {
         let combinedCapabilities = [preferredCodecCapability] + otherCapabilities
 
         // Codecs not set in codecPreferences will not be negotiated in the offer
-        codecPreferences = combinedCapabilities.compactMap { $0 }
+        do {
+            try setCodecPreferences(combinedCapabilities.compactMap { $0 }, error: ())
+        } catch {
+            throw LiveKitError(.webRTC, message: "Failed to set codec preferences", internalError: error)
+        }
 
         log("codecPreferences set: \(codecPreferences.map { String(describing: $0) }.joined(separator: ", "))")
 

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -458,7 +458,7 @@ extension LocalParticipant {
         log("[Publish] Added transceiver...")
 
         // Set codec...
-        transceiver.set(preferredVideoCodec: videoCodec)
+        try transceiver.set(preferredVideoCodec: videoCodec)
 
         let sender = transceiver.sender
 
@@ -667,7 +667,7 @@ extension LocalParticipant {
                     }
 
                     if let preferredCodec = publishOptions.preferredCodec {
-                        transceiver.set(preferredVideoCodec: preferredCodec)
+                        try transceiver.set(preferredVideoCodec: preferredCodec)
                     }
                 }
 


### PR DESCRIPTION
Let's see what we can do without patching.

As an alternative: we can create a webrtc patch and see what's really allocated, then try to dump it once the transceiver is stopped.