### PR TITLE
Handle macOS stream errors

### DIFF
--- a/.changes/turn-off-display
+++ b/.changes/turn-off-display
@@ -1,0 +1,1 @@
+patch type="fixed" "Screen sharing getting stuck on macOS when the display is turned off"

--- a/Sources/LiveKit/TrackPublications/LocalTrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/LocalTrackPublication.swift
@@ -119,6 +119,17 @@ extension LocalTrackPublication: VideoCapturerDelegate {
                 try await participant.unpublish(publication: self)
             }
         }
+        // A similar check for macOS may be triggered e.g. when the display is powered off.
+        #elseif os(macOS)
+        if #available(macOS 12.3, *), state == .stopped, capturer is MacOSScreenCapturer {
+            Task {
+                guard let participant = try await self.requireParticipant() as? LocalParticipant else {
+                    return
+                }
+
+                try await participant.unpublish(publication: self)
+            }
+        }
         #endif
     }
 }


### PR DESCRIPTION
Resolves #331 

Handles stream errors in a way similar to iOS broadcast (by unpublishing the track so it won't get stuck).