### PR TITLE
Fix recording perms check for manual audio

### DIFF
--- a/.changes/recording-perms-check-only-device
+++ b/.changes/recording-perms-check-only-device
@@ -1,0 +1,1 @@
+patch type="fixed" "Only check audio recording perms for device rendering mode"

--- a/Sources/LiveKit/Audio/AudioDeviceModuleDelegateAdapter.swift
+++ b/Sources/LiveKit/Audio/AudioDeviceModuleDelegateAdapter.swift
@@ -45,8 +45,8 @@ class AudioDeviceModuleDelegateAdapter: NSObject, LKRTCAudioDeviceModuleDelegate
         let entryPoint = audioManager.buildEngineObserverChain()
         let result = entryPoint?.engineWillEnable(engine, isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled) ?? 0
 
-        // At this point mic perms / session should be configured for recording.
-        if result == 0, isRecordingEnabled {
+        // At this point mic perms / session should be configured for recording (only if device rendering mode).
+        if result == 0, !engine.isInManualRenderingMode, isRecordingEnabled {
             // This will block WebRTC's worker thread, but when instantiating AVAudioInput node it will block by showing a dialog anyways.
             // Attempt to acquire mic perms at this point to return an error at SDK level.
             let isAuthorized = LiveKitSDK.ensureDeviceAccessSync(for: [.audio])


### PR DESCRIPTION
We don't need to check recording perms & audio session for manual rendering mode since it doesn't use the device (mic).