### PR TITLE
Encrypted data channel

### DIFF
--- a/.changes/encrypted-dc
+++ b/.changes/encrypted-dc
@@ -1,0 +1,1 @@
+minor type="added" "Added support for data channel encryption, deprecated existing E2EE options"

--- a/LiveKitClient.podspec
+++ b/LiveKitClient.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |spec|
 
   spec.source_files = "Sources/**/*"
 
-  spec.dependency("LiveKitWebRTC", "= 137.7151.04")
+  spec.dependency("LiveKitWebRTC", "= 137.7151.07")
   spec.dependency("SwiftProtobuf")
   spec.dependency("Logging", "= 1.5.4")
   spec.dependency("DequeModule", "= 1.1.4")

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.06"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.07"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.05"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.06"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
         .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.07"),
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
         // Only used for DocC generation

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -21,7 +21,7 @@ let package = Package(
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
         .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.07"),
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
         // Only used for DocC generation

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.05"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.06"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.06"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.07"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -342,13 +342,13 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
     }
 
     private func withEncryption(_ packet: Livekit_DataPacket) throws -> Livekit_DataPacket {
-        guard let payload = Livekit_EncryptedPacketPayload(dataPacket: packet),
-              let e2eeManager, e2eeManager.isDataChannelEncryptionEnabled else { return packet }
+        guard let e2eeManager, e2eeManager.isDataChannelEncryptionEnabled,
+              let payload = Livekit_EncryptedPacketPayload(dataPacket: packet) else { return packet }
         var packet = packet
         do {
             let payloadData = try payload.serializedData()
-            let rtcEncrypted = try e2eeManager.encrypt(data: payloadData)
-            packet.encryptedPacket = Livekit_EncryptedPacket(rtcPacket: rtcEncrypted)
+            let rtcEncryptedPacket = try e2eeManager.encrypt(data: payloadData)
+            packet.encryptedPacket = Livekit_EncryptedPacket(rtcPacket: rtcEncryptedPacket)
         } catch {
             throw LiveKitError(.encryptionFailed, internalError: error)
         }

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -318,7 +318,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
     }
 
     func send(dataPacket packet: Livekit_DataPacket) async throws {
-        let packet = try await withSequence(withEncryption(packet))
+        let packet = try await withEncryption(withSequence(packet))
         let serializedData = try packet.serializedData()
         let rtcData = RTC.createDataBuffer(data: serializedData)
 

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -436,7 +436,7 @@ extension DataChannelPair: LKRTCDataChannelDelegate {
         }
 
         if let encryptedPacket = dataPacket.encryptedPacketOrNil,
-           let e2eeManager, e2eeManager.isDataChannelEncryptionEnabled
+           let e2eeManager
         {
             do {
                 let decryptedData = try e2eeManager.handle(encryptedData: encryptedPacket.toRTCEncryptedPacket(), participantIdentity: dataPacket.participantIdentity)

--- a/Sources/LiveKit/Core/Room+EngineDelegate.swift
+++ b/Sources/LiveKit/Core/Room+EngineDelegate.swift
@@ -180,20 +180,20 @@ extension Room {
         await publication.set(track: nil)
     }
 
-    func engine(_ engine: Room, didReceiveUserPacket packet: Livekit_UserPacket) {
+    func engine(_ engine: Room, didReceiveUserPacket packet: Livekit_UserPacket, encryptionType: EncryptionType) {
         // participant could be null if data broadcasted from server
         let identity = Participant.Identity(from: packet.participantIdentity)
         let participant = _state.remoteParticipants[identity]
 
         if case .connected = engine._state.connectionState {
             delegates.notify(label: { "room.didReceive data: \(packet.payload)" }) {
-                $0.room?(self, participant: participant, didReceiveData: packet.payload, forTopic: packet.topic)
+                $0.room?(self, participant: participant, didReceiveData: packet.payload, forTopic: packet.topic, encryptionType: encryptionType)
             }
 
             if let participant {
                 participant.delegates.notify(label: { "participant.didReceive data: \(packet.payload)" }) { [weak participant] delegate in
                     guard let participant else { return }
-                    delegate.participant?(participant, didReceiveData: packet.payload, forTopic: packet.topic)
+                    delegate.participant?(participant, didReceiveData: packet.payload, forTopic: packet.topic, encryptionType: encryptionType)
                 }
             }
         }

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -121,7 +121,7 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
     lazy var outgoingStreamManager = OutgoingStreamManager { [weak self] packet in
         try await self?.send(dataPacket: packet)
     } encryptionProvider: { [weak self] in
-        self?.e2eeManager?.encryptionType ?? .none
+        self?.e2eeManager?.dataChannelEncryptionType ?? .none
     }
 
     // MARK: - PreConnect

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -121,7 +121,7 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
     lazy var outgoingStreamManager = OutgoingStreamManager { [weak self] packet in
         try await self?.send(dataPacket: packet)
     } encryptionProvider: { [weak self] in
-        (self?.e2eeManager?.isDataChannelEncryptionEnabled ?? false) ? .gcm : .none
+        self?.e2eeManager?.encryptionType ?? .none
     }
 
     // MARK: - PreConnect

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -354,7 +354,7 @@ private extension SignalClient {
             log("Received roomMoved message")
 
         case .mediaSectionsRequirement:
-            #warning("TODO")
+            log("Received mediaSectionsRequirement message")
         }
     }
 }

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -352,6 +352,9 @@ private extension SignalClient {
 
         case .roomMoved:
             log("Received roomMoved message")
+
+        case .mediaSectionsRequirement:
+            #warning("TODO")
         }
     }
 }

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -61,10 +61,10 @@ actor IncomingStreamManager: Loggable {
     // MARK: - Packet processing
 
     /// Handles a data stream header.
-    func handle(header: Livekit_DataStream.Header, from identityString: String) {
+    func handle(header: Livekit_DataStream.Header, from identityString: String, encryptionType: EncryptionType) {
         let identity = Participant.Identity(from: identityString)
 
-        guard let streamInfo = Self.streamInfo(from: header) else {
+        guard let streamInfo = Self.streamInfo(from: header, encryptionType: encryptionType) else {
             return
         }
         openStream(with: streamInfo, from: identity)
@@ -110,8 +110,18 @@ actor IncomingStreamManager: Loggable {
     }
 
     /// Handles a data stream chunk.
-    func handle(chunk: Livekit_DataStream.Chunk) {
+    func handle(chunk: Livekit_DataStream.Chunk, encryptionType: EncryptionType) {
         guard !chunk.content.isEmpty, let descriptor = openStreams[chunk.streamID] else { return }
+
+        if descriptor.info.encryptionType != encryptionType {
+            let error = StreamError.encryptionTypeMismatch(
+                streamId: chunk.streamID,
+                expected: descriptor.info.encryptionType,
+                received: encryptionType
+            )
+            descriptor.continuation.finish(throwing: error)
+            return
+        }
 
         let readLength = descriptor.readLength + chunk.content.count
 
@@ -126,10 +136,21 @@ actor IncomingStreamManager: Loggable {
     }
 
     /// Handles a data stream trailer.
-    func handle(trailer: Livekit_DataStream.Trailer) {
+    func handle(trailer: Livekit_DataStream.Trailer, encryptionType: EncryptionType) {
         guard let descriptor = openStreams[trailer.streamID] else {
             return
         }
+
+        if descriptor.info.encryptionType != encryptionType {
+            let error = StreamError.encryptionTypeMismatch(
+                streamId: trailer.streamID,
+                expected: descriptor.info.encryptionType,
+                received: encryptionType
+            )
+            descriptor.continuation.finish(throwing: error)
+            return
+        }
+
         if let totalLength = descriptor.info.totalLength {
             guard descriptor.readLength == totalLength else {
                 descriptor.continuation.finish(throwing: StreamError.incomplete)
@@ -186,10 +207,10 @@ public typealias TextStreamHandler = @Sendable (TextStreamReader, Participant.Id
 // MARK: - From protocol types
 
 extension IncomingStreamManager {
-    static func streamInfo(from header: Livekit_DataStream.Header) -> StreamInfo? {
+    static func streamInfo(from header: Livekit_DataStream.Header, encryptionType: EncryptionType) -> StreamInfo? {
         switch header.contentHeader {
-        case let .byteHeader(byteHeader): ByteStreamInfo(header, byteHeader)
-        case let .textHeader(textHeader): TextStreamInfo(header, textHeader)
+        case let .byteHeader(byteHeader): ByteStreamInfo(header, byteHeader, encryptionType: encryptionType)
+        case let .textHeader(textHeader): TextStreamInfo(header, textHeader, encryptionType: encryptionType)
         default: nil
         }
     }
@@ -198,7 +219,8 @@ extension IncomingStreamManager {
 extension ByteStreamInfo {
     convenience init(
         _ header: Livekit_DataStream.Header,
-        _ byteHeader: Livekit_DataStream.ByteHeader
+        _ byteHeader: Livekit_DataStream.ByteHeader,
+        encryptionType: EncryptionType
     ) {
         self.init(
             id: header.streamID,
@@ -206,6 +228,7 @@ extension ByteStreamInfo {
             timestamp: header.timestampDate,
             totalLength: header.hasTotalLength ? Int(header.totalLength) : nil,
             attributes: header.attributes,
+            encryptionType: encryptionType,
             // ---
             mimeType: header.mimeType,
             name: byteHeader.name
@@ -216,7 +239,8 @@ extension ByteStreamInfo {
 extension TextStreamInfo {
     convenience init(
         _ header: Livekit_DataStream.Header,
-        _ textHeader: Livekit_DataStream.TextHeader
+        _ textHeader: Livekit_DataStream.TextHeader,
+        encryptionType: EncryptionType
     ) {
         self.init(
             id: header.streamID,
@@ -224,6 +248,7 @@ extension TextStreamInfo {
             timestamp: header.timestampDate,
             totalLength: header.hasTotalLength ? Int(header.totalLength) : nil,
             attributes: header.attributes,
+            encryptionType: encryptionType,
             // ---
             operationType: TextStreamInfo.OperationType(textHeader.operationType),
             version: Int(textHeader.version),

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -207,8 +207,8 @@ public typealias TextStreamHandler = @Sendable (TextStreamReader, Participant.Id
 extension IncomingStreamManager {
     static func streamInfo(from header: Livekit_DataStream.Header, encryptionType: EncryptionType) -> StreamInfo? {
         switch header.contentHeader {
-        case let .byteHeader(byteHeader): ByteStreamInfo(header, byteHeader, encryptionType: encryptionType)
-        case let .textHeader(textHeader): TextStreamInfo(header, textHeader, encryptionType: encryptionType)
+        case let .byteHeader(byteHeader): ByteStreamInfo(header, byteHeader, encryptionType)
+        case let .textHeader(textHeader): TextStreamInfo(header, textHeader, encryptionType)
         default: nil
         }
     }
@@ -218,7 +218,7 @@ extension ByteStreamInfo {
     convenience init(
         _ header: Livekit_DataStream.Header,
         _ byteHeader: Livekit_DataStream.ByteHeader,
-        encryptionType: EncryptionType
+        _ encryptionType: EncryptionType
     ) {
         self.init(
             id: header.streamID,
@@ -238,7 +238,7 @@ extension TextStreamInfo {
     convenience init(
         _ header: Livekit_DataStream.Header,
         _ textHeader: Livekit_DataStream.TextHeader,
-        encryptionType: EncryptionType
+        _ encryptionType: EncryptionType
     ) {
         self.init(
             id: header.streamID,

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -115,7 +115,6 @@ actor IncomingStreamManager: Loggable {
 
         if descriptor.info.encryptionType != encryptionType {
             let error = StreamError.encryptionTypeMismatch(
-                streamId: chunk.streamID,
                 expected: descriptor.info.encryptionType,
                 received: encryptionType
             )
@@ -143,7 +142,6 @@ actor IncomingStreamManager: Loggable {
 
         if descriptor.info.encryptionType != encryptionType {
             let error = StreamError.encryptionTypeMismatch(
-                streamId: trailer.streamID,
                 expected: descriptor.info.encryptionType,
                 received: encryptionType
             )

--- a/Sources/LiveKit/DataStream/Outgoing/OutgoingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Outgoing/OutgoingStreamManager.swift
@@ -19,11 +19,14 @@ import Foundation
 /// Manages state of outgoing data streams.
 actor OutgoingStreamManager: Loggable {
     typealias PacketHandler = @Sendable (Livekit_DataPacket) async throws -> Void
+    typealias EncryptionProvider = @Sendable () -> EncryptionType
 
     private nonisolated let packetHandler: PacketHandler
+    private nonisolated let encryptionProvider: EncryptionProvider
 
-    init(packetHandler: @escaping PacketHandler) {
+    init(packetHandler: @escaping PacketHandler, encryptionProvider: @escaping EncryptionProvider) {
         self.packetHandler = packetHandler
+        self.encryptionProvider = encryptionProvider
     }
 
     // MARK: - Opening streams
@@ -35,6 +38,7 @@ actor OutgoingStreamManager: Loggable {
             timestamp: Date(),
             totalLength: text.utf8.count, // Number of bytes in UTF-8 representation
             attributes: options.attributes,
+            encryptionType: encryptionProvider(),
             operationType: .create,
             version: options.version,
             replyToStreamID: options.replyToStreamID,
@@ -61,6 +65,7 @@ actor OutgoingStreamManager: Loggable {
             timestamp: Date(),
             totalLength: fileInfo.size, // Not overridable
             attributes: options.attributes,
+            encryptionType: encryptionProvider(),
             mimeType: options.mimeType ?? fileInfo.mimeType ?? Self.byteMimeType,
             name: options.name ?? fileInfo.name
         )
@@ -81,6 +86,7 @@ actor OutgoingStreamManager: Loggable {
             timestamp: Date(),
             totalLength: nil,
             attributes: options.attributes,
+            encryptionType: encryptionProvider(),
             operationType: .create,
             version: options.version,
             replyToStreamID: options.replyToStreamID,
@@ -100,6 +106,7 @@ actor OutgoingStreamManager: Loggable {
             timestamp: Date(),
             totalLength: options.totalSize,
             attributes: options.attributes,
+            encryptionType: encryptionProvider(),
             mimeType: options.mimeType ?? Self.byteMimeType,
             name: options.name
         )

--- a/Sources/LiveKit/DataStream/StreamError.swift
+++ b/Sources/LiveKit/DataStream/StreamError.swift
@@ -44,4 +44,7 @@ public enum StreamError: Error, Equatable {
 
     /// Unable to read information about the file to send.
     case fileInfoUnavailable
+
+    /// Encryption type mismatch between stream header and chunk/trailer.
+    case encryptionTypeMismatch(streamId: String, expected: EncryptionType, received: EncryptionType)
 }

--- a/Sources/LiveKit/DataStream/StreamError.swift
+++ b/Sources/LiveKit/DataStream/StreamError.swift
@@ -46,5 +46,5 @@ public enum StreamError: Error, Equatable {
     case fileInfoUnavailable
 
     /// Encryption type mismatch between stream header and chunk/trailer.
-    case encryptionTypeMismatch(streamId: String, expected: EncryptionType, received: EncryptionType)
+    case encryptionTypeMismatch(expected: EncryptionType, received: EncryptionType)
 }

--- a/Sources/LiveKit/DataStream/StreamInfo.swift
+++ b/Sources/LiveKit/DataStream/StreamInfo.swift
@@ -32,6 +32,9 @@ public protocol StreamInfo: Sendable {
 
     /// Additional attributes as needed for your application.
     var attributes: [String: String] { get }
+
+    /// The encryption type used for this stream.
+    var encryptionType: EncryptionType { get }
 }
 
 /// Information about a text data stream.
@@ -42,6 +45,7 @@ public final class TextStreamInfo: NSObject, StreamInfo {
     public let timestamp: Date
     public let totalLength: Int?
     public let attributes: [String: String]
+    public let encryptionType: EncryptionType
 
     @objc(TextStreamInfoOperationType)
     public enum OperationType: Int, Sendable {
@@ -63,6 +67,7 @@ public final class TextStreamInfo: NSObject, StreamInfo {
         timestamp: Date,
         totalLength: Int?,
         attributes: [String: String],
+        encryptionType: EncryptionType,
         operationType: OperationType,
         version: Int,
         replyToStreamID: String?,
@@ -74,6 +79,7 @@ public final class TextStreamInfo: NSObject, StreamInfo {
         self.timestamp = timestamp
         self.totalLength = totalLength
         self.attributes = attributes
+        self.encryptionType = encryptionType
         self.operationType = operationType
         self.version = version
         self.replyToStreamID = replyToStreamID
@@ -90,6 +96,7 @@ public final class ByteStreamInfo: NSObject, StreamInfo {
     public let timestamp: Date
     public let totalLength: Int?
     public let attributes: [String: String]
+    public let encryptionType: EncryptionType
 
     /// The MIME type of the stream data.
     public let mimeType: String
@@ -103,6 +110,7 @@ public final class ByteStreamInfo: NSObject, StreamInfo {
         timestamp: Date,
         totalLength: Int?,
         attributes: [String: String],
+        encryptionType: EncryptionType,
         mimeType: String,
         name: String?
     ) {
@@ -112,6 +120,7 @@ public final class ByteStreamInfo: NSObject, StreamInfo {
         self.timestamp = timestamp
         self.totalLength = totalLength
         self.attributes = attributes
+        self.encryptionType = encryptionType
         self.name = name
     }
 }

--- a/Sources/LiveKit/E2EE/E2EEManager.swift
+++ b/Sources/LiveKit/E2EE/E2EEManager.swift
@@ -272,7 +272,8 @@ extension E2EEManager {
             throw LiveKitError(.invalidState, message: "Cryptor is nil")
         }
 
-        guard let encryptedPacket = cryptor.encrypt(identity, keyIndex: 0, data: data) else {
+        let keyIndex = UInt32(keyProvider.getCurrentKeyIndex())
+        guard let encryptedPacket = cryptor.encrypt(identity, keyIndex: keyIndex, data: data) else {
             throw LiveKitError(.encryptionFailed, message: "Failed to encrypt data packet")
         }
 

--- a/Sources/LiveKit/E2EE/E2EEManager.swift
+++ b/Sources/LiveKit/E2EE/E2EEManager.swift
@@ -258,7 +258,7 @@ extension E2EEManager: RoomDelegate {
     }
 }
 
-// MARK: - Data Packet Encryption
+// MARK: - Data Packet encryption
 
 extension E2EEManager {
     func encrypt(data: Data) throws -> LKRTCEncryptedPacket {
@@ -273,11 +273,11 @@ extension E2EEManager {
         }
 
         let keyIndex = UInt32(keyProvider.getCurrentKeyIndex())
-        guard let encryptedPacket = cryptor.encrypt(identity, keyIndex: keyIndex, data: data) else {
+        guard let encryptedData = cryptor.encrypt(identity, keyIndex: keyIndex, data: data) else {
             throw LiveKitError(.encryptionFailed, message: "Failed to encrypt data packet")
         }
 
-        return encryptedPacket
+        return encryptedData
     }
 
     func handle(encryptedData: LKRTCEncryptedPacket, participantIdentity: String) throws -> Data {

--- a/Sources/LiveKit/E2EE/E2EEManager.swift
+++ b/Sources/LiveKit/E2EE/E2EEManager.swift
@@ -71,10 +71,6 @@ public class E2EEManager: NSObject, @unchecked Sendable, ObservableObject, Logga
         self.e2eeOptions = e2eeOptions
         #warning("Override")
         dataChannelEncryptionEnabled = true
-
-        _state.mutate {
-            $0.dataCryptor = LKRTCDataPacketCryptor(algorithm: e2eeOptions.encryptionType.toRTCType(), keyProvider: e2eeOptions.keyProvider.rtcKeyProvider)
-        }
     }
 
 //    public init(options: EncryptionOptions) {
@@ -104,6 +100,8 @@ public class E2EEManager: NSObject, @unchecked Sendable, ObservableObject, Logga
                 }
             }
         }
+
+        addDataChannelCryptor()
     }
 
     public func enableE2EE(enabled: Bool) {
@@ -175,6 +173,12 @@ public class E2EEManager: NSObject, @unchecked Sendable, ObservableObject, Logga
         }
     }
 
+    func addDataChannelCryptor() {
+        _state.mutate {
+            $0.dataCryptor = LKRTCDataPacketCryptor(algorithm: .aesGcm, keyProvider: e2eeOptions.keyProvider.rtcKeyProvider)
+        }
+    }
+
     public func cleanUp() {
         _state.mutate {
             for (_, frameCryptor) in $0.frameCryptors {
@@ -182,7 +186,6 @@ public class E2EEManager: NSObject, @unchecked Sendable, ObservableObject, Logga
             }
             $0.frameCryptors.removeAll()
             $0.trackPublications.removeAll()
-            $0.dataCryptor = nil
         }
     }
 }

--- a/Sources/LiveKit/E2EE/E2EEManager.swift
+++ b/Sources/LiveKit/E2EE/E2EEManager.swift
@@ -261,7 +261,7 @@ extension E2EEManager: RoomDelegate {
 // MARK: - Data Packet Encryption
 
 extension E2EEManager {
-    func encrypt(data: Data) async throws -> LKRTCEncryptedPacket {
+    func encrypt(data: Data) throws -> LKRTCEncryptedPacket {
         guard let room = _room,
               let identity = room.localParticipant.identity?.stringValue
         else {
@@ -280,7 +280,7 @@ extension E2EEManager {
         return encryptedPacket
     }
 
-    func handle(encryptedData: LKRTCEncryptedPacket, participantIdentity: String) async throws -> Data {
+    func handle(encryptedData: LKRTCEncryptedPacket, participantIdentity: String) throws -> Data {
         guard let cryptor = _state.dataCryptor else {
             throw LiveKitError(.invalidState, message: "Cryptor is nil")
         }

--- a/Sources/LiveKit/E2EE/E2EEManager.swift
+++ b/Sources/LiveKit/E2EE/E2EEManager.swift
@@ -42,8 +42,6 @@ public class E2EEManager: NSObject, @unchecked Sendable, ObservableObject, Logga
     public let e2eeOptions: E2EEOptions?
     public let options: EncryptionOptions?
 
-    private let dataChannelEncryptionEnabled: Bool
-
     public var keyProvider: BaseKeyProvider {
         options?.keyProvider ?? e2eeOptions?.keyProvider ?? BaseKeyProvider()
     }
@@ -53,7 +51,7 @@ public class E2EEManager: NSObject, @unchecked Sendable, ObservableObject, Logga
     }
 
     public var isDataChannelEncryptionEnabled: Bool {
-        _state.enabled && dataChannelEncryptionEnabled
+        _state.enabled && options != nil
     }
 
     // MARK: - Private
@@ -75,13 +73,11 @@ public class E2EEManager: NSObject, @unchecked Sendable, ObservableObject, Logga
     public init(e2eeOptions: E2EEOptions) {
         self.e2eeOptions = e2eeOptions
         options = nil
-        dataChannelEncryptionEnabled = false
     }
 
     public init(options: EncryptionOptions) {
         e2eeOptions = nil
         self.options = options
-        dataChannelEncryptionEnabled = true
     }
 
     public func setup(room: Room) {
@@ -285,7 +281,7 @@ extension E2EEManager {
             throw LiveKitError(.encryptionFailed, message: "Failed to encrypt data packet")
         }
 
-        log("Encrypted \(encryptedData)", .trace)
+        log("Encrypted \(encryptedData.data)", .trace)
 
         return encryptedData
     }

--- a/Sources/LiveKit/E2EE/E2EEManager.swift
+++ b/Sources/LiveKit/E2EE/E2EEManager.swift
@@ -46,12 +46,17 @@ public class E2EEManager: NSObject, @unchecked Sendable, ObservableObject, Logga
         options?.keyProvider ?? e2eeOptions?.keyProvider ?? BaseKeyProvider()
     }
 
-    public var encryptionType: EncryptionType {
+    public var frameEncryptionType: EncryptionType {
         options?.encryptionType ?? e2eeOptions?.encryptionType ?? .none
     }
 
     public var isDataChannelEncryptionEnabled: Bool {
         _state.enabled && options != nil
+    }
+
+    public var dataChannelEncryptionType: EncryptionType {
+        guard isDataChannelEncryptionEnabled else { return .none }
+        return options?.encryptionType ?? .none
     }
 
     // MARK: - Private

--- a/Sources/LiveKit/E2EE/KeyProvider.swift
+++ b/Sources/LiveKit/E2EE/KeyProvider.swift
@@ -22,6 +22,7 @@ public let defaultRatchetSalt: String = "LKFrameEncryptionKey"
 public let defaultMagicBytes: String = "LK-ROCKS"
 public let defaultRatchetWindowSize: Int32 = 0
 public let defaultFailureTolerance: Int32 = -1
+public let defaultKeyRingSize: Int32 = 16
 
 @objc
 public final class KeyProviderOptions: NSObject, Sendable {
@@ -40,17 +41,22 @@ public final class KeyProviderOptions: NSObject, Sendable {
     @objc
     public let failureTolerance: Int32
 
+    @objc
+    public let keyRingSize: Int32
+
     public init(sharedKey: Bool = true,
                 ratchetSalt: Data = defaultRatchetSalt.data(using: .utf8)!,
                 ratchetWindowSize: Int32 = defaultRatchetWindowSize,
                 uncryptedMagicBytes: Data = defaultMagicBytes.data(using: .utf8)!,
-                failureTolerance: Int32 = defaultFailureTolerance)
+                failureTolerance: Int32 = defaultFailureTolerance,
+                keyRingSize: Int32 = defaultKeyRingSize)
     {
         self.sharedKey = sharedKey
         self.ratchetSalt = ratchetSalt
         self.ratchetWindowSize = ratchetWindowSize
         self.uncryptedMagicBytes = uncryptedMagicBytes
         self.failureTolerance = failureTolerance
+        self.keyRingSize = keyRingSize
     }
 
     // MARK: - Equal
@@ -61,7 +67,8 @@ public final class KeyProviderOptions: NSObject, Sendable {
             ratchetSalt == other.ratchetSalt &&
             ratchetWindowSize == other.ratchetWindowSize &&
             uncryptedMagicBytes == other.uncryptedMagicBytes &&
-            failureTolerance == other.failureTolerance
+            failureTolerance == other.failureTolerance &&
+            keyRingSize == other.keyRingSize
     }
 
     override public var hash: Int {
@@ -71,6 +78,7 @@ public final class KeyProviderOptions: NSObject, Sendable {
         hasher.combine(ratchetWindowSize)
         hasher.combine(uncryptedMagicBytes)
         hasher.combine(failureTolerance)
+        hasher.combine(keyRingSize)
         return hasher.finalize()
     }
 }
@@ -84,6 +92,14 @@ public final class BaseKeyProvider: NSObject, Loggable, Sendable {
 
     let rtcKeyProvider: LKRTCFrameCryptorKeyProvider
 
+    // MARK: - State
+
+    struct State {
+        var currentKeyIndex: Int32 = 0
+    }
+
+    private let _state = StateSync(State())
+
     public init(isSharedKey: Bool, sharedKey: String? = nil) {
         options = KeyProviderOptions(sharedKey: isSharedKey)
         rtcKeyProvider = LKRTCFrameCryptorKeyProvider(ratchetSalt: options.ratchetSalt,
@@ -91,7 +107,7 @@ public final class BaseKeyProvider: NSObject, Loggable, Sendable {
                                                       sharedKeyMode: isSharedKey,
                                                       uncryptedMagicBytes: options.uncryptedMagicBytes,
                                                       failureTolerance: options.failureTolerance,
-                                                      keyRingSize: 16)
+                                                      keyRingSize: options.keyRingSize)
         if isSharedKey, sharedKey != nil {
             let keyData = sharedKey!.data(using: .utf8)!
             rtcKeyProvider.setSharedKey(keyData, with: 0)
@@ -103,28 +119,35 @@ public final class BaseKeyProvider: NSObject, Loggable, Sendable {
         rtcKeyProvider = LKRTCFrameCryptorKeyProvider(ratchetSalt: options.ratchetSalt,
                                                       ratchetWindowSize: options.ratchetWindowSize,
                                                       sharedKeyMode: options.sharedKey,
-                                                      uncryptedMagicBytes: options.uncryptedMagicBytes)
+                                                      uncryptedMagicBytes: options.uncryptedMagicBytes,
+                                                      failureTolerance: options.failureTolerance,
+                                                      keyRingSize: options.keyRingSize)
     }
 
-    public func setKey(key: String, participantId: String? = nil, index: Int32? = 0) {
+    public func setKey(key: String, participantId: String? = nil, index: Int32? = nil) {
+        let targetIndex = index ?? getCurrentKeyIndex()
+
         if options.sharedKey {
             let keyData = key.data(using: .utf8)!
-            rtcKeyProvider.setSharedKey(keyData, with: index ?? 0)
-            return
+            rtcKeyProvider.setSharedKey(keyData, with: targetIndex)
+        } else {
+            if participantId == nil {
+                log("setKey: Please provide valid participantId for non-SharedKey mode.")
+                return
+            }
+
+            let keyData = key.data(using: .utf8)!
+            rtcKeyProvider.setKey(keyData, with: targetIndex, forParticipant: participantId!)
         }
 
-        if participantId == nil {
-            log("setKey: Please provide valid participantId for non-SharedKey mode.")
-            return
-        }
-
-        let keyData = key.data(using: .utf8)!
-        rtcKeyProvider.setKey(keyData, with: index!, forParticipant: participantId!)
+        setCurrentKeyIndex(targetIndex)
     }
 
-    public func ratchetKey(participantId: String? = nil, index: Int32? = 0) -> Data? {
+    public func ratchetKey(participantId: String? = nil, index: Int32? = nil) -> Data? {
+        let targetIndex = index ?? getCurrentKeyIndex()
+
         if options.sharedKey {
-            return rtcKeyProvider.ratchetSharedKey(index ?? 0)
+            return rtcKeyProvider.ratchetSharedKey(targetIndex)
         }
 
         if participantId == nil {
@@ -132,12 +155,14 @@ public final class BaseKeyProvider: NSObject, Loggable, Sendable {
             return nil
         }
 
-        return rtcKeyProvider.ratchetKey(participantId!, with: index ?? 0)
+        return rtcKeyProvider.ratchetKey(participantId!, with: targetIndex)
     }
 
-    public func exportKey(participantId: String? = nil, index: Int32? = 0) -> Data? {
+    public func exportKey(participantId: String? = nil, index: Int32? = nil) -> Data? {
+        let targetIndex = index ?? getCurrentKeyIndex()
+
         if options.sharedKey {
-            return rtcKeyProvider.exportSharedKey(index ?? 0)
+            return rtcKeyProvider.exportSharedKey(targetIndex)
         }
 
         if participantId == nil {
@@ -145,11 +170,21 @@ public final class BaseKeyProvider: NSObject, Loggable, Sendable {
             return nil
         }
 
-        return rtcKeyProvider.exportKey(participantId!, with: index ?? 0)
+        return rtcKeyProvider.exportKey(participantId!, with: targetIndex)
     }
 
     public func setSifTrailer(trailer: Data) {
         rtcKeyProvider.setSifTrailer(trailer)
+    }
+
+    @objc
+    public func getCurrentKeyIndex() -> Int32 {
+        _state.currentKeyIndex
+    }
+
+    @objc
+    public func setCurrentKeyIndex(_ index: Int32) {
+        _state.mutate { $0.currentKeyIndex = index % options.keyRingSize }
     }
 
     // MARK: - Equal

--- a/Sources/LiveKit/E2EE/KeyProvider.swift
+++ b/Sources/LiveKit/E2EE/KeyProvider.swift
@@ -20,6 +20,7 @@ internal import LiveKitWebRTC
 
 public let defaultRatchetSalt: String = "LKFrameEncryptionKey"
 public let defaultMagicBytes: String = "LK-ROCKS"
+// Disable automatic ratcheting for the default shared key mode
 public let defaultRatchetWindowSize: Int32 = 0
 public let defaultFailureTolerance: Int32 = -1
 public let defaultKeyRingSize: Int32 = 16

--- a/Sources/LiveKit/E2EE/KeyProvider.swift
+++ b/Sources/LiveKit/E2EE/KeyProvider.swift
@@ -20,7 +20,7 @@ internal import LiveKitWebRTC
 
 public let defaultRatchetSalt: String = "LKFrameEncryptionKey"
 public let defaultMagicBytes: String = "LK-ROCKS"
-public let defaultRatchetWindowSize: Int32 = 8
+public let defaultRatchetWindowSize: Int32 = 0
 public let defaultFailureTolerance: Int32 = -1
 public let defaultKeyRingSize: Int32 = 16
 

--- a/Sources/LiveKit/E2EE/KeyProvider.swift
+++ b/Sources/LiveKit/E2EE/KeyProvider.swift
@@ -20,7 +20,7 @@ internal import LiveKitWebRTC
 
 public let defaultRatchetSalt: String = "LKFrameEncryptionKey"
 public let defaultMagicBytes: String = "LK-ROCKS"
-public let defaultRatchetWindowSize: Int32 = 0
+public let defaultRatchetWindowSize: Int32 = 8
 public let defaultFailureTolerance: Int32 = -1
 public let defaultKeyRingSize: Int32 = 16
 

--- a/Sources/LiveKit/E2EE/KeyProvider.swift
+++ b/Sources/LiveKit/E2EE/KeyProvider.swift
@@ -100,6 +100,8 @@ public final class BaseKeyProvider: NSObject, Loggable, Sendable {
 
     private let _state = StateSync(State())
 
+    // MARK: Init
+
     public init(isSharedKey: Bool, sharedKey: String? = nil) {
         options = KeyProviderOptions(sharedKey: isSharedKey)
         rtcKeyProvider = LKRTCFrameCryptorKeyProvider(ratchetSalt: options.ratchetSalt,
@@ -123,6 +125,8 @@ public final class BaseKeyProvider: NSObject, Loggable, Sendable {
                                                       failureTolerance: options.failureTolerance,
                                                       keyRingSize: options.keyRingSize)
     }
+
+    // MARK: - Key management
 
     public func setKey(key: String, participantId: String? = nil, index: Int32? = nil) {
         let targetIndex = index ?? getCurrentKeyIndex()

--- a/Sources/LiveKit/E2EE/Options.swift
+++ b/Sources/LiveKit/E2EE/Options.swift
@@ -16,6 +16,8 @@
 
 import Foundation
 
+internal import LiveKitWebRTC
+
 @objc
 public enum EncryptionType: Int, Sendable {
     case none
@@ -31,6 +33,10 @@ extension EncryptionType {
         case .custom: .custom
         default: .custom
         }
+    }
+
+    func toRTCType() -> LKRTCCryptorAlgorithm {
+        .aesGcm
     }
 }
 

--- a/Sources/LiveKit/E2EE/Options.swift
+++ b/Sources/LiveKit/E2EE/Options.swift
@@ -45,7 +45,7 @@ extension Livekit_Encryption.TypeEnum {
     }
 }
 
-@available(*, deprecated, message: "Use EncryptionOptions instead that will enable data channel encryption (requires support from all clients).")
+@available(*, deprecated, message: "Migrate to 'EncryptionOptions' instead. Important: It will enable data channel encryption by default (requires support from all platforms).")
 @objc
 public final class E2EEOptions: NSObject, Sendable {
     @objc

--- a/Sources/LiveKit/E2EE/Options.swift
+++ b/Sources/LiveKit/E2EE/Options.swift
@@ -34,10 +34,6 @@ extension EncryptionType {
         default: .custom
         }
     }
-
-    func toRTCType() -> LKRTCCryptorAlgorithm {
-        .aesGcm
-    }
 }
 
 extension Livekit_Encryption.TypeEnum {

--- a/Sources/LiveKit/E2EE/Options.swift
+++ b/Sources/LiveKit/E2EE/Options.swift
@@ -16,8 +16,6 @@
 
 import Foundation
 
-internal import LiveKitWebRTC
-
 @objc
 public enum EncryptionType: Int, Sendable {
     case none

--- a/Sources/LiveKit/E2EE/Options.swift
+++ b/Sources/LiveKit/E2EE/Options.swift
@@ -45,8 +45,40 @@ extension Livekit_Encryption.TypeEnum {
     }
 }
 
+@available(*, deprecated, message: "Use EncryptionOptions instead that will enable data channel encryption (requires support from all clients).")
 @objc
 public final class E2EEOptions: NSObject, Sendable {
+    @objc
+    public let keyProvider: BaseKeyProvider
+
+    @objc
+    public let encryptionType: EncryptionType
+
+    public init(keyProvider: BaseKeyProvider,
+                encryptionType: EncryptionType = .gcm)
+    {
+        self.keyProvider = keyProvider
+        self.encryptionType = encryptionType
+    }
+
+    // MARK: - Equal
+
+    override public func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return keyProvider == other.keyProvider &&
+            encryptionType == other.encryptionType
+    }
+
+    override public var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(keyProvider)
+        hasher.combine(encryptionType)
+        return hasher.finalize()
+    }
+}
+
+@objc
+public final class EncryptionOptions: NSObject, Sendable {
     @objc
     public let keyProvider: BaseKeyProvider
 

--- a/Sources/LiveKit/E2EE/Protos+E2EE.swift
+++ b/Sources/LiveKit/E2EE/Protos+E2EE.swift
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+internal import LiveKitWebRTC
+
+// MARK: - EncryptedPacket Extensions
+
+extension Livekit_EncryptedPacket {
+    init(from rtcPacket: LKRTCEncryptedPacket) {
+        encryptionType = .gcm
+        iv = rtcPacket.iv
+        keyIndex = rtcPacket.keyIndex
+        encryptedValue = rtcPacket.data
+    }
+
+    func toRTCEncryptedPacket() -> LKRTCEncryptedPacket {
+        LKRTCEncryptedPacket(
+            data: encryptedValue,
+            iv: iv,
+            keyIndex: keyIndex
+        )
+    }
+}
+
+// MARK: - EncryptedPacketPayload Extensions
+
+extension Livekit_EncryptedPacketPayload {
+    init(from dataPacket: Livekit_DataPacket) throws {
+        switch dataPacket.value {
+        case let .user(userPacket):
+            user = userPacket
+        case let .chatMessage(chatMessage):
+            self.chatMessage = chatMessage
+        case let .rpcRequest(rpcRequest):
+            self.rpcRequest = rpcRequest
+        case let .rpcAck(rpcAck):
+            self.rpcAck = rpcAck
+        case let .rpcResponse(rpcResponse):
+            self.rpcResponse = rpcResponse
+        case let .streamHeader(streamHeader):
+            self.streamHeader = streamHeader
+        case let .streamChunk(streamChunk):
+            self.streamChunk = streamChunk
+        case let .streamTrailer(streamTrailer):
+            self.streamTrailer = streamTrailer
+        case .encryptedPacket:
+            // Already encrypted, this shouldn't happen
+            throw LiveKitError(.encryptionFailed, message: "Attempting to encrypt an already encrypted packet")
+        case .sipDtmf, .transcription, .metrics, .speaker, .none:
+            // These types are not encrypted
+            throw LiveKitError(.encryptionFailed, message: "Unsupported packet type for encryption")
+        }
+    }
+
+    func applyTo(_ dataPacket: inout Livekit_DataPacket) {
+        switch value {
+        case let .user(userPacket):
+            dataPacket.user = userPacket
+        case let .chatMessage(chatMessage):
+            dataPacket.chatMessage = chatMessage
+        case let .rpcRequest(rpcRequest):
+            dataPacket.rpcRequest = rpcRequest
+        case let .rpcAck(rpcAck):
+            dataPacket.rpcAck = rpcAck
+        case let .rpcResponse(rpcResponse):
+            dataPacket.rpcResponse = rpcResponse
+        case let .streamHeader(streamHeader):
+            dataPacket.streamHeader = streamHeader
+        case let .streamChunk(streamChunk):
+            dataPacket.streamChunk = streamChunk
+        case let .streamTrailer(streamTrailer):
+            dataPacket.streamTrailer = streamTrailer
+        case .none:
+            break
+        }
+    }
+}
+
+// MARK: - DataPacket E2EE Helper Extensions
+
+extension Livekit_DataPacket {
+    var hasEncryptablePayload: Bool {
+        switch value {
+        case .user, .chatMessage, .rpcRequest, .rpcAck, .rpcResponse,
+             .streamHeader, .streamChunk, .streamTrailer:
+            true
+        case .encryptedPacket, .sipDtmf, .transcription, .metrics, .speaker, .none:
+            false
+        }
+    }
+
+    var hasDecryptablePayload: Bool {
+        switch value {
+        case .encryptedPacket: true
+        default: false
+        }
+    }
+
+    func encrypted(using encryptedPacket: Livekit_EncryptedPacket) -> Livekit_DataPacket {
+        var encrypted = Livekit_DataPacket()
+
+        // Copy metadata fields
+        encrypted.participantIdentity = participantIdentity
+        encrypted.participantSid = participantSid
+        encrypted.destinationIdentities = destinationIdentities
+        encrypted.sequence = sequence
+
+        // Set the encrypted payload
+        encrypted.encryptedPacket = encryptedPacket
+
+        return encrypted
+    }
+
+    func decrypted(with payload: Livekit_EncryptedPacketPayload) -> Livekit_DataPacket {
+        var decrypted = Livekit_DataPacket()
+
+        // Copy metadata fields
+        decrypted.participantIdentity = participantIdentity
+        decrypted.participantSid = participantSid
+        decrypted.destinationIdentities = destinationIdentities
+        decrypted.sequence = sequence
+
+        // Apply the decrypted payload
+        payload.applyTo(&decrypted)
+
+        return decrypted
+    }
+}

--- a/Sources/LiveKit/E2EE/Protos+E2EE.swift
+++ b/Sources/LiveKit/E2EE/Protos+E2EE.swift
@@ -90,7 +90,8 @@ extension Livekit_EncryptedPacketPayload {
 // MARK: - DataPacket
 
 extension Livekit_DataPacket {
-    var decrypt: Livekit_EncryptedPacket? {
+    // Skip the default value returned from protobufs
+    var encryptedPacketOrNil: Livekit_EncryptedPacket? {
         switch value {
         case .encryptedPacket: encryptedPacket
         default: nil

--- a/Sources/LiveKit/E2EE/Protos+E2EE.swift
+++ b/Sources/LiveKit/E2EE/Protos+E2EE.swift
@@ -42,8 +42,8 @@ extension Livekit_EncryptedPacket {
 extension Livekit_EncryptedPacketPayload {
     init?(dataPacket: Livekit_DataPacket) {
         switch dataPacket.value {
-        case let .user(userPacket):
-            user = userPacket
+        case let .user(user):
+            self.user = user
         case let .chatMessage(chatMessage):
             self.chatMessage = chatMessage
         case let .rpcRequest(rpcRequest):

--- a/Sources/LiveKit/Errors.swift
+++ b/Sources/LiveKit/Errors.swift
@@ -57,9 +57,8 @@ public enum LiveKitErrorType: Int, Sendable {
     case codecNotSupported = 901
 
     // Encryption
-    case encryptionTypeMismatch = 1001
-    case encryptionFailed = 1002
-    case decryptionFailed = 1003
+    case encryptionFailed = 1001
+    case decryptionFailed = 1002
 }
 
 extension LiveKitErrorType: CustomStringConvertible {
@@ -113,8 +112,6 @@ extension LiveKitErrorType: CustomStringConvertible {
             "Encryption failed"
         case .decryptionFailed:
             "Decryption failed"
-        case .encryptionTypeMismatch:
-            "Encryption type mismatch"
         default: "Unknown"
         }
     }

--- a/Sources/LiveKit/Errors.swift
+++ b/Sources/LiveKit/Errors.swift
@@ -55,6 +55,11 @@ public enum LiveKitErrorType: Int, Sendable {
     case audioSession = 802
 
     case codecNotSupported = 901
+
+    // Encryption
+    case encryptionTypeMismatch = 1001
+    case encryptionFailed = 1002
+    case decryptionFailed = 1003
 }
 
 extension LiveKitErrorType: CustomStringConvertible {
@@ -102,6 +107,14 @@ extension LiveKitErrorType: CustomStringConvertible {
             "Audio Engine Error"
         case .audioSession:
             "Audio Session Error"
+        case .codecNotSupported:
+            "Codec not supported"
+        case .encryptionFailed:
+            "Encryption failed"
+        case .decryptionFailed:
+            "Decryption failed"
+        case .encryptionTypeMismatch:
+            "Encryption type mismatch"
         default: "Unknown"
         }
     }

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -635,7 +635,7 @@ extension LocalParticipant {
                                                          name: addTrackName,
                                                          type: track.kind.toPBType(),
                                                          source: track.source.toPBType(),
-                                                         encryption: room.e2eeManager?.e2eeOptions.encryptionType.toPBType() ?? .none,
+                                                         encryption: room.e2eeManager?.encryptionType.toPBType() ?? .none,
                                                          populatorFunc)
             }
 

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -635,7 +635,7 @@ extension LocalParticipant {
                                                          name: addTrackName,
                                                          type: track.kind.toPBType(),
                                                          source: track.source.toPBType(),
-                                                         encryption: room.e2eeManager?.encryptionType.toPBType() ?? .none,
+                                                         encryption: room.e2eeManager?.frameEncryptionType.toPBType() ?? .none,
                                                          populatorFunc)
             }
 

--- a/Sources/LiveKit/Protocols/ParticipantDelegate.swift
+++ b/Sources/LiveKit/Protocols/ParticipantDelegate.swift
@@ -130,7 +130,7 @@ public protocol ParticipantDelegate: AnyObject, Sendable {
 
     /// Data was received from a ``RemoteParticipant``.
     @objc optional
-    func participant(_ participant: RemoteParticipant, didReceiveData data: Data, forTopic topic: String)
+    func participant(_ participant: RemoteParticipant, didReceiveData data: Data, forTopic topic: String, encryptionType: EncryptionType)
 
     // MARK: - Deprecated
 

--- a/Sources/LiveKit/Protocols/ParticipantDelegate.swift
+++ b/Sources/LiveKit/Protocols/ParticipantDelegate.swift
@@ -134,6 +134,11 @@ public protocol ParticipantDelegate: AnyObject, Sendable {
 
     // MARK: - Deprecated
 
+    /// Renamed to ``ParticipantDelegate/participant(_:didReceiveData:forTopic:encryptionType:)``.
+    @available(*, unavailable, renamed: "participant(_:didReceiveData:forTopic:encryptionType:)")
+    @objc optional
+    func participant(_ participant: RemoteParticipant, didReceiveData data: Data, forTopic topic: String)
+
     /// Renamed to ``ParticipantDelegate/participant(_:didUpdateMetadata:)``.
     @available(*, unavailable, renamed: "participant(_:didUpdateMetadata:)")
     @objc(participant:didUpdateMetadata_:) optional

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -156,6 +156,10 @@ public protocol RoomDelegate: AnyObject, Sendable {
     @objc optional
     func room(_ room: Room, trackPublication: TrackPublication, didUpdateE2EEState state: E2EEState)
 
+    /// Failed to decrypt a data packet when E2EE is enabled.
+    @objc optional
+    func room(_ room: Room, didFailToDecryptDataWithEror error: LiveKitError)
+
     /// ``TrackPublication/isMuted`` has updated.
     @objc optional
     func room(_ room: Room, participant: Participant, trackPublication: TrackPublication, didUpdateIsMuted isMuted: Bool)

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -153,7 +153,7 @@ public protocol RoomDelegate: AnyObject, Sendable {
     @objc optional
     func room(_ room: Room, participant: RemoteParticipant?, didReceiveData data: Data, forTopic topic: String, encryptionType: EncryptionType)
 
-    /// Failed to decrypt a data packet when E2EE is enabled.
+    /// Failed to decrypt a data packet when encryption is enabled.
     @objc optional
     func room(_ room: Room, didFailToDecryptDataWithEror error: LiveKitError)
 

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -153,12 +153,12 @@ public protocol RoomDelegate: AnyObject, Sendable {
     @objc optional
     func room(_ room: Room, participant: RemoteParticipant?, didReceiveData data: Data, forTopic topic: String, encryptionType: EncryptionType)
 
-    @objc optional
-    func room(_ room: Room, trackPublication: TrackPublication, didUpdateE2EEState state: E2EEState)
-
     /// Failed to decrypt a data packet when E2EE is enabled.
     @objc optional
     func room(_ room: Room, didFailToDecryptDataWithEror error: LiveKitError)
+
+    @objc optional
+    func room(_ room: Room, trackPublication: TrackPublication, didUpdateE2EEState state: E2EEState)
 
     /// ``TrackPublication/isMuted`` has updated.
     @objc optional
@@ -173,6 +173,11 @@ public protocol RoomDelegate: AnyObject, Sendable {
     func room(_ room: Room, participant: RemoteParticipant, trackPublication: RemoteTrackPublication, didUpdateIsSubscriptionAllowed isSubscriptionAllowed: Bool)
 
     // MARK: - Deprecated
+
+    /// Renamed to ``RoomDelegate/room(_:participant:didReceiveData:forTopic:encryptionType:)``.
+    @available(*, unavailable, renamed: "room(_:participant:didReceiveData:forTopic:encryptionType:)")
+    @objc optional
+    func room(_ room: Room, participant: RemoteParticipant?, didReceiveData data: Data, forTopic topic: String)
 
     /// Renamed to ``RoomDelegate/room(_:didUpdateConnectionState:from:)``.
     @available(*, unavailable, renamed: "room(_:didUpdateConnectionState:from:)")

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -151,7 +151,7 @@ public protocol RoomDelegate: AnyObject, Sendable {
 
     /// Received data from from a user or server. `participant` will be nil if broadcasted from server.
     @objc optional
-    func room(_ room: Room, participant: RemoteParticipant?, didReceiveData data: Data, forTopic topic: String)
+    func room(_ room: Room, participant: RemoteParticipant?, didReceiveData data: Data, forTopic topic: String, encryptionType: EncryptionType)
 
     @objc optional
     func room(_ room: Room, trackPublication: TrackPublication, didUpdateE2EEState state: E2EEState)

--- a/Sources/LiveKit/Protos/livekit_metrics.pb.swift
+++ b/Sources/LiveKit/Protos/livekit_metrics.pb.swift
@@ -321,40 +321,12 @@ struct Livekit_EventMetric: Sendable {
 fileprivate let _protobuf_package = "livekit"
 
 extension Livekit_MetricLabel: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "AGENTS_LLM_TTFT"),
-    1: .same(proto: "AGENTS_STT_TTFT"),
-    2: .same(proto: "AGENTS_TTS_TTFB"),
-    3: .same(proto: "CLIENT_VIDEO_SUBSCRIBER_FREEZE_COUNT"),
-    4: .same(proto: "CLIENT_VIDEO_SUBSCRIBER_TOTAL_FREEZE_DURATION"),
-    5: .same(proto: "CLIENT_VIDEO_SUBSCRIBER_PAUSE_COUNT"),
-    6: .same(proto: "CLIENT_VIDEO_SUBSCRIBER_TOTAL_PAUSES_DURATION"),
-    7: .same(proto: "CLIENT_AUDIO_SUBSCRIBER_CONCEALED_SAMPLES"),
-    8: .same(proto: "CLIENT_AUDIO_SUBSCRIBER_SILENT_CONCEALED_SAMPLES"),
-    9: .same(proto: "CLIENT_AUDIO_SUBSCRIBER_CONCEALMENT_EVENTS"),
-    10: .same(proto: "CLIENT_AUDIO_SUBSCRIBER_INTERRUPTION_COUNT"),
-    11: .same(proto: "CLIENT_AUDIO_SUBSCRIBER_TOTAL_INTERRUPTION_DURATION"),
-    12: .same(proto: "CLIENT_SUBSCRIBER_JITTER_BUFFER_DELAY"),
-    13: .same(proto: "CLIENT_SUBSCRIBER_JITTER_BUFFER_EMITTED_COUNT"),
-    14: .same(proto: "CLIENT_VIDEO_PUBLISHER_QUALITY_LIMITATION_DURATION_BANDWIDTH"),
-    15: .same(proto: "CLIENT_VIDEO_PUBLISHER_QUALITY_LIMITATION_DURATION_CPU"),
-    16: .same(proto: "CLIENT_VIDEO_PUBLISHER_QUALITY_LIMITATION_DURATION_OTHER"),
-    17: .same(proto: "PUBLISHER_RTT"),
-    18: .same(proto: "SERVER_MESH_RTT"),
-    19: .same(proto: "SUBSCRIBER_RTT"),
-    4096: .same(proto: "METRIC_LABEL_PREDEFINED_MAX_VALUE"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0AGENTS_LLM_TTFT\0\u{1}AGENTS_STT_TTFT\0\u{1}AGENTS_TTS_TTFB\0\u{1}CLIENT_VIDEO_SUBSCRIBER_FREEZE_COUNT\0\u{1}CLIENT_VIDEO_SUBSCRIBER_TOTAL_FREEZE_DURATION\0\u{1}CLIENT_VIDEO_SUBSCRIBER_PAUSE_COUNT\0\u{1}CLIENT_VIDEO_SUBSCRIBER_TOTAL_PAUSES_DURATION\0\u{1}CLIENT_AUDIO_SUBSCRIBER_CONCEALED_SAMPLES\0\u{1}CLIENT_AUDIO_SUBSCRIBER_SILENT_CONCEALED_SAMPLES\0\u{1}CLIENT_AUDIO_SUBSCRIBER_CONCEALMENT_EVENTS\0\u{1}CLIENT_AUDIO_SUBSCRIBER_INTERRUPTION_COUNT\0\u{1}CLIENT_AUDIO_SUBSCRIBER_TOTAL_INTERRUPTION_DURATION\0\u{1}CLIENT_SUBSCRIBER_JITTER_BUFFER_DELAY\0\u{1}CLIENT_SUBSCRIBER_JITTER_BUFFER_EMITTED_COUNT\0\u{1}CLIENT_VIDEO_PUBLISHER_QUALITY_LIMITATION_DURATION_BANDWIDTH\0\u{1}CLIENT_VIDEO_PUBLISHER_QUALITY_LIMITATION_DURATION_CPU\0\u{1}CLIENT_VIDEO_PUBLISHER_QUALITY_LIMITATION_DURATION_OTHER\0\u{1}PUBLISHER_RTT\0\u{1}SERVER_MESH_RTT\0\u{1}SUBSCRIBER_RTT\0\u{2}m?METRIC_LABEL_PREDEFINED_MAX_VALUE\0")
 }
 
 extension Livekit_MetricsBatch: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MetricsBatch"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "timestamp_ms"),
-    2: .standard(proto: "normalized_timestamp"),
-    3: .standard(proto: "str_data"),
-    4: .standard(proto: "time_series"),
-    5: .same(proto: "events"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}timestamp_ms\0\u{3}normalized_timestamp\0\u{3}str_data\0\u{3}time_series\0\u{1}events\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -408,13 +380,7 @@ extension Livekit_MetricsBatch: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
 
 extension Livekit_TimeSeriesMetric: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TimeSeriesMetric"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "label"),
-    2: .standard(proto: "participant_identity"),
-    3: .standard(proto: "track_sid"),
-    4: .same(proto: "samples"),
-    5: .same(proto: "rid"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}label\0\u{3}participant_identity\0\u{3}track_sid\0\u{1}samples\0\u{1}rid\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -464,11 +430,7 @@ extension Livekit_TimeSeriesMetric: SwiftProtobuf.Message, SwiftProtobuf._Messag
 
 extension Livekit_MetricSample: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MetricSample"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "timestamp_ms"),
-    2: .standard(proto: "normalized_timestamp"),
-    3: .same(proto: "value"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}timestamp_ms\0\u{3}normalized_timestamp\0\u{1}value\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -512,17 +474,7 @@ extension Livekit_MetricSample: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
 
 extension Livekit_EventMetric: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".EventMetric"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "label"),
-    2: .standard(proto: "participant_identity"),
-    3: .standard(proto: "track_sid"),
-    4: .standard(proto: "start_timestamp_ms"),
-    5: .standard(proto: "end_timestamp_ms"),
-    6: .standard(proto: "normalized_start_timestamp"),
-    7: .standard(proto: "normalized_end_timestamp"),
-    8: .same(proto: "metadata"),
-    9: .same(proto: "rid"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}label\0\u{3}participant_identity\0\u{3}track_sid\0\u{3}start_timestamp_ms\0\u{3}end_timestamp_ms\0\u{3}normalized_start_timestamp\0\u{3}normalized_end_timestamp\0\u{1}metadata\0\u{1}rid\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Sources/LiveKit/Protos/livekit_models.pb.swift
+++ b/Sources/LiveKit/Protos/livekit_models.pb.swift
@@ -1557,7 +1557,7 @@ struct Livekit_DataPacket: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Livekit_EncryptedPacket: @unchecked Sendable {
+struct Livekit_EncryptedPacket: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1695,7 +1695,7 @@ struct Livekit_SpeakerInfo: Sendable {
   init() {}
 }
 
-struct Livekit_UserPacket: @unchecked Sendable {
+struct Livekit_UserPacket: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2848,7 +2848,7 @@ struct Livekit_DataStream: Sendable {
     fileprivate var _totalLength: UInt64? = nil
   }
 
-  struct Chunk: @unchecked Sendable {
+  struct Chunk: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -2924,139 +2924,60 @@ struct Livekit_WebhookConfig: Sendable {
 fileprivate let _protobuf_package = "livekit"
 
 extension Livekit_AudioCodec: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "DEFAULT_AC"),
-    1: .same(proto: "OPUS"),
-    2: .same(proto: "AAC"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0DEFAULT_AC\0\u{1}OPUS\0\u{1}AAC\0")
 }
 
 extension Livekit_VideoCodec: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "DEFAULT_VC"),
-    1: .same(proto: "H264_BASELINE"),
-    2: .same(proto: "H264_MAIN"),
-    3: .same(proto: "H264_HIGH"),
-    4: .same(proto: "VP8"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0DEFAULT_VC\0\u{1}H264_BASELINE\0\u{1}H264_MAIN\0\u{1}H264_HIGH\0\u{1}VP8\0")
 }
 
 extension Livekit_ImageCodec: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "IC_DEFAULT"),
-    1: .same(proto: "IC_JPEG"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0IC_DEFAULT\0\u{1}IC_JPEG\0")
 }
 
 extension Livekit_BackupCodecPolicy: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "PREFER_REGRESSION"),
-    1: .same(proto: "SIMULCAST"),
-    2: .same(proto: "REGRESSION"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0PREFER_REGRESSION\0\u{1}SIMULCAST\0\u{1}REGRESSION\0")
 }
 
 extension Livekit_TrackType: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "AUDIO"),
-    1: .same(proto: "VIDEO"),
-    2: .same(proto: "DATA"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0AUDIO\0\u{1}VIDEO\0\u{1}DATA\0")
 }
 
 extension Livekit_TrackSource: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "UNKNOWN"),
-    1: .same(proto: "CAMERA"),
-    2: .same(proto: "MICROPHONE"),
-    3: .same(proto: "SCREEN_SHARE"),
-    4: .same(proto: "SCREEN_SHARE_AUDIO"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNKNOWN\0\u{1}CAMERA\0\u{1}MICROPHONE\0\u{1}SCREEN_SHARE\0\u{1}SCREEN_SHARE_AUDIO\0")
 }
 
 extension Livekit_VideoQuality: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "LOW"),
-    1: .same(proto: "MEDIUM"),
-    2: .same(proto: "HIGH"),
-    3: .same(proto: "OFF"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0LOW\0\u{1}MEDIUM\0\u{1}HIGH\0\u{1}OFF\0")
 }
 
 extension Livekit_ConnectionQuality: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "POOR"),
-    1: .same(proto: "GOOD"),
-    2: .same(proto: "EXCELLENT"),
-    3: .same(proto: "LOST"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0POOR\0\u{1}GOOD\0\u{1}EXCELLENT\0\u{1}LOST\0")
 }
 
 extension Livekit_ClientConfigSetting: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "UNSET"),
-    1: .same(proto: "DISABLED"),
-    2: .same(proto: "ENABLED"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNSET\0\u{1}DISABLED\0\u{1}ENABLED\0")
 }
 
 extension Livekit_DisconnectReason: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "UNKNOWN_REASON"),
-    1: .same(proto: "CLIENT_INITIATED"),
-    2: .same(proto: "DUPLICATE_IDENTITY"),
-    3: .same(proto: "SERVER_SHUTDOWN"),
-    4: .same(proto: "PARTICIPANT_REMOVED"),
-    5: .same(proto: "ROOM_DELETED"),
-    6: .same(proto: "STATE_MISMATCH"),
-    7: .same(proto: "JOIN_FAILURE"),
-    8: .same(proto: "MIGRATION"),
-    9: .same(proto: "SIGNAL_CLOSE"),
-    10: .same(proto: "ROOM_CLOSED"),
-    11: .same(proto: "USER_UNAVAILABLE"),
-    12: .same(proto: "USER_REJECTED"),
-    13: .same(proto: "SIP_TRUNK_FAILURE"),
-    14: .same(proto: "CONNECTION_TIMEOUT"),
-    15: .same(proto: "MEDIA_FAILURE"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNKNOWN_REASON\0\u{1}CLIENT_INITIATED\0\u{1}DUPLICATE_IDENTITY\0\u{1}SERVER_SHUTDOWN\0\u{1}PARTICIPANT_REMOVED\0\u{1}ROOM_DELETED\0\u{1}STATE_MISMATCH\0\u{1}JOIN_FAILURE\0\u{1}MIGRATION\0\u{1}SIGNAL_CLOSE\0\u{1}ROOM_CLOSED\0\u{1}USER_UNAVAILABLE\0\u{1}USER_REJECTED\0\u{1}SIP_TRUNK_FAILURE\0\u{1}CONNECTION_TIMEOUT\0\u{1}MEDIA_FAILURE\0")
 }
 
 extension Livekit_ReconnectReason: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "RR_UNKNOWN"),
-    1: .same(proto: "RR_SIGNAL_DISCONNECTED"),
-    2: .same(proto: "RR_PUBLISHER_FAILED"),
-    3: .same(proto: "RR_SUBSCRIBER_FAILED"),
-    4: .same(proto: "RR_SWITCH_CANDIDATE"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0RR_UNKNOWN\0\u{1}RR_SIGNAL_DISCONNECTED\0\u{1}RR_PUBLISHER_FAILED\0\u{1}RR_SUBSCRIBER_FAILED\0\u{1}RR_SWITCH_CANDIDATE\0")
 }
 
 extension Livekit_SubscriptionError: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "SE_UNKNOWN"),
-    1: .same(proto: "SE_CODEC_UNSUPPORTED"),
-    2: .same(proto: "SE_TRACK_NOTFOUND"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SE_UNKNOWN\0\u{1}SE_CODEC_UNSUPPORTED\0\u{1}SE_TRACK_NOTFOUND\0")
 }
 
 extension Livekit_AudioTrackFeature: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "TF_STEREO"),
-    1: .same(proto: "TF_NO_DTX"),
-    2: .same(proto: "TF_AUTO_GAIN_CONTROL"),
-    3: .same(proto: "TF_ECHO_CANCELLATION"),
-    4: .same(proto: "TF_NOISE_SUPPRESSION"),
-    5: .same(proto: "TF_ENHANCED_NOISE_CANCELLATION"),
-    6: .same(proto: "TF_PRECONNECT_BUFFER"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0TF_STEREO\0\u{1}TF_NO_DTX\0\u{1}TF_AUTO_GAIN_CONTROL\0\u{1}TF_ECHO_CANCELLATION\0\u{1}TF_NOISE_SUPPRESSION\0\u{1}TF_ENHANCED_NOISE_CANCELLATION\0\u{1}TF_PRECONNECT_BUFFER\0")
 }
 
 extension Livekit_Pagination: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Pagination"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "after_id"),
-    2: .same(proto: "limit"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}after_id\0\u{1}limit\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3091,9 +3012,7 @@ extension Livekit_Pagination: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
 
 extension Livekit_TokenPagination: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TokenPagination"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "token"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}token\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3123,12 +3042,7 @@ extension Livekit_TokenPagination: SwiftProtobuf.Message, SwiftProtobuf._Message
 
 extension Livekit_ListUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ListUpdate"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "set"),
-    2: .same(proto: "add"),
-    3: .same(proto: "del"),
-    4: .same(proto: "clear"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}set\0\u{1}add\0\u{1}del\0\u{1}clear\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3173,22 +3087,7 @@ extension Livekit_ListUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
 
 extension Livekit_Room: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Room"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "sid"),
-    2: .same(proto: "name"),
-    3: .standard(proto: "empty_timeout"),
-    14: .standard(proto: "departure_timeout"),
-    4: .standard(proto: "max_participants"),
-    5: .standard(proto: "creation_time"),
-    15: .standard(proto: "creation_time_ms"),
-    6: .standard(proto: "turn_password"),
-    7: .standard(proto: "enabled_codecs"),
-    8: .same(proto: "metadata"),
-    9: .standard(proto: "num_participants"),
-    11: .standard(proto: "num_publishers"),
-    10: .standard(proto: "active_recording"),
-    13: .same(proto: "version"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sid\0\u{1}name\0\u{3}empty_timeout\0\u{3}max_participants\0\u{3}creation_time\0\u{3}turn_password\0\u{3}enabled_codecs\0\u{1}metadata\0\u{3}num_participants\0\u{3}active_recording\0\u{3}num_publishers\0\u{2}\u{2}version\0\u{3}departure_timeout\0\u{3}creation_time_ms\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3287,10 +3186,7 @@ extension Livekit_Room: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
 
 extension Livekit_Codec: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Codec"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "mime"),
-    2: .standard(proto: "fmtp_line"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}mime\0\u{3}fmtp_line\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3325,11 +3221,7 @@ extension Livekit_Codec: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
 
 extension Livekit_PlayoutDelay: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PlayoutDelay"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "enabled"),
-    2: .same(proto: "min"),
-    3: .same(proto: "max"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}enabled\0\u{1}min\0\u{1}max\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3369,17 +3261,7 @@ extension Livekit_PlayoutDelay: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
 
 extension Livekit_ParticipantPermission: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ParticipantPermission"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "can_subscribe"),
-    2: .standard(proto: "can_publish"),
-    3: .standard(proto: "can_publish_data"),
-    9: .standard(proto: "can_publish_sources"),
-    7: .same(proto: "hidden"),
-    8: .same(proto: "recorder"),
-    10: .standard(proto: "can_update_metadata"),
-    11: .same(proto: "agent"),
-    12: .standard(proto: "can_subscribe_metrics"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}can_subscribe\0\u{3}can_publish\0\u{3}can_publish_data\0\u{2}\u{4}hidden\0\u{1}recorder\0\u{3}can_publish_sources\0\u{3}can_update_metadata\0\u{1}agent\0\u{3}can_subscribe_metrics\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3449,24 +3331,7 @@ extension Livekit_ParticipantPermission: SwiftProtobuf.Message, SwiftProtobuf._M
 
 extension Livekit_ParticipantInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ParticipantInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "sid"),
-    2: .same(proto: "identity"),
-    3: .same(proto: "state"),
-    4: .same(proto: "tracks"),
-    5: .same(proto: "metadata"),
-    6: .standard(proto: "joined_at"),
-    17: .standard(proto: "joined_at_ms"),
-    9: .same(proto: "name"),
-    10: .same(proto: "version"),
-    11: .same(proto: "permission"),
-    12: .same(proto: "region"),
-    13: .standard(proto: "is_publisher"),
-    14: .same(proto: "kind"),
-    15: .same(proto: "attributes"),
-    16: .standard(proto: "disconnect_reason"),
-    18: .standard(proto: "kind_details"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sid\0\u{1}identity\0\u{1}state\0\u{1}tracks\0\u{1}metadata\0\u{3}joined_at\0\u{2}\u{3}name\0\u{1}version\0\u{1}permission\0\u{1}region\0\u{3}is_publisher\0\u{1}kind\0\u{1}attributes\0\u{3}disconnect_reason\0\u{3}joined_at_ms\0\u{3}kind_details\0")
 
   fileprivate class _StorageClass {
     var _sid: String = String()
@@ -3486,15 +3351,11 @@ extension Livekit_ParticipantInfo: SwiftProtobuf.Message, SwiftProtobuf._Message
     var _disconnectReason: Livekit_DisconnectReason = .unknownReason
     var _kindDetails: [Livekit_ParticipantInfo.KindDetail] = []
 
-    #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
       // This will force a copy to be made of this reference when the first mutation occurs;
       // hence, it is safe to mark this as `nonisolated(unsafe)`.
       static nonisolated(unsafe) let defaultInstance = _StorageClass()
-    #else
-      static let defaultInstance = _StorageClass()
-    #endif
 
     private init() {}
 
@@ -3644,29 +3505,15 @@ extension Livekit_ParticipantInfo: SwiftProtobuf.Message, SwiftProtobuf._Message
 }
 
 extension Livekit_ParticipantInfo.State: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "JOINING"),
-    1: .same(proto: "JOINED"),
-    2: .same(proto: "ACTIVE"),
-    3: .same(proto: "DISCONNECTED"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0JOINING\0\u{1}JOINED\0\u{1}ACTIVE\0\u{1}DISCONNECTED\0")
 }
 
 extension Livekit_ParticipantInfo.Kind: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "STANDARD"),
-    1: .same(proto: "INGRESS"),
-    2: .same(proto: "EGRESS"),
-    3: .same(proto: "SIP"),
-    4: .same(proto: "AGENT"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0STANDARD\0\u{1}INGRESS\0\u{1}EGRESS\0\u{1}SIP\0\u{1}AGENT\0")
 }
 
 extension Livekit_ParticipantInfo.KindDetail: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "CLOUD_AGENT"),
-    1: .same(proto: "FORWARDED"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CLOUD_AGENT\0\u{1}FORWARDED\0")
 }
 
 extension Livekit_Encryption: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -3689,23 +3536,12 @@ extension Livekit_Encryption: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
 }
 
 extension Livekit_Encryption.TypeEnum: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "NONE"),
-    1: .same(proto: "GCM"),
-    2: .same(proto: "CUSTOM"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0NONE\0\u{1}GCM\0\u{1}CUSTOM\0")
 }
 
 extension Livekit_SimulcastCodecInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SimulcastCodecInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "mime_type"),
-    2: .same(proto: "mid"),
-    3: .same(proto: "cid"),
-    4: .same(proto: "layers"),
-    5: .standard(proto: "video_layer_mode"),
-    6: .standard(proto: "sdp_cid"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}mime_type\0\u{1}mid\0\u{1}cid\0\u{1}layers\0\u{3}video_layer_mode\0\u{3}sdp_cid\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3760,28 +3596,7 @@ extension Livekit_SimulcastCodecInfo: SwiftProtobuf.Message, SwiftProtobuf._Mess
 
 extension Livekit_TrackInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TrackInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "sid"),
-    2: .same(proto: "type"),
-    3: .same(proto: "name"),
-    4: .same(proto: "muted"),
-    5: .same(proto: "width"),
-    6: .same(proto: "height"),
-    7: .same(proto: "simulcast"),
-    8: .standard(proto: "disable_dtx"),
-    9: .same(proto: "source"),
-    10: .same(proto: "layers"),
-    11: .standard(proto: "mime_type"),
-    12: .same(proto: "mid"),
-    13: .same(proto: "codecs"),
-    14: .same(proto: "stereo"),
-    15: .standard(proto: "disable_red"),
-    16: .same(proto: "encryption"),
-    17: .same(proto: "stream"),
-    18: .same(proto: "version"),
-    19: .standard(proto: "audio_features"),
-    20: .standard(proto: "backup_codec_policy"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sid\0\u{1}type\0\u{1}name\0\u{1}muted\0\u{1}width\0\u{1}height\0\u{1}simulcast\0\u{3}disable_dtx\0\u{1}source\0\u{1}layers\0\u{3}mime_type\0\u{1}mid\0\u{1}codecs\0\u{1}stereo\0\u{3}disable_red\0\u{1}encryption\0\u{1}stream\0\u{1}version\0\u{3}audio_features\0\u{3}backup_codec_policy\0")
 
   fileprivate class _StorageClass {
     var _sid: String = String()
@@ -3805,15 +3620,11 @@ extension Livekit_TrackInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
     var _audioFeatures: [Livekit_AudioTrackFeature] = []
     var _backupCodecPolicy: Livekit_BackupCodecPolicy = .preferRegression
 
-    #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
       // This will force a copy to be made of this reference when the first mutation occurs;
       // hence, it is safe to mark this as `nonisolated(unsafe)`.
       static nonisolated(unsafe) let defaultInstance = _StorageClass()
-    #else
-      static let defaultInstance = _StorageClass()
-    #endif
 
     private init() {}
 
@@ -3988,15 +3799,7 @@ extension Livekit_TrackInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
 
 extension Livekit_VideoLayer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".VideoLayer"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "quality"),
-    2: .same(proto: "width"),
-    3: .same(proto: "height"),
-    4: .same(proto: "bitrate"),
-    5: .same(proto: "ssrc"),
-    6: .standard(proto: "spatial_layer"),
-    7: .same(proto: "rid"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}quality\0\u{1}width\0\u{1}height\0\u{1}bitrate\0\u{1}ssrc\0\u{3}spatial_layer\0\u{1}rid\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4055,35 +3858,12 @@ extension Livekit_VideoLayer: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
 }
 
 extension Livekit_VideoLayer.Mode: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "MODE_UNUSED"),
-    1: .same(proto: "ONE_SPATIAL_LAYER_PER_STREAM"),
-    2: .same(proto: "MULTIPLE_SPATIAL_LAYERS_PER_STREAM"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0MODE_UNUSED\0\u{1}ONE_SPATIAL_LAYER_PER_STREAM\0\u{1}MULTIPLE_SPATIAL_LAYERS_PER_STREAM\0")
 }
 
 extension Livekit_DataPacket: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DataPacket"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "kind"),
-    4: .standard(proto: "participant_identity"),
-    5: .standard(proto: "destination_identities"),
-    2: .same(proto: "user"),
-    3: .same(proto: "speaker"),
-    6: .standard(proto: "sip_dtmf"),
-    7: .same(proto: "transcription"),
-    8: .same(proto: "metrics"),
-    9: .standard(proto: "chat_message"),
-    10: .standard(proto: "rpc_request"),
-    11: .standard(proto: "rpc_ack"),
-    12: .standard(proto: "rpc_response"),
-    13: .standard(proto: "stream_header"),
-    14: .standard(proto: "stream_chunk"),
-    15: .standard(proto: "stream_trailer"),
-    18: .standard(proto: "encrypted_packet"),
-    16: .same(proto: "sequence"),
-    17: .standard(proto: "participant_sid"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}kind\0\u{1}user\0\u{1}speaker\0\u{3}participant_identity\0\u{3}destination_identities\0\u{3}sip_dtmf\0\u{1}transcription\0\u{1}metrics\0\u{3}chat_message\0\u{3}rpc_request\0\u{3}rpc_ack\0\u{3}rpc_response\0\u{3}stream_header\0\u{3}stream_chunk\0\u{3}stream_trailer\0\u{1}sequence\0\u{3}participant_sid\0\u{3}encrypted_packet\0")
 
   fileprivate class _StorageClass {
     var _kind: Livekit_DataPacket.Kind = .reliable
@@ -4093,15 +3873,11 @@ extension Livekit_DataPacket: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
     var _sequence: UInt32 = 0
     var _participantSid: String = String()
 
-    #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
       // This will force a copy to be made of this reference when the first mutation occurs;
       // hence, it is safe to mark this as `nonisolated(unsafe)`.
       static nonisolated(unsafe) let defaultInstance = _StorageClass()
-    #else
-      static let defaultInstance = _StorageClass()
-    #endif
 
     private init() {}
 
@@ -4413,20 +4189,12 @@ extension Livekit_DataPacket: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
 }
 
 extension Livekit_DataPacket.Kind: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "RELIABLE"),
-    1: .same(proto: "LOSSY"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0RELIABLE\0\u{1}LOSSY\0")
 }
 
 extension Livekit_EncryptedPacket: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".EncryptedPacket"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "encryption_type"),
-    2: .same(proto: "iv"),
-    3: .standard(proto: "key_index"),
-    4: .standard(proto: "encrypted_value"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}encryption_type\0\u{1}iv\0\u{3}key_index\0\u{3}encrypted_value\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4471,16 +4239,7 @@ extension Livekit_EncryptedPacket: SwiftProtobuf.Message, SwiftProtobuf._Message
 
 extension Livekit_EncryptedPacketPayload: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".EncryptedPacketPayload"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "user"),
-    3: .standard(proto: "chat_message"),
-    4: .standard(proto: "rpc_request"),
-    5: .standard(proto: "rpc_ack"),
-    6: .standard(proto: "rpc_response"),
-    7: .standard(proto: "stream_header"),
-    8: .standard(proto: "stream_chunk"),
-    9: .standard(proto: "stream_trailer"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}user\0\u{4}\u{2}chat_message\0\u{3}rpc_request\0\u{3}rpc_ack\0\u{3}rpc_response\0\u{3}stream_header\0\u{3}stream_chunk\0\u{3}stream_trailer\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4649,9 +4408,7 @@ extension Livekit_EncryptedPacketPayload: SwiftProtobuf.Message, SwiftProtobuf._
 
 extension Livekit_ActiveSpeakerUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ActiveSpeakerUpdate"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "speakers"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}speakers\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4681,11 +4438,7 @@ extension Livekit_ActiveSpeakerUpdate: SwiftProtobuf.Message, SwiftProtobuf._Mes
 
 extension Livekit_SpeakerInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SpeakerInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "sid"),
-    2: .same(proto: "level"),
-    3: .same(proto: "active"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sid\0\u{1}level\0\u{1}active\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4725,18 +4478,7 @@ extension Livekit_SpeakerInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
 
 extension Livekit_UserPacket: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UserPacket"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "participant_sid"),
-    5: .standard(proto: "participant_identity"),
-    2: .same(proto: "payload"),
-    3: .standard(proto: "destination_sids"),
-    6: .standard(proto: "destination_identities"),
-    4: .same(proto: "topic"),
-    8: .same(proto: "id"),
-    9: .standard(proto: "start_time"),
-    10: .standard(proto: "end_time"),
-    11: .same(proto: "nonce"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}participant_sid\0\u{1}payload\0\u{3}destination_sids\0\u{1}topic\0\u{3}participant_identity\0\u{3}destination_identities\0\u{2}\u{2}id\0\u{3}start_time\0\u{3}end_time\0\u{1}nonce\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4815,10 +4557,7 @@ extension Livekit_UserPacket: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
 
 extension Livekit_SipDTMF: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SipDTMF"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    3: .same(proto: "code"),
-    4: .same(proto: "digit"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\u{3}code\0\u{1}digit\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4853,11 +4592,7 @@ extension Livekit_SipDTMF: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
 
 extension Livekit_Transcription: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Transcription"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    2: .standard(proto: "transcribed_participant_identity"),
-    3: .standard(proto: "track_id"),
-    4: .same(proto: "segments"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{2}transcribed_participant_identity\0\u{3}track_id\0\u{1}segments\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4897,14 +4632,7 @@ extension Livekit_Transcription: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
 
 extension Livekit_TranscriptionSegment: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TranscriptionSegment"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "id"),
-    2: .same(proto: "text"),
-    3: .standard(proto: "start_time"),
-    4: .standard(proto: "end_time"),
-    5: .same(proto: "final"),
-    6: .same(proto: "language"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}text\0\u{3}start_time\0\u{3}end_time\0\u{1}final\0\u{1}language\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4959,14 +4687,7 @@ extension Livekit_TranscriptionSegment: SwiftProtobuf.Message, SwiftProtobuf._Me
 
 extension Livekit_ChatMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ChatMessage"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "id"),
-    2: .same(proto: "timestamp"),
-    3: .standard(proto: "edit_timestamp"),
-    4: .same(proto: "message"),
-    5: .same(proto: "deleted"),
-    6: .same(proto: "generated"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}timestamp\0\u{3}edit_timestamp\0\u{1}message\0\u{1}deleted\0\u{1}generated\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5025,13 +4746,7 @@ extension Livekit_ChatMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
 
 extension Livekit_RpcRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RpcRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "id"),
-    2: .same(proto: "method"),
-    3: .same(proto: "payload"),
-    4: .standard(proto: "response_timeout_ms"),
-    5: .same(proto: "version"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}method\0\u{1}payload\0\u{3}response_timeout_ms\0\u{1}version\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5081,9 +4796,7 @@ extension Livekit_RpcRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
 
 extension Livekit_RpcAck: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RpcAck"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "request_id"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}request_id\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5113,11 +4826,7 @@ extension Livekit_RpcAck: SwiftProtobuf.Message, SwiftProtobuf._MessageImplement
 
 extension Livekit_RpcResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RpcResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "request_id"),
-    2: .same(proto: "payload"),
-    3: .same(proto: "error"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}request_id\0\u{1}payload\0\u{1}error\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5184,11 +4893,7 @@ extension Livekit_RpcResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
 
 extension Livekit_RpcError: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RpcError"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "code"),
-    2: .same(proto: "message"),
-    3: .same(proto: "data"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}code\0\u{1}message\0\u{1}data\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5228,10 +4933,7 @@ extension Livekit_RpcError: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
 
 extension Livekit_ParticipantTracks: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ParticipantTracks"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "participant_sid"),
-    2: .standard(proto: "track_sids"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}participant_sid\0\u{3}track_sids\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5266,15 +4968,7 @@ extension Livekit_ParticipantTracks: SwiftProtobuf.Message, SwiftProtobuf._Messa
 
 extension Livekit_ServerInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "edition"),
-    2: .same(proto: "version"),
-    3: .same(proto: "protocol"),
-    4: .same(proto: "region"),
-    5: .standard(proto: "node_id"),
-    6: .standard(proto: "debug_info"),
-    7: .standard(proto: "agent_protocol"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}edition\0\u{1}version\0\u{1}protocol\0\u{1}region\0\u{3}node_id\0\u{3}debug_info\0\u{3}agent_protocol\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5333,27 +5027,12 @@ extension Livekit_ServerInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
 }
 
 extension Livekit_ServerInfo.Edition: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "Standard"),
-    1: .same(proto: "Cloud"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0Standard\0\u{1}Cloud\0")
 }
 
 extension Livekit_ClientInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "sdk"),
-    2: .same(proto: "version"),
-    3: .same(proto: "protocol"),
-    4: .same(proto: "os"),
-    5: .standard(proto: "os_version"),
-    6: .standard(proto: "device_model"),
-    7: .same(proto: "browser"),
-    8: .standard(proto: "browser_version"),
-    9: .same(proto: "address"),
-    10: .same(proto: "network"),
-    11: .standard(proto: "other_sdks"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sdk\0\u{1}version\0\u{1}protocol\0\u{1}os\0\u{3}os_version\0\u{3}device_model\0\u{1}browser\0\u{3}browser_version\0\u{1}address\0\u{1}network\0\u{3}other_sdks\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5432,34 +5111,12 @@ extension Livekit_ClientInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
 }
 
 extension Livekit_ClientInfo.SDK: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "UNKNOWN"),
-    1: .same(proto: "JS"),
-    2: .same(proto: "SWIFT"),
-    3: .same(proto: "ANDROID"),
-    4: .same(proto: "FLUTTER"),
-    5: .same(proto: "GO"),
-    6: .same(proto: "UNITY"),
-    7: .same(proto: "REACT_NATIVE"),
-    8: .same(proto: "RUST"),
-    9: .same(proto: "PYTHON"),
-    10: .same(proto: "CPP"),
-    11: .same(proto: "UNITY_WEB"),
-    12: .same(proto: "NODE"),
-    13: .same(proto: "UNREAL"),
-    14: .same(proto: "ESP32"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNKNOWN\0\u{1}JS\0\u{1}SWIFT\0\u{1}ANDROID\0\u{1}FLUTTER\0\u{1}GO\0\u{1}UNITY\0\u{1}REACT_NATIVE\0\u{1}RUST\0\u{1}PYTHON\0\u{1}CPP\0\u{1}UNITY_WEB\0\u{1}NODE\0\u{1}UNREAL\0\u{1}ESP32\0")
 }
 
 extension Livekit_ClientConfiguration: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientConfiguration"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "video"),
-    2: .same(proto: "screen"),
-    3: .standard(proto: "resume_connection"),
-    4: .standard(proto: "disabled_codecs"),
-    5: .standard(proto: "force_relay"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}video\0\u{1}screen\0\u{3}resume_connection\0\u{3}disabled_codecs\0\u{3}force_relay\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5513,9 +5170,7 @@ extension Livekit_ClientConfiguration: SwiftProtobuf.Message, SwiftProtobuf._Mes
 
 extension Livekit_VideoConfiguration: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".VideoConfiguration"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "hardware_encoder"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}hardware_encoder\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5545,10 +5200,7 @@ extension Livekit_VideoConfiguration: SwiftProtobuf.Message, SwiftProtobuf._Mess
 
 extension Livekit_DisabledCodecs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DisabledCodecs"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "codecs"),
-    2: .same(proto: "publish"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}codecs\0\u{1}publish\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5583,17 +5235,7 @@ extension Livekit_DisabledCodecs: SwiftProtobuf.Message, SwiftProtobuf._MessageI
 
 extension Livekit_RTPDrift: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RTPDrift"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "start_time"),
-    2: .standard(proto: "end_time"),
-    3: .same(proto: "duration"),
-    4: .standard(proto: "start_timestamp"),
-    5: .standard(proto: "end_timestamp"),
-    6: .standard(proto: "rtp_clock_ticks"),
-    7: .standard(proto: "drift_samples"),
-    8: .standard(proto: "drift_ms"),
-    9: .standard(proto: "clock_rate"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}start_time\0\u{3}end_time\0\u{1}duration\0\u{3}start_timestamp\0\u{3}end_timestamp\0\u{3}rtp_clock_ticks\0\u{3}drift_samples\0\u{3}drift_ms\0\u{3}clock_rate\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5667,53 +5309,7 @@ extension Livekit_RTPDrift: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
 
 extension Livekit_RTPStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RTPStats"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "start_time"),
-    2: .standard(proto: "end_time"),
-    3: .same(proto: "duration"),
-    4: .same(proto: "packets"),
-    5: .standard(proto: "packet_rate"),
-    6: .same(proto: "bytes"),
-    39: .standard(proto: "header_bytes"),
-    7: .same(proto: "bitrate"),
-    8: .standard(proto: "packets_lost"),
-    9: .standard(proto: "packet_loss_rate"),
-    10: .standard(proto: "packet_loss_percentage"),
-    11: .standard(proto: "packets_duplicate"),
-    12: .standard(proto: "packet_duplicate_rate"),
-    13: .standard(proto: "bytes_duplicate"),
-    40: .standard(proto: "header_bytes_duplicate"),
-    14: .standard(proto: "bitrate_duplicate"),
-    15: .standard(proto: "packets_padding"),
-    16: .standard(proto: "packet_padding_rate"),
-    17: .standard(proto: "bytes_padding"),
-    41: .standard(proto: "header_bytes_padding"),
-    18: .standard(proto: "bitrate_padding"),
-    19: .standard(proto: "packets_out_of_order"),
-    20: .same(proto: "frames"),
-    21: .standard(proto: "frame_rate"),
-    22: .standard(proto: "jitter_current"),
-    23: .standard(proto: "jitter_max"),
-    24: .standard(proto: "gap_histogram"),
-    25: .same(proto: "nacks"),
-    37: .standard(proto: "nack_acks"),
-    26: .standard(proto: "nack_misses"),
-    38: .standard(proto: "nack_repeated"),
-    27: .same(proto: "plis"),
-    28: .standard(proto: "last_pli"),
-    29: .same(proto: "firs"),
-    30: .standard(proto: "last_fir"),
-    31: .standard(proto: "rtt_current"),
-    32: .standard(proto: "rtt_max"),
-    33: .standard(proto: "key_frames"),
-    34: .standard(proto: "last_key_frame"),
-    35: .standard(proto: "layer_lock_plis"),
-    36: .standard(proto: "last_layer_lock_pli"),
-    44: .standard(proto: "packet_drift"),
-    45: .standard(proto: "ntp_report_drift"),
-    46: .standard(proto: "rebased_report_drift"),
-    47: .standard(proto: "received_report_drift"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}start_time\0\u{3}end_time\0\u{1}duration\0\u{1}packets\0\u{3}packet_rate\0\u{1}bytes\0\u{1}bitrate\0\u{3}packets_lost\0\u{3}packet_loss_rate\0\u{3}packet_loss_percentage\0\u{3}packets_duplicate\0\u{3}packet_duplicate_rate\0\u{3}bytes_duplicate\0\u{3}bitrate_duplicate\0\u{3}packets_padding\0\u{3}packet_padding_rate\0\u{3}bytes_padding\0\u{3}bitrate_padding\0\u{3}packets_out_of_order\0\u{1}frames\0\u{3}frame_rate\0\u{3}jitter_current\0\u{3}jitter_max\0\u{3}gap_histogram\0\u{1}nacks\0\u{3}nack_misses\0\u{1}plis\0\u{3}last_pli\0\u{1}firs\0\u{3}last_fir\0\u{3}rtt_current\0\u{3}rtt_max\0\u{3}key_frames\0\u{3}last_key_frame\0\u{3}layer_lock_plis\0\u{3}last_layer_lock_pli\0\u{3}nack_acks\0\u{3}nack_repeated\0\u{3}header_bytes\0\u{3}header_bytes_duplicate\0\u{3}header_bytes_padding\0\u{4}\u{3}packet_drift\0\u{3}ntp_report_drift\0\u{3}rebased_report_drift\0\u{3}received_report_drift\0")
 
   fileprivate class _StorageClass {
     var _startTime: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
@@ -5762,15 +5358,11 @@ extension Livekit_RTPStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     var _rebasedReportDrift: Livekit_RTPDrift? = nil
     var _receivedReportDrift: Livekit_RTPDrift? = nil
 
-    #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
       // This will force a copy to be made of this reference when the first mutation occurs;
       // hence, it is safe to mark this as `nonisolated(unsafe)`.
       static nonisolated(unsafe) let defaultInstance = _StorageClass()
-    #else
-      static let defaultInstance = _StorageClass()
-    #endif
 
     private init() {}
 
@@ -6095,15 +5687,7 @@ extension Livekit_RTPStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
 
 extension Livekit_RTCPSenderReportState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RTCPSenderReportState"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "rtp_timestamp"),
-    2: .standard(proto: "rtp_timestamp_ext"),
-    3: .standard(proto: "ntp_timestamp"),
-    4: .same(proto: "at"),
-    5: .standard(proto: "at_adjusted"),
-    6: .same(proto: "packets"),
-    7: .same(proto: "octets"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}rtp_timestamp\0\u{3}rtp_timestamp_ext\0\u{3}ntp_timestamp\0\u{1}at\0\u{3}at_adjusted\0\u{1}packets\0\u{1}octets\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -6163,16 +5747,7 @@ extension Livekit_RTCPSenderReportState: SwiftProtobuf.Message, SwiftProtobuf._M
 
 extension Livekit_RTPForwarderState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RTPForwarderState"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "started"),
-    2: .standard(proto: "reference_layer_spatial"),
-    3: .standard(proto: "pre_start_time"),
-    4: .standard(proto: "ext_first_timestamp"),
-    5: .standard(proto: "dummy_start_timestamp_offset"),
-    6: .standard(proto: "rtp_munger"),
-    7: .standard(proto: "vp8_munger"),
-    8: .standard(proto: "sender_report_state"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}started\0\u{3}reference_layer_spatial\0\u{3}pre_start_time\0\u{3}ext_first_timestamp\0\u{3}dummy_start_timestamp_offset\0\u{3}rtp_munger\0\u{3}vp8_munger\0\u{3}sender_report_state\0")
 
   fileprivate class _StorageClass {
     var _started: Bool = false
@@ -6184,15 +5759,11 @@ extension Livekit_RTPForwarderState: SwiftProtobuf.Message, SwiftProtobuf._Messa
     var _codecMunger: Livekit_RTPForwarderState.OneOf_CodecMunger?
     var _senderReportState: [Livekit_RTCPSenderReportState] = []
 
-    #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
       // This will force a copy to be made of this reference when the first mutation occurs;
       // hence, it is safe to mark this as `nonisolated(unsafe)`.
       static nonisolated(unsafe) let defaultInstance = _StorageClass()
-    #else
-      static let defaultInstance = _StorageClass()
-    #endif
 
     private init() {}
 
@@ -6307,14 +5878,7 @@ extension Livekit_RTPForwarderState: SwiftProtobuf.Message, SwiftProtobuf._Messa
 
 extension Livekit_RTPMungerState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RTPMungerState"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "ext_last_sequence_number"),
-    2: .standard(proto: "ext_second_last_sequence_number"),
-    3: .standard(proto: "ext_last_timestamp"),
-    4: .standard(proto: "ext_second_last_timestamp"),
-    5: .standard(proto: "last_marker"),
-    6: .standard(proto: "second_last_marker"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}ext_last_sequence_number\0\u{3}ext_second_last_sequence_number\0\u{3}ext_last_timestamp\0\u{3}ext_second_last_timestamp\0\u{3}last_marker\0\u{3}second_last_marker\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -6369,15 +5933,7 @@ extension Livekit_RTPMungerState: SwiftProtobuf.Message, SwiftProtobuf._MessageI
 
 extension Livekit_VP8MungerState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".VP8MungerState"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "ext_last_picture_id"),
-    2: .standard(proto: "picture_id_used"),
-    3: .standard(proto: "last_tl0_pic_idx"),
-    4: .standard(proto: "tl0_pic_idx_used"),
-    5: .standard(proto: "tid_used"),
-    6: .standard(proto: "last_key_idx"),
-    7: .standard(proto: "key_idx_used"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}ext_last_picture_id\0\u{3}picture_id_used\0\u{3}last_tl0_pic_idx\0\u{3}tl0_pic_idx_used\0\u{3}tid_used\0\u{3}last_key_idx\0\u{3}key_idx_used\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -6437,10 +5993,7 @@ extension Livekit_VP8MungerState: SwiftProtobuf.Message, SwiftProtobuf._MessageI
 
 extension Livekit_TimedVersion: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TimedVersion"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "unix_micro"),
-    2: .same(proto: "ticks"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}unix_micro\0\u{1}ticks\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -6493,23 +6046,12 @@ extension Livekit_DataStream: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
 }
 
 extension Livekit_DataStream.OperationType: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "CREATE"),
-    1: .same(proto: "UPDATE"),
-    2: .same(proto: "DELETE"),
-    3: .same(proto: "REACTION"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CREATE\0\u{1}UPDATE\0\u{1}DELETE\0\u{1}REACTION\0")
 }
 
 extension Livekit_DataStream.TextHeader: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Livekit_DataStream.protoMessageName + ".TextHeader"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "operation_type"),
-    2: .same(proto: "version"),
-    3: .standard(proto: "reply_to_stream_id"),
-    4: .standard(proto: "attached_stream_ids"),
-    5: .same(proto: "generated"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}operation_type\0\u{1}version\0\u{3}reply_to_stream_id\0\u{3}attached_stream_ids\0\u{1}generated\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -6559,9 +6101,7 @@ extension Livekit_DataStream.TextHeader: SwiftProtobuf.Message, SwiftProtobuf._M
 
 extension Livekit_DataStream.ByteHeader: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Livekit_DataStream.protoMessageName + ".ByteHeader"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "name"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -6591,17 +6131,7 @@ extension Livekit_DataStream.ByteHeader: SwiftProtobuf.Message, SwiftProtobuf._M
 
 extension Livekit_DataStream.Header: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Livekit_DataStream.protoMessageName + ".Header"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "stream_id"),
-    2: .same(proto: "timestamp"),
-    3: .same(proto: "topic"),
-    4: .standard(proto: "mime_type"),
-    5: .standard(proto: "total_length"),
-    7: .standard(proto: "encryption_type"),
-    8: .same(proto: "attributes"),
-    9: .standard(proto: "text_header"),
-    10: .standard(proto: "byte_header"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}stream_id\0\u{1}timestamp\0\u{1}topic\0\u{3}mime_type\0\u{3}total_length\0\u{4}\u{2}encryption_type\0\u{1}attributes\0\u{3}text_header\0\u{3}byte_header\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -6703,13 +6233,7 @@ extension Livekit_DataStream.Header: SwiftProtobuf.Message, SwiftProtobuf._Messa
 
 extension Livekit_DataStream.Chunk: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Livekit_DataStream.protoMessageName + ".Chunk"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "stream_id"),
-    2: .standard(proto: "chunk_index"),
-    3: .same(proto: "content"),
-    4: .same(proto: "version"),
-    5: .same(proto: "iv"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}stream_id\0\u{3}chunk_index\0\u{1}content\0\u{1}version\0\u{1}iv\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -6763,11 +6287,7 @@ extension Livekit_DataStream.Chunk: SwiftProtobuf.Message, SwiftProtobuf._Messag
 
 extension Livekit_DataStream.Trailer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Livekit_DataStream.protoMessageName + ".Trailer"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "stream_id"),
-    2: .same(proto: "reason"),
-    3: .same(proto: "attributes"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}stream_id\0\u{1}reason\0\u{1}attributes\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -6807,10 +6327,7 @@ extension Livekit_DataStream.Trailer: SwiftProtobuf.Message, SwiftProtobuf._Mess
 
 extension Livekit_WebhookConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WebhookConfig"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "url"),
-    2: .standard(proto: "signing_key"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}url\0\u{3}signing_key\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Sources/LiveKit/Protos/livekit_rtc.pb.swift
+++ b/Sources/LiveKit/Protos/livekit_rtc.pb.swift
@@ -1880,7 +1880,7 @@ struct Livekit_JoinRequest: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Livekit_WrappedJoinRequest: @unchecked Sendable {
+struct Livekit_WrappedJoinRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1948,48 +1948,20 @@ struct Livekit_MediaSectionsRequirement: Sendable {
 fileprivate let _protobuf_package = "livekit"
 
 extension Livekit_SignalTarget: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "PUBLISHER"),
-    1: .same(proto: "SUBSCRIBER"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0PUBLISHER\0\u{1}SUBSCRIBER\0")
 }
 
 extension Livekit_StreamState: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "ACTIVE"),
-    1: .same(proto: "PAUSED"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0ACTIVE\0\u{1}PAUSED\0")
 }
 
 extension Livekit_CandidateProtocol: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "UDP"),
-    1: .same(proto: "TCP"),
-    2: .same(proto: "TLS"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UDP\0\u{1}TCP\0\u{1}TLS\0")
 }
 
 extension Livekit_SignalRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SignalRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "offer"),
-    2: .same(proto: "answer"),
-    3: .same(proto: "trickle"),
-    4: .standard(proto: "add_track"),
-    5: .same(proto: "mute"),
-    6: .same(proto: "subscription"),
-    7: .standard(proto: "track_setting"),
-    8: .same(proto: "leave"),
-    10: .standard(proto: "update_layers"),
-    11: .standard(proto: "subscription_permission"),
-    12: .standard(proto: "sync_state"),
-    13: .same(proto: "simulate"),
-    14: .same(proto: "ping"),
-    15: .standard(proto: "update_metadata"),
-    16: .standard(proto: "ping_req"),
-    17: .standard(proto: "update_audio_track"),
-    18: .standard(proto: "update_video_track"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}offer\0\u{1}answer\0\u{1}trickle\0\u{3}add_track\0\u{1}mute\0\u{1}subscription\0\u{3}track_setting\0\u{1}leave\0\u{4}\u{2}update_layers\0\u{3}subscription_permission\0\u{3}sync_state\0\u{1}simulate\0\u{1}ping\0\u{3}update_metadata\0\u{3}ping_req\0\u{3}update_audio_track\0\u{3}update_video_track\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -2306,32 +2278,7 @@ extension Livekit_SignalRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
 
 extension Livekit_SignalResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SignalResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "join"),
-    2: .same(proto: "answer"),
-    3: .same(proto: "offer"),
-    4: .same(proto: "trickle"),
-    5: .same(proto: "update"),
-    6: .standard(proto: "track_published"),
-    8: .same(proto: "leave"),
-    9: .same(proto: "mute"),
-    10: .standard(proto: "speakers_changed"),
-    11: .standard(proto: "room_update"),
-    12: .standard(proto: "connection_quality"),
-    13: .standard(proto: "stream_state_update"),
-    14: .standard(proto: "subscribed_quality_update"),
-    15: .standard(proto: "subscription_permission_update"),
-    16: .standard(proto: "refresh_token"),
-    17: .standard(proto: "track_unpublished"),
-    18: .same(proto: "pong"),
-    19: .same(proto: "reconnect"),
-    20: .standard(proto: "pong_resp"),
-    21: .standard(proto: "subscription_response"),
-    22: .standard(proto: "request_response"),
-    23: .standard(proto: "track_subscribed"),
-    24: .standard(proto: "room_moved"),
-    25: .standard(proto: "media_sections_requirement"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}join\0\u{1}answer\0\u{1}offer\0\u{1}trickle\0\u{1}update\0\u{3}track_published\0\u{2}\u{2}leave\0\u{1}mute\0\u{3}speakers_changed\0\u{3}room_update\0\u{3}connection_quality\0\u{3}stream_state_update\0\u{3}subscribed_quality_update\0\u{3}subscription_permission_update\0\u{3}refresh_token\0\u{3}track_unpublished\0\u{1}pong\0\u{1}reconnect\0\u{3}pong_resp\0\u{3}subscription_response\0\u{3}request_response\0\u{3}track_subscribed\0\u{3}room_moved\0\u{3}media_sections_requirement\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -2762,12 +2709,7 @@ extension Livekit_SignalResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageI
 
 extension Livekit_SimulcastCodec: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SimulcastCodec"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "codec"),
-    2: .same(proto: "cid"),
-    4: .same(proto: "layers"),
-    5: .standard(proto: "video_layer_mode"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}codec\0\u{1}cid\0\u{2}\u{2}layers\0\u{3}video_layer_mode\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -2812,25 +2754,7 @@ extension Livekit_SimulcastCodec: SwiftProtobuf.Message, SwiftProtobuf._MessageI
 
 extension Livekit_AddTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".AddTrackRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "cid"),
-    2: .same(proto: "name"),
-    3: .same(proto: "type"),
-    4: .same(proto: "width"),
-    5: .same(proto: "height"),
-    6: .same(proto: "muted"),
-    7: .standard(proto: "disable_dtx"),
-    8: .same(proto: "source"),
-    9: .same(proto: "layers"),
-    10: .standard(proto: "simulcast_codecs"),
-    11: .same(proto: "sid"),
-    12: .same(proto: "stereo"),
-    13: .standard(proto: "disable_red"),
-    14: .same(proto: "encryption"),
-    15: .same(proto: "stream"),
-    16: .standard(proto: "backup_codec_policy"),
-    17: .standard(proto: "audio_features"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}cid\0\u{1}name\0\u{1}type\0\u{1}width\0\u{1}height\0\u{1}muted\0\u{3}disable_dtx\0\u{1}source\0\u{1}layers\0\u{3}simulcast_codecs\0\u{1}sid\0\u{1}stereo\0\u{3}disable_red\0\u{1}encryption\0\u{1}stream\0\u{3}backup_codec_policy\0\u{3}audio_features\0")
 
   fileprivate class _StorageClass {
     var _cid: String = String()
@@ -2851,15 +2775,11 @@ extension Livekit_AddTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._Message
     var _backupCodecPolicy: Livekit_BackupCodecPolicy = .preferRegression
     var _audioFeatures: [Livekit_AudioTrackFeature] = []
 
-    #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
       // This will force a copy to be made of this reference when the first mutation occurs;
       // hence, it is safe to mark this as `nonisolated(unsafe)`.
       static nonisolated(unsafe) let defaultInstance = _StorageClass()
-    #else
-      static let defaultInstance = _StorageClass()
-    #endif
 
     private init() {}
 
@@ -3012,11 +2932,7 @@ extension Livekit_AddTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._Message
 
 extension Livekit_TrickleRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TrickleRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "candidateInit"),
-    2: .same(proto: "target"),
-    3: .same(proto: "final"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}candidateInit\0\u{1}target\0\u{1}final\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3056,10 +2972,7 @@ extension Livekit_TrickleRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageI
 
 extension Livekit_MuteTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MuteTrackRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "sid"),
-    2: .same(proto: "muted"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sid\0\u{1}muted\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3094,23 +3007,7 @@ extension Livekit_MuteTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._Messag
 
 extension Livekit_JoinResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".JoinResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "room"),
-    2: .same(proto: "participant"),
-    3: .standard(proto: "other_participants"),
-    4: .standard(proto: "server_version"),
-    5: .standard(proto: "ice_servers"),
-    6: .standard(proto: "subscriber_primary"),
-    7: .standard(proto: "alternative_url"),
-    8: .standard(proto: "client_configuration"),
-    9: .standard(proto: "server_region"),
-    10: .standard(proto: "ping_timeout"),
-    11: .standard(proto: "ping_interval"),
-    12: .standard(proto: "server_info"),
-    13: .standard(proto: "sif_trailer"),
-    14: .standard(proto: "enabled_publish_codecs"),
-    15: .standard(proto: "fast_publish"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}room\0\u{1}participant\0\u{3}other_participants\0\u{3}server_version\0\u{3}ice_servers\0\u{3}subscriber_primary\0\u{3}alternative_url\0\u{3}client_configuration\0\u{3}server_region\0\u{3}ping_timeout\0\u{3}ping_interval\0\u{3}server_info\0\u{3}sif_trailer\0\u{3}enabled_publish_codecs\0\u{3}fast_publish\0")
 
   fileprivate class _StorageClass {
     var _room: Livekit_Room? = nil
@@ -3129,15 +3026,11 @@ extension Livekit_JoinResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
     var _enabledPublishCodecs: [Livekit_Codec] = []
     var _fastPublish: Bool = false
 
-    #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
       // This will force a copy to be made of this reference when the first mutation occurs;
       // hence, it is safe to mark this as `nonisolated(unsafe)`.
       static nonisolated(unsafe) let defaultInstance = _StorageClass()
-    #else
-      static let defaultInstance = _StorageClass()
-    #endif
 
     private init() {}
 
@@ -3282,12 +3175,7 @@ extension Livekit_JoinResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
 
 extension Livekit_ReconnectResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ReconnectResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "ice_servers"),
-    2: .standard(proto: "client_configuration"),
-    3: .standard(proto: "server_info"),
-    4: .standard(proto: "last_message_seq"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}ice_servers\0\u{3}client_configuration\0\u{3}server_info\0\u{3}last_message_seq\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3336,10 +3224,7 @@ extension Livekit_ReconnectResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
 
 extension Livekit_TrackPublishedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TrackPublishedResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "cid"),
-    2: .same(proto: "track"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}cid\0\u{1}track\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3378,9 +3263,7 @@ extension Livekit_TrackPublishedResponse: SwiftProtobuf.Message, SwiftProtobuf._
 
 extension Livekit_TrackUnpublishedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TrackUnpublishedResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "track_sid"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3410,11 +3293,7 @@ extension Livekit_TrackUnpublishedResponse: SwiftProtobuf.Message, SwiftProtobuf
 
 extension Livekit_SessionDescription: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SessionDescription"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "type"),
-    2: .same(proto: "sdp"),
-    3: .same(proto: "id"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}type\0\u{1}sdp\0\u{1}id\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3454,9 +3333,7 @@ extension Livekit_SessionDescription: SwiftProtobuf.Message, SwiftProtobuf._Mess
 
 extension Livekit_ParticipantUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ParticipantUpdate"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "participants"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}participants\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3486,11 +3363,7 @@ extension Livekit_ParticipantUpdate: SwiftProtobuf.Message, SwiftProtobuf._Messa
 
 extension Livekit_UpdateSubscription: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UpdateSubscription"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "track_sids"),
-    2: .same(proto: "subscribe"),
-    3: .standard(proto: "participant_tracks"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sids\0\u{1}subscribe\0\u{3}participant_tracks\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3530,15 +3403,7 @@ extension Livekit_UpdateSubscription: SwiftProtobuf.Message, SwiftProtobuf._Mess
 
 extension Livekit_UpdateTrackSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UpdateTrackSettings"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "track_sids"),
-    3: .same(proto: "disabled"),
-    4: .same(proto: "quality"),
-    5: .same(proto: "width"),
-    6: .same(proto: "height"),
-    7: .same(proto: "fps"),
-    8: .same(proto: "priority"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sids\0\u{2}\u{2}disabled\0\u{1}quality\0\u{1}width\0\u{1}height\0\u{1}fps\0\u{1}priority\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3598,10 +3463,7 @@ extension Livekit_UpdateTrackSettings: SwiftProtobuf.Message, SwiftProtobuf._Mes
 
 extension Livekit_UpdateLocalAudioTrack: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UpdateLocalAudioTrack"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "track_sid"),
-    2: .same(proto: "features"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0\u{1}features\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3636,11 +3498,7 @@ extension Livekit_UpdateLocalAudioTrack: SwiftProtobuf.Message, SwiftProtobuf._M
 
 extension Livekit_UpdateLocalVideoTrack: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UpdateLocalVideoTrack"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "track_sid"),
-    2: .same(proto: "width"),
-    3: .same(proto: "height"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0\u{1}width\0\u{1}height\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3680,12 +3538,7 @@ extension Livekit_UpdateLocalVideoTrack: SwiftProtobuf.Message, SwiftProtobuf._M
 
 extension Livekit_LeaveRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".LeaveRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "can_reconnect"),
-    2: .same(proto: "reason"),
-    3: .same(proto: "action"),
-    4: .same(proto: "regions"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}can_reconnect\0\u{1}reason\0\u{1}action\0\u{1}regions\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3733,19 +3586,12 @@ extension Livekit_LeaveRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
 }
 
 extension Livekit_LeaveRequest.Action: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "DISCONNECT"),
-    1: .same(proto: "RESUME"),
-    2: .same(proto: "RECONNECT"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0DISCONNECT\0\u{1}RESUME\0\u{1}RECONNECT\0")
 }
 
 extension Livekit_UpdateVideoLayers: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UpdateVideoLayers"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "track_sid"),
-    2: .same(proto: "layers"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0\u{1}layers\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3780,12 +3626,7 @@ extension Livekit_UpdateVideoLayers: SwiftProtobuf.Message, SwiftProtobuf._Messa
 
 extension Livekit_UpdateParticipantMetadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UpdateParticipantMetadata"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "metadata"),
-    2: .same(proto: "name"),
-    3: .same(proto: "attributes"),
-    4: .standard(proto: "request_id"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}metadata\0\u{1}name\0\u{1}attributes\0\u{3}request_id\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3830,11 +3671,7 @@ extension Livekit_UpdateParticipantMetadata: SwiftProtobuf.Message, SwiftProtobu
 
 extension Livekit_ICEServer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ICEServer"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "urls"),
-    2: .same(proto: "username"),
-    3: .same(proto: "credential"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}urls\0\u{1}username\0\u{1}credential\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3874,9 +3711,7 @@ extension Livekit_ICEServer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
 
 extension Livekit_SpeakersChanged: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SpeakersChanged"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "speakers"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}speakers\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3906,9 +3741,7 @@ extension Livekit_SpeakersChanged: SwiftProtobuf.Message, SwiftProtobuf._Message
 
 extension Livekit_RoomUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RoomUpdate"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "room"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}room\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3942,11 +3775,7 @@ extension Livekit_RoomUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
 
 extension Livekit_ConnectionQualityInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConnectionQualityInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "participant_sid"),
-    2: .same(proto: "quality"),
-    3: .same(proto: "score"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}participant_sid\0\u{1}quality\0\u{1}score\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3986,9 +3815,7 @@ extension Livekit_ConnectionQualityInfo: SwiftProtobuf.Message, SwiftProtobuf._M
 
 extension Livekit_ConnectionQualityUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConnectionQualityUpdate"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "updates"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}updates\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4018,11 +3845,7 @@ extension Livekit_ConnectionQualityUpdate: SwiftProtobuf.Message, SwiftProtobuf.
 
 extension Livekit_StreamStateInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamStateInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "participant_sid"),
-    2: .standard(proto: "track_sid"),
-    3: .same(proto: "state"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}participant_sid\0\u{3}track_sid\0\u{1}state\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4062,9 +3885,7 @@ extension Livekit_StreamStateInfo: SwiftProtobuf.Message, SwiftProtobuf._Message
 
 extension Livekit_StreamStateUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamStateUpdate"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "stream_states"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}stream_states\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4094,10 +3915,7 @@ extension Livekit_StreamStateUpdate: SwiftProtobuf.Message, SwiftProtobuf._Messa
 
 extension Livekit_SubscribedQuality: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubscribedQuality"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "quality"),
-    2: .same(proto: "enabled"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}quality\0\u{1}enabled\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4132,10 +3950,7 @@ extension Livekit_SubscribedQuality: SwiftProtobuf.Message, SwiftProtobuf._Messa
 
 extension Livekit_SubscribedCodec: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubscribedCodec"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "codec"),
-    2: .same(proto: "qualities"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}codec\0\u{1}qualities\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4170,11 +3985,7 @@ extension Livekit_SubscribedCodec: SwiftProtobuf.Message, SwiftProtobuf._Message
 
 extension Livekit_SubscribedQualityUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubscribedQualityUpdate"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "track_sid"),
-    2: .standard(proto: "subscribed_qualities"),
-    3: .standard(proto: "subscribed_codecs"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0\u{3}subscribed_qualities\0\u{3}subscribed_codecs\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4214,12 +4025,7 @@ extension Livekit_SubscribedQualityUpdate: SwiftProtobuf.Message, SwiftProtobuf.
 
 extension Livekit_TrackPermission: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TrackPermission"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "participant_sid"),
-    2: .standard(proto: "all_tracks"),
-    3: .standard(proto: "track_sids"),
-    4: .standard(proto: "participant_identity"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}participant_sid\0\u{3}all_tracks\0\u{3}track_sids\0\u{3}participant_identity\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4264,10 +4070,7 @@ extension Livekit_TrackPermission: SwiftProtobuf.Message, SwiftProtobuf._Message
 
 extension Livekit_SubscriptionPermission: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubscriptionPermission"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "all_participants"),
-    2: .standard(proto: "track_permissions"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}all_participants\0\u{3}track_permissions\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4302,11 +4105,7 @@ extension Livekit_SubscriptionPermission: SwiftProtobuf.Message, SwiftProtobuf._
 
 extension Livekit_SubscriptionPermissionUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubscriptionPermissionUpdate"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "participant_sid"),
-    2: .standard(proto: "track_sid"),
-    3: .same(proto: "allowed"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}participant_sid\0\u{3}track_sid\0\u{1}allowed\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4346,12 +4145,7 @@ extension Livekit_SubscriptionPermissionUpdate: SwiftProtobuf.Message, SwiftProt
 
 extension Livekit_RoomMovedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RoomMovedResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "room"),
-    2: .same(proto: "token"),
-    3: .same(proto: "participant"),
-    4: .standard(proto: "other_participants"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}room\0\u{1}token\0\u{1}participant\0\u{3}other_participants\0")
 
   fileprivate class _StorageClass {
     var _room: Livekit_Room? = nil
@@ -4359,15 +4153,11 @@ extension Livekit_RoomMovedResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
     var _participant: Livekit_ParticipantInfo? = nil
     var _otherParticipants: [Livekit_ParticipantInfo] = []
 
-    #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
       // This will force a copy to be made of this reference when the first mutation occurs;
       // hence, it is safe to mark this as `nonisolated(unsafe)`.
       static nonisolated(unsafe) let defaultInstance = _StorageClass()
-    #else
-      static let defaultInstance = _StorageClass()
-    #endif
 
     private init() {}
 
@@ -4446,15 +4236,7 @@ extension Livekit_RoomMovedResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
 
 extension Livekit_SyncState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SyncState"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "answer"),
-    2: .same(proto: "subscription"),
-    3: .standard(proto: "publish_tracks"),
-    4: .standard(proto: "data_channels"),
-    5: .same(proto: "offer"),
-    6: .standard(proto: "track_sids_disabled"),
-    7: .standard(proto: "datachannel_receive_states"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}answer\0\u{1}subscription\0\u{3}publish_tracks\0\u{3}data_channels\0\u{1}offer\0\u{3}track_sids_disabled\0\u{3}datachannel_receive_states\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4518,10 +4300,7 @@ extension Livekit_SyncState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
 
 extension Livekit_DataChannelReceiveState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DataChannelReceiveState"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "publisher_sid"),
-    2: .standard(proto: "last_seq"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}publisher_sid\0\u{3}last_seq\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4556,11 +4335,7 @@ extension Livekit_DataChannelReceiveState: SwiftProtobuf.Message, SwiftProtobuf.
 
 extension Livekit_DataChannelInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DataChannelInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "label"),
-    2: .same(proto: "id"),
-    3: .same(proto: "target"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}label\0\u{1}id\0\u{1}target\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4600,17 +4375,7 @@ extension Livekit_DataChannelInfo: SwiftProtobuf.Message, SwiftProtobuf._Message
 
 extension Livekit_SimulateScenario: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SimulateScenario"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "speaker_update"),
-    2: .standard(proto: "node_failure"),
-    3: .same(proto: "migration"),
-    4: .standard(proto: "server_leave"),
-    5: .standard(proto: "switch_candidate_protocol"),
-    6: .standard(proto: "subscriber_bandwidth"),
-    7: .standard(proto: "disconnect_signal_on_resume"),
-    8: .standard(proto: "disconnect_signal_on_resume_no_messages"),
-    9: .standard(proto: "leave_request_full_reconnect"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}speaker_update\0\u{3}node_failure\0\u{1}migration\0\u{3}server_leave\0\u{3}switch_candidate_protocol\0\u{3}subscriber_bandwidth\0\u{3}disconnect_signal_on_resume\0\u{3}disconnect_signal_on_resume_no_messages\0\u{3}leave_request_full_reconnect\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4751,10 +4516,7 @@ extension Livekit_SimulateScenario: SwiftProtobuf.Message, SwiftProtobuf._Messag
 
 extension Livekit_Ping: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Ping"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "timestamp"),
-    2: .same(proto: "rtt"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}timestamp\0\u{1}rtt\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4789,10 +4551,7 @@ extension Livekit_Ping: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
 
 extension Livekit_Pong: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Pong"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "last_ping_timestamp"),
-    2: .same(proto: "timestamp"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}last_ping_timestamp\0\u{1}timestamp\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4827,9 +4586,7 @@ extension Livekit_Pong: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
 
 extension Livekit_RegionSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RegionSettings"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "regions"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}regions\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4859,11 +4616,7 @@ extension Livekit_RegionSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageI
 
 extension Livekit_RegionInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RegionInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "region"),
-    2: .same(proto: "url"),
-    3: .same(proto: "distance"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}region\0\u{1}url\0\u{1}distance\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4903,10 +4656,7 @@ extension Livekit_RegionInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
 
 extension Livekit_SubscriptionResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubscriptionResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "track_sid"),
-    2: .same(proto: "err"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0\u{1}err\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4941,11 +4691,7 @@ extension Livekit_SubscriptionResponse: SwiftProtobuf.Message, SwiftProtobuf._Me
 
 extension Livekit_RequestResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RequestResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "request_id"),
-    2: .same(proto: "reason"),
-    3: .same(proto: "message"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}request_id\0\u{1}reason\0\u{1}message\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4984,19 +4730,12 @@ extension Livekit_RequestResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
 }
 
 extension Livekit_RequestResponse.Reason: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "OK"),
-    1: .same(proto: "NOT_FOUND"),
-    2: .same(proto: "NOT_ALLOWED"),
-    3: .same(proto: "LIMIT_EXCEEDED"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OK\0\u{1}NOT_FOUND\0\u{1}NOT_ALLOWED\0\u{1}LIMIT_EXCEEDED\0")
 }
 
 extension Livekit_TrackSubscribed: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TrackSubscribed"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "track_sid"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5026,12 +4765,7 @@ extension Livekit_TrackSubscribed: SwiftProtobuf.Message, SwiftProtobuf._Message
 
 extension Livekit_ConnectionSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConnectionSettings"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "auto_subscribe"),
-    2: .standard(proto: "adaptive_stream"),
-    3: .standard(proto: "subscriber_allow_pause"),
-    4: .standard(proto: "disable_ice_lite"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}auto_subscribe\0\u{3}adaptive_stream\0\u{3}subscriber_allow_pause\0\u{3}disable_ice_lite\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5080,18 +4814,7 @@ extension Livekit_ConnectionSettings: SwiftProtobuf.Message, SwiftProtobuf._Mess
 
 extension Livekit_JoinRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".JoinRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "client_info"),
-    2: .standard(proto: "connection_settings"),
-    3: .same(proto: "metadata"),
-    4: .standard(proto: "participant_attributes"),
-    5: .standard(proto: "add_track_requests"),
-    6: .standard(proto: "publisher_offer"),
-    7: .same(proto: "reconnect"),
-    8: .standard(proto: "reconnect_reason"),
-    9: .standard(proto: "participant_sid"),
-    10: .standard(proto: "sync_state"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}client_info\0\u{3}connection_settings\0\u{1}metadata\0\u{3}participant_attributes\0\u{3}add_track_requests\0\u{3}publisher_offer\0\u{1}reconnect\0\u{3}reconnect_reason\0\u{3}participant_sid\0\u{3}sync_state\0")
 
   fileprivate class _StorageClass {
     var _clientInfo: Livekit_ClientInfo? = nil
@@ -5105,15 +4828,11 @@ extension Livekit_JoinRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
     var _participantSid: String = String()
     var _syncState: Livekit_SyncState? = nil
 
-    #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
       // This will force a copy to be made of this reference when the first mutation occurs;
       // hence, it is safe to mark this as `nonisolated(unsafe)`.
       static nonisolated(unsafe) let defaultInstance = _StorageClass()
-    #else
-      static let defaultInstance = _StorageClass()
-    #endif
 
     private init() {}
 
@@ -5228,10 +4947,7 @@ extension Livekit_JoinRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
 
 extension Livekit_WrappedJoinRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WrappedJoinRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "compression"),
-    2: .standard(proto: "join_request"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}compression\0\u{3}join_request\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5265,18 +4981,12 @@ extension Livekit_WrappedJoinRequest: SwiftProtobuf.Message, SwiftProtobuf._Mess
 }
 
 extension Livekit_WrappedJoinRequest.Compression: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "NONE"),
-    1: .same(proto: "GZIP"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0NONE\0\u{1}GZIP\0")
 }
 
 extension Livekit_MediaSectionsRequirement: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MediaSectionsRequirement"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "num_audios"),
-    2: .standard(proto: "num_videos"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}num_audios\0\u{3}num_videos\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Sources/LiveKit/Types/Options/RoomOptions.swift
+++ b/Sources/LiveKit/Types/Options/RoomOptions.swift
@@ -102,6 +102,10 @@ public final class RoomOptions: NSObject, Sendable {
                 encryptionOptions: EncryptionOptions? = nil,
                 reportRemoteTrackStatistics: Bool = false)
     {
+        if e2eeOptions != nil, encryptionOptions != nil {
+            assertionFailure("Specifying both 'e2eeOptions' and 'encryptionOptions' is not supported. Migrate to 'EncryptionOptions' to enable data channel encryption (requires support from all platforms).")
+        }
+
         self.defaultCameraCaptureOptions = defaultCameraCaptureOptions
         self.defaultScreenShareCaptureOptions = defaultScreenShareCaptureOptions
         self.defaultAudioCaptureOptions = defaultAudioCaptureOptions

--- a/Sources/LiveKit/Types/Options/RoomOptions.swift
+++ b/Sources/LiveKit/Types/Options/RoomOptions.swift
@@ -65,6 +65,8 @@ public final class RoomOptions: NSObject, Sendable {
 
     /// E2EE Options
     public let e2eeOptions: E2EEOptions?
+    /// Encryption
+    public let encryptionOptions: EncryptionOptions?
 
     @objc
     public let reportRemoteTrackStatistics: Bool
@@ -81,6 +83,7 @@ public final class RoomOptions: NSObject, Sendable {
         stopLocalTrackOnUnpublish = true
         suspendLocalVideoTracksInBackground = true
         e2eeOptions = nil
+        encryptionOptions = nil
         reportRemoteTrackStatistics = false
     }
 
@@ -96,6 +99,7 @@ public final class RoomOptions: NSObject, Sendable {
                 stopLocalTrackOnUnpublish: Bool = true,
                 suspendLocalVideoTracksInBackground: Bool = true,
                 e2eeOptions: E2EEOptions? = nil,
+                encryptionOptions: EncryptionOptions? = nil,
                 reportRemoteTrackStatistics: Bool = false)
     {
         self.defaultCameraCaptureOptions = defaultCameraCaptureOptions
@@ -109,6 +113,7 @@ public final class RoomOptions: NSObject, Sendable {
         self.stopLocalTrackOnUnpublish = stopLocalTrackOnUnpublish
         self.suspendLocalVideoTracksInBackground = suspendLocalVideoTracksInBackground
         self.e2eeOptions = e2eeOptions
+        self.encryptionOptions = encryptionOptions
         self.reportRemoteTrackStatistics = reportRemoteTrackStatistics
     }
 
@@ -127,6 +132,7 @@ public final class RoomOptions: NSObject, Sendable {
             stopLocalTrackOnUnpublish == other.stopLocalTrackOnUnpublish &&
             suspendLocalVideoTracksInBackground == other.suspendLocalVideoTracksInBackground &&
             e2eeOptions == other.e2eeOptions &&
+            encryptionOptions == other.encryptionOptions &&
             reportRemoteTrackStatistics == other.reportRemoteTrackStatistics
     }
 
@@ -143,6 +149,7 @@ public final class RoomOptions: NSObject, Sendable {
         hasher.combine(stopLocalTrackOnUnpublish)
         hasher.combine(suspendLocalVideoTracksInBackground)
         hasher.combine(e2eeOptions)
+        hasher.combine(encryptionOptions)
         hasher.combine(reportRemoteTrackStatistics)
         return hasher.finalize()
     }

--- a/Sources/LiveKit/Types/Options/RoomOptions.swift
+++ b/Sources/LiveKit/Types/Options/RoomOptions.swift
@@ -99,13 +99,8 @@ public final class RoomOptions: NSObject, Sendable {
                 stopLocalTrackOnUnpublish: Bool = true,
                 suspendLocalVideoTracksInBackground: Bool = true,
                 e2eeOptions: E2EEOptions? = nil,
-                encryptionOptions: EncryptionOptions? = nil,
                 reportRemoteTrackStatistics: Bool = false)
     {
-        if e2eeOptions != nil, encryptionOptions != nil {
-            assertionFailure("Specifying both 'e2eeOptions' and 'encryptionOptions' is not supported. Migrate to 'EncryptionOptions' to enable data channel encryption (requires support from all platforms).")
-        }
-
         self.defaultCameraCaptureOptions = defaultCameraCaptureOptions
         self.defaultScreenShareCaptureOptions = defaultScreenShareCaptureOptions
         self.defaultAudioCaptureOptions = defaultAudioCaptureOptions
@@ -117,6 +112,35 @@ public final class RoomOptions: NSObject, Sendable {
         self.stopLocalTrackOnUnpublish = stopLocalTrackOnUnpublish
         self.suspendLocalVideoTracksInBackground = suspendLocalVideoTracksInBackground
         self.e2eeOptions = e2eeOptions
+        encryptionOptions = nil // don't pass both
+        self.reportRemoteTrackStatistics = reportRemoteTrackStatistics
+    }
+
+    @objc
+    public init(defaultCameraCaptureOptions: CameraCaptureOptions = CameraCaptureOptions(),
+                defaultScreenShareCaptureOptions: ScreenShareCaptureOptions = ScreenShareCaptureOptions(),
+                defaultAudioCaptureOptions: AudioCaptureOptions = AudioCaptureOptions(),
+                defaultVideoPublishOptions: VideoPublishOptions = VideoPublishOptions(),
+                defaultAudioPublishOptions: AudioPublishOptions = AudioPublishOptions(),
+                defaultDataPublishOptions: DataPublishOptions = DataPublishOptions(),
+                adaptiveStream: Bool = false,
+                dynacast: Bool = false,
+                stopLocalTrackOnUnpublish: Bool = true,
+                suspendLocalVideoTracksInBackground: Bool = true,
+                encryptionOptions: EncryptionOptions? = nil,
+                reportRemoteTrackStatistics: Bool = false)
+    {
+        self.defaultCameraCaptureOptions = defaultCameraCaptureOptions
+        self.defaultScreenShareCaptureOptions = defaultScreenShareCaptureOptions
+        self.defaultAudioCaptureOptions = defaultAudioCaptureOptions
+        self.defaultVideoPublishOptions = defaultVideoPublishOptions
+        self.defaultAudioPublishOptions = defaultAudioPublishOptions
+        self.defaultDataPublishOptions = defaultDataPublishOptions
+        self.adaptiveStream = adaptiveStream
+        self.dynacast = dynacast
+        self.stopLocalTrackOnUnpublish = stopLocalTrackOnUnpublish
+        self.suspendLocalVideoTracksInBackground = suspendLocalVideoTracksInBackground
+        e2eeOptions = nil // don't pass both
         self.encryptionOptions = encryptionOptions
         self.reportRemoteTrackStatistics = reportRemoteTrackStatistics
     }

--- a/Sources/LiveKit/Types/Options/RoomOptions.swift
+++ b/Sources/LiveKit/Types/Options/RoomOptions.swift
@@ -64,8 +64,10 @@ public final class RoomOptions: NSObject, Sendable {
     public let suspendLocalVideoTracksInBackground: Bool
 
     /// E2EE Options
+    @objc
     public let e2eeOptions: E2EEOptions?
     /// Encryption
+    @objc
     public let encryptionOptions: EncryptionOptions?
 
     @objc

--- a/Tests/LiveKitTests/DataChannel/EncryptedDataChannelTests.swift
+++ b/Tests/LiveKitTests/DataChannel/EncryptedDataChannelTests.swift
@@ -20,13 +20,13 @@ import XCTest
 
 class EncryptedDataChannelTests: LKTestCase, @unchecked Sendable {
     var receivedDataExpectation: XCTestExpectation!
-    var receivedData: Data?
+    var receivedData: Data!
     var decryptionErrorExpectation: XCTestExpectation!
     var lastDecryptionError: Error?
 
     override func setUp() {
         super.setUp()
-        receivedData = nil
+        receivedData = Data()
         lastDecryptionError = nil
     }
 

--- a/Tests/LiveKitTests/DataChannel/RealiableDataChannelTests.swift
+++ b/Tests/LiveKitTests/DataChannel/RealiableDataChannelTests.swift
@@ -17,18 +17,18 @@
 @testable import LiveKit
 import XCTest
 
-class DataChannelTests: LKTestCase, @unchecked Sendable {
+class RealiableDataChannelTests: LKTestCase, @unchecked Sendable {
     var receivedExpectation: XCTestExpectation!
     var receivedData: Data!
 
     override func setUp() {
         super.setUp()
-        receivedExpectation = expectation(description: "Data received")
         receivedData = Data()
     }
 
     func testReliableRetry() async throws {
         let iterations = 128
+        receivedExpectation = expectation(description: "Data received")
         receivedExpectation.expectedFulfillmentCount = iterations
 
         let testString = "abcdefghijklmnopqrstuvwxyz🔥"
@@ -69,7 +69,7 @@ class DataChannelTests: LKTestCase, @unchecked Sendable {
     }
 }
 
-extension DataChannelTests: RoomDelegate {
+extension RealiableDataChannelTests: RoomDelegate {
     func room(_: Room, participant _: RemoteParticipant?, didReceiveData data: Data, forTopic _: String, encryptionType _: EncryptionType) {
         receivedData.append(data)
         receivedExpectation.fulfill()

--- a/Tests/LiveKitTests/DataStream/ByteStreamInfoTests.swift
+++ b/Tests/LiveKitTests/DataStream/ByteStreamInfoTests.swift
@@ -25,6 +25,7 @@ class ByteStreamInfoTests: LKTestCase {
             timestamp: Date(timeIntervalSince1970: 100),
             totalLength: 128,
             attributes: ["key": "value"],
+            encryptionType: .none,
             mimeType: "image/jpeg",
             name: "filename.bin"
         )
@@ -37,7 +38,7 @@ class ByteStreamInfoTests: LKTestCase {
         XCTAssertEqual(header.attributes, info.attributes)
         XCTAssertEqual(header.byteHeader.name, info.name)
 
-        let newInfo = ByteStreamInfo(header, header.byteHeader)
+        let newInfo = ByteStreamInfo(header, header.byteHeader, encryptionType: .none)
         XCTAssertEqual(newInfo.id, info.id)
         XCTAssertEqual(newInfo.mimeType, info.mimeType)
         XCTAssertEqual(newInfo.topic, info.topic)

--- a/Tests/LiveKitTests/DataStream/ByteStreamInfoTests.swift
+++ b/Tests/LiveKitTests/DataStream/ByteStreamInfoTests.swift
@@ -38,7 +38,7 @@ class ByteStreamInfoTests: LKTestCase {
         XCTAssertEqual(header.attributes, info.attributes)
         XCTAssertEqual(header.byteHeader.name, info.name)
 
-        let newInfo = ByteStreamInfo(header, header.byteHeader, encryptionType: .none)
+        let newInfo = ByteStreamInfo(header, header.byteHeader, .none)
         XCTAssertEqual(newInfo.id, info.id)
         XCTAssertEqual(newInfo.mimeType, info.mimeType)
         XCTAssertEqual(newInfo.topic, info.topic)

--- a/Tests/LiveKitTests/DataStream/ByteStreamReaderTests.swift
+++ b/Tests/LiveKitTests/DataStream/ByteStreamReaderTests.swift
@@ -27,6 +27,7 @@ class ByteStreamReaderTests: LKTestCase, @unchecked Sendable {
         timestamp: Date(),
         totalLength: nil,
         attributes: [:],
+        encryptionType: .none,
         mimeType: "application/octet-stream",
         name: "filename.bin"
     )

--- a/Tests/LiveKitTests/DataStream/DataChannelTests.swift
+++ b/Tests/LiveKitTests/DataStream/DataChannelTests.swift
@@ -70,7 +70,7 @@ class DataChannelTests: LKTestCase, @unchecked Sendable {
 }
 
 extension DataChannelTests: RoomDelegate {
-    func room(_: Room, participant _: RemoteParticipant?, didReceiveData data: Data, forTopic _: String) {
+    func room(_: Room, participant _: RemoteParticipant?, didReceiveData data: Data, forTopic _: String, encryptionType _: EncryptionType) {
         receivedData.append(data)
         receivedExpectation.fulfill()
     }

--- a/Tests/LiveKitTests/DataStream/IncomingStreamManagerTests.swift
+++ b/Tests/LiveKitTests/DataStream/IncomingStreamManagerTests.swift
@@ -86,7 +86,7 @@ class IncomingStreamManagerTests: LKTestCase, @unchecked Sendable {
         header.streamID = streamID
         header.topic = topicName
         header.contentHeader = .byteHeader(Livekit_DataStream.ByteHeader())
-        await manager.handle(header: header, from: participant.stringValue)
+        await manager.handle(header: header, from: participant.stringValue, encryptionType: .none)
 
         // 2. Send chunk packets
         for (index, chunkData) in testChunks.enumerated() {
@@ -94,14 +94,14 @@ class IncomingStreamManagerTests: LKTestCase, @unchecked Sendable {
             chunk.streamID = streamID
             chunk.chunkIndex = UInt64(index)
             chunk.content = chunkData
-            await manager.handle(chunk: chunk)
+            await manager.handle(chunk: chunk, encryptionType: .none)
         }
 
         // 3. Send trailer packet
         var trailer = Livekit_DataStream.Trailer()
         trailer.streamID = streamID
         trailer.reason = "" // indicates normal closure
-        await manager.handle(trailer: trailer)
+        await manager.handle(trailer: trailer, encryptionType: .none)
 
         await fulfillment(
             of: [receiveExpectation],
@@ -136,7 +136,7 @@ class IncomingStreamManagerTests: LKTestCase, @unchecked Sendable {
         header.streamID = streamID
         header.topic = topicName
         header.contentHeader = .textHeader(Livekit_DataStream.TextHeader())
-        await manager.handle(header: header, from: participant.stringValue)
+        await manager.handle(header: header, from: participant.stringValue, encryptionType: .none)
 
         // 2. Send chunk packets
         for (index, chunkData) in testChunks.enumerated() {
@@ -144,14 +144,14 @@ class IncomingStreamManagerTests: LKTestCase, @unchecked Sendable {
             chunk.streamID = streamID
             chunk.chunkIndex = UInt64(index)
             chunk.content = Data(chunkData.utf8)
-            await manager.handle(chunk: chunk)
+            await manager.handle(chunk: chunk, encryptionType: .none)
         }
 
         // 3. Send trailer packet
         var trailer = Livekit_DataStream.Trailer()
         trailer.streamID = streamID
         trailer.reason = "" // indicates normal closure
-        await manager.handle(trailer: trailer)
+        await manager.handle(trailer: trailer, encryptionType: .none)
 
         await fulfillment(
             of: [receiveExpectation],
@@ -182,20 +182,20 @@ class IncomingStreamManagerTests: LKTestCase, @unchecked Sendable {
         header.topic = topicName
         header.contentHeader = .textHeader(Livekit_DataStream.TextHeader())
         header.totalLength = UInt64(testPayload.count)
-        await manager.handle(header: header, from: participant.stringValue)
+        await manager.handle(header: header, from: participant.stringValue, encryptionType: .none)
 
         // 2. Send chunk packet
         var chunk = Livekit_DataStream.Chunk()
         chunk.streamID = streamID
         chunk.chunkIndex = 0
         chunk.content = Data(testPayload)
-        await manager.handle(chunk: chunk)
+        await manager.handle(chunk: chunk, encryptionType: .none)
 
         // 3. Send trailer packet
         var trailer = Livekit_DataStream.Trailer()
         trailer.streamID = streamID
         trailer.reason = "" // indicates normal closure
-        await manager.handle(trailer: trailer)
+        await manager.handle(trailer: trailer, encryptionType: .none)
 
         await fulfillment(
             of: [throwsExpectation],
@@ -223,13 +223,13 @@ class IncomingStreamManagerTests: LKTestCase, @unchecked Sendable {
         header.streamID = streamID
         header.topic = topicName
         header.contentHeader = .byteHeader(Livekit_DataStream.ByteHeader())
-        await manager.handle(header: header, from: participant.stringValue)
+        await manager.handle(header: header, from: participant.stringValue, encryptionType: .none)
 
         // 2. Send trailer packet
         var trailer = Livekit_DataStream.Trailer()
         trailer.streamID = streamID
         trailer.reason = closureReason // indicates abnormal closure
-        await manager.handle(trailer: trailer)
+        await manager.handle(trailer: trailer, encryptionType: .none)
 
         await fulfillment(
             of: [throwsExpectation],
@@ -259,24 +259,64 @@ class IncomingStreamManagerTests: LKTestCase, @unchecked Sendable {
         header.topic = topicName
         header.contentHeader = .byteHeader(Livekit_DataStream.ByteHeader())
         header.totalLength = UInt64(testPayload.count + 10) // expect more bytes
-        await manager.handle(header: header, from: participant.stringValue)
+        await manager.handle(header: header, from: participant.stringValue, encryptionType: .none)
 
         // 2. Send chunk packet
         var chunk = Livekit_DataStream.Chunk()
         chunk.streamID = streamID
         chunk.chunkIndex = 0
         chunk.content = Data(testPayload)
-        await manager.handle(chunk: chunk)
+        await manager.handle(chunk: chunk, encryptionType: .none)
 
         // 3. Send trailer packet
         var trailer = Livekit_DataStream.Trailer()
         trailer.streamID = streamID
         trailer.reason = "" // indicates normal closure
-        await manager.handle(trailer: trailer)
+        await manager.handle(trailer: trailer, encryptionType: .none)
 
         await fulfillment(
             of: [throwsExpectation],
             timeout: 5
         )
+    }
+
+    func testEncryptionTypeMismatch() async throws {
+        let manager = IncomingStreamManager()
+        let topic = "test-encryption-mismatch"
+        let streamExpectation = expectation(description: "Stream should receive error")
+
+        try await manager.registerByteStreamHandler(for: topic) { reader, _ in
+            do {
+                _ = try await reader.readAll()
+            } catch let error as StreamError {
+                if case let .encryptionTypeMismatch(streamId, expected, received) = error {
+                    XCTAssertEqual(streamId, "test-stream-id")
+                    XCTAssertEqual(expected, .gcm) // Stream was created with .gcm
+                    XCTAssertEqual(received, .none) // But chunk sent with .none
+                    streamExpectation.fulfill()
+                } else {
+                    XCTFail("Expected encryptionTypeMismatch error, got \(error)")
+                }
+            }
+        }
+        var header = Livekit_DataStream.Header()
+        header.streamID = "test-stream-id"
+        header.topic = topic
+        header.mimeType = "application/octet-stream"
+        header.timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        header.contentHeader = .byteHeader(.with {
+            $0.name = "test-file.bin"
+        })
+
+        await manager.handle(header: header, from: "test-participant", encryptionType: .gcm)
+
+        var chunk = Livekit_DataStream.Chunk()
+        chunk.streamID = "test-stream-id"
+        chunk.chunkIndex = 0
+        chunk.content = Data("test data".utf8)
+
+        await manager.handle(chunk: chunk, encryptionType: .none)
+
+        await fulfillment(of: [streamExpectation], timeout: 5.0)
     }
 }

--- a/Tests/LiveKitTests/DataStream/IncomingStreamManagerTests.swift
+++ b/Tests/LiveKitTests/DataStream/IncomingStreamManagerTests.swift
@@ -289,8 +289,7 @@ class IncomingStreamManagerTests: LKTestCase, @unchecked Sendable {
             do {
                 _ = try await reader.readAll()
             } catch let error as StreamError {
-                if case let .encryptionTypeMismatch(streamId, expected, received) = error {
-                    XCTAssertEqual(streamId, "test-stream-id")
+                if case let .encryptionTypeMismatch(expected, received) = error {
                     XCTAssertEqual(expected, .gcm) // Stream was created with .gcm
                     XCTAssertEqual(received, .none) // But chunk sent with .none
                     streamExpectation.fulfill()

--- a/Tests/LiveKitTests/DataStream/OutgoingStreamManagerTests.swift
+++ b/Tests/LiveKitTests/DataStream/OutgoingStreamManagerTests.swift
@@ -64,6 +64,8 @@ class OutgoingStreamManagerTests: LKTestCase {
 
             default: XCTFail("Produced unexpected packet type")
             }
+        } encryptionProvider: {
+            .none
         }
 
         let writer = try await manager.streamBytes(
@@ -128,6 +130,8 @@ class OutgoingStreamManagerTests: LKTestCase {
 
             default: XCTFail("Produced unexpected packet type")
             }
+        } encryptionProvider: {
+            .none
         }
 
         let writer = try await manager.streamText(
@@ -158,6 +162,8 @@ class OutgoingStreamManagerTests: LKTestCase {
                 throw testError
             default: break
             }
+        } encryptionProvider: {
+            .none
         }
 
         let writer = try await manager.streamText(

--- a/Tests/LiveKitTests/DataStream/TextStreamInfoTests.swift
+++ b/Tests/LiveKitTests/DataStream/TextStreamInfoTests.swift
@@ -44,7 +44,7 @@ class TextStreamInfoTests: LKTestCase {
         XCTAssertEqual(header.textHeader.attachedStreamIds, info.attachedStreamIDs)
         XCTAssertEqual(header.textHeader.generated, info.generated)
 
-        let newInfo = TextStreamInfo(header, header.textHeader, encryptionType: .none)
+        let newInfo = TextStreamInfo(header, header.textHeader, .none)
         XCTAssertEqual(newInfo.id, info.id)
         XCTAssertEqual(newInfo.topic, info.topic)
         XCTAssertEqual(newInfo.timestamp, info.timestamp)

--- a/Tests/LiveKitTests/DataStream/TextStreamInfoTests.swift
+++ b/Tests/LiveKitTests/DataStream/TextStreamInfoTests.swift
@@ -25,6 +25,7 @@ class TextStreamInfoTests: LKTestCase {
             timestamp: Date(timeIntervalSince1970: 100),
             totalLength: 128,
             attributes: ["key": "value"],
+            encryptionType: .none,
             operationType: .reaction,
             version: 10,
             replyToStreamID: "replyID",
@@ -43,7 +44,7 @@ class TextStreamInfoTests: LKTestCase {
         XCTAssertEqual(header.textHeader.attachedStreamIds, info.attachedStreamIDs)
         XCTAssertEqual(header.textHeader.generated, info.generated)
 
-        let newInfo = TextStreamInfo(header, header.textHeader)
+        let newInfo = TextStreamInfo(header, header.textHeader, encryptionType: .none)
         XCTAssertEqual(newInfo.id, info.id)
         XCTAssertEqual(newInfo.topic, info.topic)
         XCTAssertEqual(newInfo.timestamp, info.timestamp)

--- a/Tests/LiveKitTests/DataStream/TextStreamReaderTests.swift
+++ b/Tests/LiveKitTests/DataStream/TextStreamReaderTests.swift
@@ -27,6 +27,7 @@ class TextStreamReaderTests: LKTestCase, @unchecked Sendable {
         timestamp: Date(),
         totalLength: nil,
         attributes: [:],
+        encryptionType: .none,
         operationType: .create,
         version: 1,
         replyToStreamID: nil,

--- a/Tests/LiveKitTests/E2EE/EncryptedDataChannelTests.swift
+++ b/Tests/LiveKitTests/E2EE/EncryptedDataChannelTests.swift
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+import LiveKitWebRTC
+import XCTest
+
+class EncryptedDataChannelTests: LKTestCase, @unchecked Sendable {
+    var receivedDataExpectation: XCTestExpectation!
+    var receivedData: Data?
+    var decryptionErrorExpectation: XCTestExpectation!
+    var lastDecryptionError: Error?
+
+    override func setUp() {
+        super.setUp()
+        receivedData = nil
+        lastDecryptionError = nil
+
+        receivedDataExpectation = expectation(description: "Data received")
+    }
+
+    // MARK: - Basic Encryption/Decryption Tests with withRooms
+
+    func testEncryptionDisabled() async throws {
+        let testMessage = "Hello, unencrypted world!"
+        let testData = testMessage.data(using: .utf8)!
+
+        try await withRooms([
+            RoomTestingOptions(canPublishData: true),
+            RoomTestingOptions(delegate: self, canSubscribe: true),
+        ]) { rooms in
+            let sender = rooms[0]
+            let remoteIdentity = try XCTUnwrap(sender.remoteParticipants.keys.first)
+
+            let userPacket = Livekit_UserPacket.with {
+                $0.payload = testData
+                $0.destinationIdentities = [remoteIdentity.stringValue]
+            }
+
+            try await sender.send(userPacket: userPacket, kind: .reliable)
+
+            await self.fulfillment(of: [self.receivedDataExpectation], timeout: 5)
+
+            let receivedMessage = String(data: self.receivedData!, encoding: .utf8)
+            XCTAssertEqual(receivedMessage, testMessage, "Received message should match sent message")
+        }
+    }
+
+    func testEncryptionWithSharedKey() async throws {
+        let testMessage = "Hello, encrypted world!"
+        let testData = testMessage.data(using: .utf8)!
+
+        try await withRooms([
+            RoomTestingOptions(canPublishData: true),
+            RoomTestingOptions(delegate: self, canSubscribe: true),
+        ]) { rooms in
+            let sender = rooms[0]
+            let remoteIdentity = try XCTUnwrap(sender.remoteParticipants.keys.first)
+
+            let userPacket = Livekit_UserPacket.with {
+                $0.payload = testData
+                $0.destinationIdentities = [remoteIdentity.stringValue]
+            }
+
+            try await sender.send(userPacket: userPacket, kind: .reliable)
+
+            await self.fulfillment(of: [self.receivedDataExpectation], timeout: 5)
+
+            let receivedMessage = String(data: self.receivedData!, encoding: .utf8)
+            XCTAssertEqual(receivedMessage, testMessage, "Received message should match sent message")
+        }
+    }
+}
+
+// MARK: - RoomDelegate Implementation
+
+extension EncryptedDataChannelTests: RoomDelegate {
+    func room(_: Room, participant _: RemoteParticipant?, didReceiveData data: Data, forTopic _: String) {
+        receivedData = data
+        receivedDataExpectation?.fulfill()
+    }
+
+    func room(_: Room, didFailToDecryptDataPacket _: Livekit_DataPacket, error: Error) {
+        lastDecryptionError = error
+        decryptionErrorExpectation?.fulfill()
+    }
+}

--- a/Tests/LiveKitTests/E2EE/EncryptedDataChannelTests.swift
+++ b/Tests/LiveKitTests/E2EE/EncryptedDataChannelTests.swift
@@ -301,7 +301,7 @@ class EncryptedDataChannelTests: LKTestCase, @unchecked Sendable {
     }
 }
 
-// MARK: - RoomDelegate Implementation
+// MARK: - RoomDelegate
 
 extension EncryptedDataChannelTests: RoomDelegate {
     func room(_: Room, participant _: RemoteParticipant?, didReceiveData data: Data, forTopic _: String, encryptionType _: EncryptionType) {

--- a/Tests/LiveKitTests/E2EE/EncryptedDataChannelTests.swift
+++ b/Tests/LiveKitTests/E2EE/EncryptedDataChannelTests.swift
@@ -69,11 +69,11 @@ class EncryptedDataChannelTests: LKTestCase, @unchecked Sendable {
 
         try await withRooms([
             RoomTestingOptions(
-                e2eeOptions: E2EEOptions(keyProvider: senderKeyProvider), canPublishData: true
+                encryptionOptions: EncryptionOptions(keyProvider: senderKeyProvider), canPublishData: true
             ),
             RoomTestingOptions(
                 delegate: self,
-                e2eeOptions: E2EEOptions(keyProvider: receiverKeyProvider), canSubscribe: true
+                encryptionOptions: EncryptionOptions(keyProvider: receiverKeyProvider), canSubscribe: true
             ),
         ]) { rooms in
             let sender = rooms[0]
@@ -116,12 +116,12 @@ class EncryptedDataChannelTests: LKTestCase, @unchecked Sendable {
 
         try await withRooms([
             RoomTestingOptions(
-                e2eeOptions: E2EEOptions(keyProvider: senderKeyProvider),
+                encryptionOptions: EncryptionOptions(keyProvider: senderKeyProvider),
                 canPublishData: true
             ),
             RoomTestingOptions(
                 delegate: self,
-                e2eeOptions: E2EEOptions(keyProvider: receiverKeyProvider),
+                encryptionOptions: EncryptionOptions(keyProvider: receiverKeyProvider),
                 canSubscribe: true
             ),
         ]) { rooms in
@@ -156,12 +156,12 @@ class EncryptedDataChannelTests: LKTestCase, @unchecked Sendable {
 
         try await withRooms([
             RoomTestingOptions(
-                e2eeOptions: E2EEOptions(keyProvider: senderKeyProvider),
+                encryptionOptions: EncryptionOptions(keyProvider: senderKeyProvider),
                 canPublishData: true
             ),
             RoomTestingOptions(
                 delegate: self,
-                e2eeOptions: E2EEOptions(keyProvider: receiverKeyProvider),
+                encryptionOptions: EncryptionOptions(keyProvider: receiverKeyProvider),
                 canSubscribe: true
             ),
         ]) { rooms in
@@ -212,12 +212,12 @@ class EncryptedDataChannelTests: LKTestCase, @unchecked Sendable {
 
         try await withRooms([
             RoomTestingOptions(
-                e2eeOptions: E2EEOptions(keyProvider: senderKeyProvider),
+                encryptionOptions: EncryptionOptions(keyProvider: senderKeyProvider),
                 canPublishData: true
             ),
             RoomTestingOptions(
                 delegate: self,
-                e2eeOptions: E2EEOptions(keyProvider: receiverKeyProvider),
+                encryptionOptions: EncryptionOptions(keyProvider: receiverKeyProvider),
                 canSubscribe: true
             ),
         ]) { rooms in
@@ -272,12 +272,12 @@ class EncryptedDataChannelTests: LKTestCase, @unchecked Sendable {
 
         try await withRooms([
             RoomTestingOptions(
-                e2eeOptions: E2EEOptions(keyProvider: senderKeyProvider),
+                encryptionOptions: EncryptionOptions(keyProvider: senderKeyProvider),
                 canPublishData: true
             ),
             RoomTestingOptions(
                 delegate: self,
-                e2eeOptions: E2EEOptions(keyProvider: receiverKeyProvider),
+                encryptionOptions: EncryptionOptions(keyProvider: receiverKeyProvider),
                 canSubscribe: true
             ),
         ]) { rooms in

--- a/Tests/LiveKitTests/E2EE/EncryptedDataChannelTests.swift
+++ b/Tests/LiveKitTests/E2EE/EncryptedDataChannelTests.swift
@@ -304,7 +304,7 @@ class EncryptedDataChannelTests: LKTestCase, @unchecked Sendable {
 // MARK: - RoomDelegate Implementation
 
 extension EncryptedDataChannelTests: RoomDelegate {
-    func room(_: Room, participant _: RemoteParticipant?, didReceiveData data: Data, forTopic _: String) {
+    func room(_: Room, participant _: RemoteParticipant?, didReceiveData data: Data, forTopic _: String, encryptionType _: EncryptionType) {
         receivedData = data
         receivedDataExpectation?.fulfill()
     }

--- a/Tests/LiveKitTests/Support/Room.swift
+++ b/Tests/LiveKitTests/Support/Room.swift
@@ -22,7 +22,7 @@ struct RoomTestingOptions {
     let url: String?
     let token: String?
     let enableMicrophone: Bool
-    let e2eeOptions: E2EEOptions?
+    let encryptionOptions: EncryptionOptions?
 
     // Perms
     let canPublish: Bool
@@ -34,7 +34,7 @@ struct RoomTestingOptions {
          url: String? = nil,
          token: String? = nil,
          enableMicrophone: Bool = false,
-         e2eeOptions: E2EEOptions? = nil,
+         encryptionOptions: EncryptionOptions? = nil,
          canPublish: Bool = false,
          canPublishData: Bool = false,
          canPublishSources: Set<Track.Source> = [],
@@ -44,7 +44,7 @@ struct RoomTestingOptions {
         self.url = url
         self.token = token
         self.enableMicrophone = enableMicrophone
-        self.e2eeOptions = e2eeOptions
+        self.encryptionOptions = encryptionOptions
         self.canPublish = canPublish
         self.canPublishData = canPublishData
         self.canPublishSources = canPublishSources
@@ -100,8 +100,8 @@ extension LKTestCase {
             let connectOptions = ConnectOptions(enableMicrophone: $0.element.enableMicrophone)
 
             // Room options
-            let e2eeOptions = $0.element.e2eeOptions ?? E2EEOptions(keyProvider: BaseKeyProvider(isSharedKey: true, sharedKey: sharedKey))
-            let roomOptions = RoomOptions(e2eeOptions: e2eeOptions, reportRemoteTrackStatistics: true)
+            let encryptionOptions = $0.element.encryptionOptions ?? EncryptionOptions(keyProvider: BaseKeyProvider(isSharedKey: true, sharedKey: sharedKey))
+            let roomOptions = RoomOptions(encryptionOptions: encryptionOptions, reportRemoteTrackStatistics: true)
 
             let room = Room(delegate: $0.element.delegate, connectOptions: connectOptions, roomOptions: roomOptions)
             let identity = "identity-\($0.offset)"

--- a/Tests/LiveKitTests/Support/Room.swift
+++ b/Tests/LiveKitTests/Support/Room.swift
@@ -225,7 +225,7 @@ final class RoomWatcher<T: Decodable & Sendable>: RoomDelegate, Sendable {
 
     // MARK: - Delegates
 
-    func room(_: Room, participant _: RemoteParticipant?, didReceiveData data: Data, forTopic topic: String) {
+    func room(_: Room, participant _: RemoteParticipant?, didReceiveData data: Data, forTopic topic: String, encryptionType _: EncryptionType) {
         // print("didReceiveData: \(data) for topic: \(topic)")
         Task {
             do {

--- a/Tests/LiveKitTests/Support/Room.swift
+++ b/Tests/LiveKitTests/Support/Room.swift
@@ -22,6 +22,7 @@ struct RoomTestingOptions {
     let url: String?
     let token: String?
     let enableMicrophone: Bool
+    let e2eeOptions: E2EEOptions?
 
     // Perms
     let canPublish: Bool
@@ -33,6 +34,7 @@ struct RoomTestingOptions {
          url: String? = nil,
          token: String? = nil,
          enableMicrophone: Bool = false,
+         e2eeOptions: E2EEOptions? = nil,
          canPublish: Bool = false,
          canPublishData: Bool = false,
          canPublishSources: Set<Track.Source> = [],
@@ -42,6 +44,7 @@ struct RoomTestingOptions {
         self.url = url
         self.token = token
         self.enableMicrophone = enableMicrophone
+        self.e2eeOptions = e2eeOptions
         self.canPublish = canPublish
         self.canPublishData = canPublishData
         self.canPublishSources = canPublishSources
@@ -87,21 +90,19 @@ extension LKTestCase {
 
     // Set up variable number of Rooms
     func withRooms(_ options: [RoomTestingOptions] = [],
-                   sharedKey: String = UUID().uuidString,
                    _ block: @escaping ([Room]) async throws -> Void) async throws
     {
-        let e2eeOptions = E2EEOptions(keyProvider: BaseKeyProvider(isSharedKey: true, sharedKey: sharedKey))
-
-        // Turn on stats
-        let roomOptions = RoomOptions(e2eeOptions: e2eeOptions, reportRemoteTrackStatistics: true)
-
         let roomName = UUID().uuidString
+        let sharedKey = UUID().uuidString
 
         let rooms = try options.enumerated().map {
             // Connect options
             let connectOptions = ConnectOptions(enableMicrophone: $0.element.enableMicrophone)
 
-            // Use shared RoomOptions
+            // Room options
+            let e2eeOptions = $0.element.e2eeOptions ?? E2EEOptions(keyProvider: BaseKeyProvider(isSharedKey: true, sharedKey: sharedKey))
+            let roomOptions = RoomOptions(e2eeOptions: e2eeOptions, reportRemoteTrackStatistics: true)
+
             let room = Room(delegate: $0.element.delegate, connectOptions: connectOptions, roomOptions: roomOptions)
             let identity = "identity-\($0.offset)"
 


### PR DESCRIPTION
- Adds data channel encryption based on https://github.com/livekit/client-sdk-js/pull/1595
- Adds `currentKey` state to `BaseKeyProvider`
  - It was missing comparing to other platforms, and we cannot explicitly default to `0`
- Adds some integration tests, as most of the _crypto_ stuff is tested by webrtc
  - Existing hi-level tests e.g. data streams will get a `sharedKey` by default 🎉 

### Migration/deprecations
- Replace `E2EEOptions` with `EncryptionOptions` (1:1)
- Add `EncryptionType` parameter to `Room/ParticipantDelegate` methods