### PR TITLE
Credential providers

### DIFF
--- a/.changes/connection-credentials
+++ b/.changes/connection-credentials
@@ -1,0 +1,1 @@
+patch type="added" "Abstract credential providers for easier token fetching"

--- a/Sources/LiveKit/Auth/ConnectionCredentials.swift
+++ b/Sources/LiveKit/Auth/ConnectionCredentials.swift
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+public enum ConnectionCredentials {
+    public struct Request: Encodable, Equatable, Sendable {
+        let roomName: String? = nil
+        let participantName: String? = nil
+        let participantIdentity: String? = nil
+        let participantMetadata: String? = nil
+        let participantAttributes: [String: String]? = nil
+//        let roomConfiguration: RoomConfiguration? = nil
+    }
+
+    public struct Response: Decodable, Sendable {
+        let serverUrl: URL
+        let participantToken: String
+    }
+
+    public typealias Literal = Response
+}
+
+// MARK: - Provider
+
+public protocol CredentialsProvider: Sendable {
+    func fetch(_ request: ConnectionCredentials.Request) async throws -> ConnectionCredentials.Response
+}
+
+// MARK: - Implementation
+
+extension ConnectionCredentials.Literal: CredentialsProvider {
+    public func fetch(_: ConnectionCredentials.Request) async throws -> ConnectionCredentials.Response {
+        self
+    }
+}
+
+public struct SandboxTokenServer: CredentialsProvider, Loggable {
+    private static let baseURL = URL(string: "https://cloud-api.livekit.io")!
+
+    public struct Options: Sendable {
+        let id: String
+        let baseURL: URL? = nil
+    }
+
+    private let options: Options
+
+    public init(options: Options) {
+        self.options = options
+    }
+
+    public init(id: String) {
+        options = .init(id: id)
+    }
+
+    public func fetch(_ request: ConnectionCredentials.Request) async throws -> ConnectionCredentials.Response {
+        log("Using sandbox token server is not applicable for production environemnt", .info)
+
+        let baseURL = options.baseURL ?? Self.baseURL
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent("api/sandbox/connection-details"))
+
+        urlRequest.httpMethod = "POST"
+        urlRequest.addValue(options.id.trimmingCharacters(in: CharacterSet(charactersIn: "\"")), forHTTPHeaderField: "X-Sandbox-ID")
+        urlRequest.httpBody = try JSONEncoder().encode(request)
+
+        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw LiveKitError(.network, message: "Error generating token from sandbox token server, no response")
+        }
+
+        guard (200 ... 299).contains(httpResponse.statusCode) else {
+            throw LiveKitError(.network, message: "Error generating token from sandbox token server, received \(httpResponse)")
+        }
+
+        return try JSONDecoder().decode(ConnectionCredentials.Response.self, from: data)
+    }
+}
+
+// MARK: - Cache
+
+public actor CachingCredentialsProvider: CredentialsProvider, Loggable {
+    private let provider: CredentialsProvider
+    private let validator: (ConnectionCredentials.Request, ConnectionCredentials.Response) -> Bool
+
+    private var cached: (ConnectionCredentials.Request, ConnectionCredentials.Response)?
+
+    public init(_ provider: CredentialsProvider, validator: @escaping (ConnectionCredentials.Request, ConnectionCredentials.Response) -> Bool = { _, res in res.hasValidToken() }) {
+        self.provider = provider
+        self.validator = validator
+    }
+
+    public func fetch(_ request: ConnectionCredentials.Request) async throws -> ConnectionCredentials.Response {
+        if let (cachedRequest, cachedResponse) = cached, cachedRequest == request, validator(cachedRequest, cachedResponse) {
+            log("Using cached credentials", .debug)
+            return cachedResponse
+        }
+
+        let response = try await provider.fetch(request)
+        cached = (request, response)
+        return response
+    }
+
+    public func invalidate() {
+        cached = nil
+    }
+}
+
+// MARK: - Validation
+
+public extension ConnectionCredentials.Response {
+    func hasValidToken(withTolerance tolerance: TimeInterval = 60) -> Bool {
+        let parts = participantToken.components(separatedBy: ".")
+        guard parts.count == 3 else {
+            return false
+        }
+
+        let payloadData = parts[1]
+
+        struct JWTPayload: Decodable {
+            let exp: Double
+        }
+
+        guard let payloadJSON = payloadData.base64URLDecode(),
+              let payload = try? JSONDecoder().decode(JWTPayload.self, from: payloadJSON)
+        else {
+            return false
+        }
+
+        let now = Date().timeIntervalSince1970
+        return payload.exp > now - tolerance
+    }
+}
+
+private extension String {
+    func base64URLDecode() -> Data? {
+        var base64 = self
+        base64 = base64.replacingOccurrences(of: "-", with: "+")
+        base64 = base64.replacingOccurrences(of: "_", with: "/")
+
+        while base64.count % 4 != 0 {
+            base64.append("=")
+        }
+
+        return Data(base64Encoded: base64)
+    }
+}

--- a/Sources/LiveKit/Auth/ConnectionCredentials.swift
+++ b/Sources/LiveKit/Auth/ConnectionCredentials.swift
@@ -17,20 +17,28 @@
 import Foundation
 
 public enum ConnectionCredentials {
-    public struct Request: Encodable, Equatable, Sendable {
+    public struct Request: Encodable, Sendable, Equatable {
         let roomName: String?
         let participantName: String?
         let participantIdentity: String?
         let participantMetadata: String?
         let participantAttributes: [String: String]?
-//        let roomConfiguration: RoomConfiguration?
+        let roomConfiguration: RoomConfiguration?
 
-        public init(roomName: String? = nil, participantName: String? = nil, participantIdentity: String? = nil, participantMetadata: String? = nil, participantAttributes: [String: String]? = nil) {
+        public init(
+            roomName: String? = nil,
+            participantName: String? = nil,
+            participantIdentity: String? = nil,
+            participantMetadata: String? = nil,
+            participantAttributes: [String: String]? = nil,
+            roomConfiguration: RoomConfiguration? = nil
+        ) {
             self.roomName = roomName
             self.participantName = participantName
             self.participantIdentity = participantIdentity
             self.participantMetadata = participantMetadata
             self.participantAttributes = participantAttributes
+            self.roomConfiguration = roomConfiguration
         }
     }
 
@@ -111,12 +119,14 @@ public struct SandboxTokenServer: TokenServer {
 // MARK: - Cache
 
 public actor CachingCredentialsProvider: CredentialsProvider, Loggable {
+    public typealias Validator = (ConnectionCredentials.Request, ConnectionCredentials.Response) -> Bool
+
     private let provider: CredentialsProvider
-    private let validator: (ConnectionCredentials.Request, ConnectionCredentials.Response) -> Bool
+    private let validator: Validator
 
     private var cached: (ConnectionCredentials.Request, ConnectionCredentials.Response)?
 
-    public init(_ provider: CredentialsProvider, validator: @escaping (ConnectionCredentials.Request, ConnectionCredentials.Response) -> Bool = { _, res in res.hasValidToken() }) {
+    public init(_ provider: CredentialsProvider, validator: @escaping Validator = { _, res in res.hasValidToken() }) {
         self.provider = provider
         self.validator = validator
     }

--- a/Sources/LiveKit/Auth/ConnectionCredentials.swift
+++ b/Sources/LiveKit/Auth/ConnectionCredentials.swift
@@ -18,19 +18,33 @@ import Foundation
 
 public enum ConnectionCredentials {
     public struct Request: Encodable, Equatable, Sendable {
-        let roomName: String? = nil
-        let participantName: String? = nil
-        let participantIdentity: String? = nil
-        let participantMetadata: String? = nil
-        let participantAttributes: [String: String]? = nil
-//        let roomConfiguration: RoomConfiguration? = nil
+        let roomName: String?
+        let participantName: String?
+        let participantIdentity: String?
+        let participantMetadata: String?
+        let participantAttributes: [String: String]?
+//        let roomConfiguration: RoomConfiguration?
+
+        public init(roomName: String? = nil, participantName: String? = nil, participantIdentity: String? = nil, participantMetadata: String? = nil, participantAttributes: [String: String]? = nil) {
+            self.roomName = roomName
+            self.participantName = participantName
+            self.participantIdentity = participantIdentity
+            self.participantMetadata = participantMetadata
+            self.participantAttributes = participantAttributes
+        }
     }
 
     public struct Response: Decodable, Sendable {
         let serverUrl: URL
         let participantToken: String
+
+        public init(serverUrl: URL, participantToken: String) {
+            self.serverUrl = serverUrl
+            self.participantToken = participantToken
+        }
     }
 
+    public typealias Options = Request
     public typealias Literal = Response
 }
 

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -408,6 +408,14 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
         log("Connected to \(String(describing: self))", .info)
     }
 
+    public func connect(credentialsProvider: CredentialsProvider,
+                        connectOptions: ConnectOptions? = nil,
+                        roomOptions: RoomOptions? = nil) async throws
+    {
+        let credentials = try await credentialsProvider.fetch(.init())
+        try await connect(url: credentials.serverUrl.absoluteString, token: credentials.participantToken, connectOptions: connectOptions, roomOptions: roomOptions)
+    }
+
     @objc
     public func disconnect() async {
         // Return if already disconnected state

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -409,10 +409,11 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
     }
 
     public func connect(credentialsProvider: CredentialsProvider,
+                        credentialsOptions: ConnectionCredentials.Options = .init(),
                         connectOptions: ConnectOptions? = nil,
                         roomOptions: RoomOptions? = nil) async throws
     {
-        let credentials = try await credentialsProvider.fetch(.init())
+        let credentials = try await credentialsProvider.fetch(credentialsOptions)
         try await connect(url: credentials.serverUrl.absoluteString, token: credentials.participantToken, connectOptions: connectOptions, roomOptions: roomOptions)
     }
 

--- a/Sources/LiveKit/Types/RoomConfiguration.swift
+++ b/Sources/LiveKit/Types/RoomConfiguration.swift
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+public struct RoomConfiguration: Encodable, Sendable, Equatable {
+    /// Room name, used as ID, must be unique
+    public let name: String?
+
+    /// Number of seconds to keep the room open if no one joins
+    public let emptyTimeout: UInt32?
+
+    /// Number of seconds to keep the room open after everyone leaves
+    public let departureTimeout: UInt32?
+
+    /// Limit number of participants that can be in a room, excluding Egress and Ingress participants
+    public let maxParticipants: UInt32?
+
+    /// Metadata of room
+    public let metadata: String?
+
+    /// Minimum playout delay of subscriber
+    public let minPlayoutDelay: UInt32?
+
+    /// Maximum playout delay of subscriber
+    public let maxPlayoutDelay: UInt32?
+
+    /// Improves A/V sync when playout_delay set to a value larger than 200ms.
+    /// It will disable transceiver re-use so not recommended for rooms with frequent subscription changes
+    public let syncStreams: Bool?
+
+    /// Define agents that should be dispatched to this room
+    public let agents: [RoomAgentDispatch]?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case emptyTimeout = "empty_timeout"
+        case departureTimeout = "departure_timeout"
+        case maxParticipants = "max_participants"
+        case metadata
+        case minPlayoutDelay = "min_playout_delay"
+        case maxPlayoutDelay = "max_playout_delay"
+        case syncStreams = "sync_streams"
+        case agents
+    }
+
+    public init(
+        name: String? = nil,
+        emptyTimeout: UInt32? = nil,
+        departureTimeout: UInt32? = nil,
+        maxParticipants: UInt32? = nil,
+        metadata: String? = nil,
+        minPlayoutDelay: UInt32? = nil,
+        maxPlayoutDelay: UInt32? = nil,
+        syncStreams: Bool? = nil,
+        agents: [RoomAgentDispatch]? = nil
+    ) {
+        self.name = name
+        self.emptyTimeout = emptyTimeout
+        self.departureTimeout = departureTimeout
+        self.maxParticipants = maxParticipants
+        self.metadata = metadata
+        self.minPlayoutDelay = minPlayoutDelay
+        self.maxPlayoutDelay = maxPlayoutDelay
+        self.syncStreams = syncStreams
+        self.agents = agents
+    }
+}
+
+public struct RoomAgentDispatch: Encodable, Sendable, Equatable {
+    /// Name of the agent to dispatch
+    public let agentName: String?
+
+    /// Metadata for the agent
+    public let metadata: String?
+
+    enum CodingKeys: String, CodingKey {
+        case agentName = "agent_name"
+        case metadata
+    }
+
+    public init(
+        agentName: String? = nil,
+        metadata: String? = nil
+    ) {
+        self.agentName = agentName
+        self.metadata = metadata
+    }
+}

--- a/Tests/LiveKitTests/ConnectionCredentialsTests.swift
+++ b/Tests/LiveKitTests/ConnectionCredentialsTests.swift
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2025 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+@testable import LiveKit
+import XCTest
+
+class ConnectionCredentialsTests: LKTestCase {
+    actor MockValidJWTProvider: CredentialsProvider {
+        let serverUrl = URL(string: "wss://test.livekit.io")!
+        let participantName: String
+        var callCount = 0
+
+        init(participantName: String = "test-participant") {
+            self.participantName = participantName
+        }
+
+        func fetch(_ request: ConnectionCredentials.Request) async throws -> ConnectionCredentials.Response {
+            callCount += 1
+
+            let tokenGenerator = TokenGenerator(
+                apiKey: "test-api-key",
+                apiSecret: "test-api-secret",
+                identity: request.participantIdentity ?? "test-identity"
+            )
+            tokenGenerator.name = request.participantName ?? participantName
+            tokenGenerator.videoGrant = VideoGrant(room: request.roomName ?? "test-room", roomJoin: true)
+
+            let token = try tokenGenerator.sign()
+
+            return ConnectionCredentials.Response(
+                serverUrl: serverUrl,
+                participantToken: token
+            )
+        }
+    }
+
+    actor MockInvalidJWTProvider: CredentialsProvider {
+        let serverUrl = URL(string: "wss://test.livekit.io")!
+        var callCount = 0
+
+        func fetch(_: ConnectionCredentials.Request) async throws -> ConnectionCredentials.Response {
+            callCount += 1
+
+            return ConnectionCredentials.Response(
+                serverUrl: serverUrl,
+                participantToken: "invalid.jwt.token"
+            )
+        }
+    }
+
+    actor MockExpiredJWTProvider: CredentialsProvider {
+        let serverUrl = URL(string: "wss://test.livekit.io")!
+        var callCount = 0
+
+        func fetch(_ request: ConnectionCredentials.Request) async throws -> ConnectionCredentials.Response {
+            callCount += 1
+
+            let tokenGenerator = TokenGenerator(
+                apiKey: "test-api-key",
+                apiSecret: "test-api-secret",
+                identity: request.participantIdentity ?? "test-identity",
+                ttl: -60
+            )
+            tokenGenerator.name = request.participantName ?? "test-participant"
+            tokenGenerator.videoGrant = VideoGrant(room: request.roomName ?? "test-room", roomJoin: true)
+
+            let token = try tokenGenerator.sign()
+
+            return ConnectionCredentials.Response(
+                serverUrl: serverUrl,
+                participantToken: token
+            )
+        }
+    }
+
+    func testValidJWTCaching() async throws {
+        let mockProvider = MockValidJWTProvider(participantName: "alice")
+        let cachingProvider = CachingCredentialsProvider(mockProvider)
+
+        let request = ConnectionCredentials.Request(
+            roomName: "test-room",
+            participantName: "alice",
+            participantIdentity: "alice-id"
+        )
+
+        let response1 = try await cachingProvider.fetch(request)
+        let callCount1 = await mockProvider.callCount
+        XCTAssertEqual(callCount1, 1)
+        XCTAssertEqual(response1.serverUrl.absoluteString, "wss://test.livekit.io")
+        XCTAssertTrue(response1.hasValidToken(), "Generated token should be valid")
+
+        let response2 = try await cachingProvider.fetch(request)
+        let callCount2 = await mockProvider.callCount
+        XCTAssertEqual(callCount2, 1)
+        XCTAssertEqual(response2.participantToken, response1.participantToken)
+        XCTAssertEqual(response2.serverUrl, response1.serverUrl)
+
+        let differentRequest = ConnectionCredentials.Request(
+            roomName: "different-room",
+            participantName: "alice",
+            participantIdentity: "alice-id"
+        )
+        let response3 = try await cachingProvider.fetch(differentRequest)
+        let callCount3 = await mockProvider.callCount
+        XCTAssertEqual(callCount3, 2)
+        XCTAssertNotEqual(response3.participantToken, response1.participantToken)
+
+        await cachingProvider.invalidate()
+        _ = try await cachingProvider.fetch(request)
+        let callCount4 = await mockProvider.callCount
+        XCTAssertEqual(callCount4, 3)
+    }
+
+    func testInvalidJWTHandling() async throws {
+        let mockInvalidProvider = MockInvalidJWTProvider()
+        let cachingProvider = CachingCredentialsProvider(mockInvalidProvider)
+
+        let request = ConnectionCredentials.Request(
+            roomName: "test-room",
+            participantName: "bob",
+            participantIdentity: "bob-id"
+        )
+
+        let response1 = try await cachingProvider.fetch(request)
+        let callCount1 = await mockInvalidProvider.callCount
+        XCTAssertEqual(callCount1, 1)
+        XCTAssertFalse(response1.hasValidToken(), "Invalid token should not be considered valid")
+
+        let response2 = try await cachingProvider.fetch(request)
+        let callCount2 = await mockInvalidProvider.callCount
+        XCTAssertEqual(callCount2, 2)
+        XCTAssertEqual(response2.participantToken, response1.participantToken)
+
+        let mockExpiredProvider = MockExpiredJWTProvider()
+        let cachingProviderExpired = CachingCredentialsProvider(mockExpiredProvider)
+
+        let response3 = try await cachingProviderExpired.fetch(request)
+        let expiredCallCount1 = await mockExpiredProvider.callCount
+        XCTAssertEqual(expiredCallCount1, 1)
+        XCTAssertFalse(response3.hasValidToken(), "Expired token should not be considered valid")
+
+        _ = try await cachingProviderExpired.fetch(request)
+        let expiredCallCount2 = await mockExpiredProvider.callCount
+        XCTAssertEqual(expiredCallCount2, 2)
+    }
+
+    func testCustomValidator() async throws {
+        let mockProvider = MockValidJWTProvider(participantName: "charlie")
+
+        let customValidator: CachingCredentialsProvider.Validator = { request, response in
+            request.participantName == "charlie" && response.hasValidToken()
+        }
+
+        let cachingProvider = CachingCredentialsProvider(mockProvider, validator: customValidator)
+
+        let charlieRequest = ConnectionCredentials.Request(
+            roomName: "test-room",
+            participantName: "charlie",
+            participantIdentity: "charlie-id"
+        )
+
+        let response1 = try await cachingProvider.fetch(charlieRequest)
+        let callCount1 = await mockProvider.callCount
+        XCTAssertEqual(callCount1, 1)
+        XCTAssertTrue(response1.hasValidToken())
+
+        let response2 = try await cachingProvider.fetch(charlieRequest)
+        let callCount2 = await mockProvider.callCount
+        XCTAssertEqual(callCount2, 1)
+        XCTAssertEqual(response2.participantToken, response1.participantToken)
+
+        let aliceRequest = ConnectionCredentials.Request(
+            roomName: "test-room",
+            participantName: "alice",
+            participantIdentity: "alice-id"
+        )
+
+        _ = try await cachingProvider.fetch(aliceRequest)
+        let callCount3 = await mockProvider.callCount
+        XCTAssertEqual(callCount3, 2)
+
+        _ = try await cachingProvider.fetch(aliceRequest)
+        let callCount4 = await mockProvider.callCount
+        XCTAssertEqual(callCount4, 3)
+
+        let tokenMockProvider = MockValidJWTProvider(participantName: "dave")
+        let tokenContentValidator: CachingCredentialsProvider.Validator = { request, response in
+            request.roomName == "test-room" && response.hasValidToken()
+        }
+
+        let tokenCachingProvider = CachingCredentialsProvider(tokenMockProvider, validator: tokenContentValidator)
+
+        let roomRequest = ConnectionCredentials.Request(
+            roomName: "test-room",
+            participantName: "dave",
+            participantIdentity: "dave-id"
+        )
+
+        _ = try await tokenCachingProvider.fetch(roomRequest)
+        let tokenCallCount1 = await tokenMockProvider.callCount
+        XCTAssertEqual(tokenCallCount1, 1)
+
+        _ = try await tokenCachingProvider.fetch(roomRequest)
+        let tokenCallCount2 = await tokenMockProvider.callCount
+        XCTAssertEqual(tokenCallCount2, 1)
+
+        let differentRoomRequest = ConnectionCredentials.Request(
+            roomName: "different-room",
+            participantName: "dave",
+            participantIdentity: "dave-id"
+        )
+
+        _ = try await tokenCachingProvider.fetch(differentRoomRequest)
+        let tokenCallCount3 = await tokenMockProvider.callCount
+        XCTAssertEqual(tokenCallCount3, 2)
+
+        _ = try await tokenCachingProvider.fetch(differentRoomRequest)
+        let tokenCallCount4 = await tokenMockProvider.callCount
+        XCTAssertEqual(tokenCallCount4, 3)
+    }
+
+    func testConcurrentAccess() async throws {
+        let mockProvider = MockValidJWTProvider(participantName: "concurrent-test")
+        let cachingProvider = CachingCredentialsProvider(mockProvider)
+
+        let request = ConnectionCredentials.Request(
+            roomName: "concurrent-room",
+            participantName: "concurrent-user",
+            participantIdentity: "concurrent-id"
+        )
+
+        let initialResponse = try await cachingProvider.fetch(request)
+        let initialCallCount = await mockProvider.callCount
+        XCTAssertEqual(initialCallCount, 1)
+
+        async let fetch1 = cachingProvider.fetch(request)
+        async let fetch2 = cachingProvider.fetch(request)
+        async let fetch3 = cachingProvider.fetch(request)
+
+        let responses = try await [fetch1, fetch2, fetch3]
+
+        XCTAssertEqual(responses[0].participantToken, initialResponse.participantToken)
+        XCTAssertEqual(responses[1].participantToken, initialResponse.participantToken)
+        XCTAssertEqual(responses[2].participantToken, initialResponse.participantToken)
+
+        XCTAssertEqual(responses[0].serverUrl, initialResponse.serverUrl)
+        XCTAssertEqual(responses[1].serverUrl, initialResponse.serverUrl)
+        XCTAssertEqual(responses[2].serverUrl, initialResponse.serverUrl)
+
+        let finalCallCount = await mockProvider.callCount
+        XCTAssertEqual(finalCallCount, 1)
+    }
+}


### PR DESCRIPTION
Incarnation of https://github.com/livekit/client-sdk-js/pull/1645

Key differences:
- Mostly leverages Swift-native approach (protocols + default impl)
- Token `fetch` is stateless, caching is opt-in wrapper (which could be extended to Keychain tho)
- JWT support is limited e.g. exposing cached token payload
  - we have a 3rd party dependency, but only used for testing - IMO it's not worth to compile it for every single use case, but I'm happy to include it based on feedback