### PR TITLE
Audio recording perms check at lib

### DIFF
--- a/LiveKitClient.podspec
+++ b/LiveKitClient.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |spec|
 
   spec.source_files = "Sources/**/*"
 
-  spec.dependency("LiveKitWebRTC", "= 137.7151.08")
+  spec.dependency("LiveKitWebRTC", "= 137.7151.09")
   spec.dependency("SwiftProtobuf")
   spec.dependency("Logging", "= 1.5.4")
   spec.dependency("DequeModule", "= 1.1.4")

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.08"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.09"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.08"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.09"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),

--- a/Sources/LiveKit/Audio/AudioDeviceModuleDelegateAdapter.swift
+++ b/Sources/LiveKit/Audio/AudioDeviceModuleDelegateAdapter.swift
@@ -43,31 +43,7 @@ class AudioDeviceModuleDelegateAdapter: NSObject, LKRTCAudioDeviceModuleDelegate
     func audioDeviceModule(_: LKRTCAudioDeviceModule, willEnableEngine engine: AVAudioEngine, isPlayoutEnabled: Bool, isRecordingEnabled: Bool) -> Int {
         guard let audioManager else { return 0 }
         let entryPoint = audioManager.buildEngineObserverChain()
-        let result = entryPoint?.engineWillEnable(engine, isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled) ?? 0
-
-        // At this point mic perms / session should be configured for recording (only if device rendering mode).
-        if result == 0, !engine.isInManualRenderingMode, isRecordingEnabled {
-            // This will block WebRTC's worker thread, but when instantiating AVAudioInput node it will block by showing a dialog anyways.
-            // Attempt to acquire mic perms at this point to return an error at SDK level.
-            let isAuthorized = LiveKitSDK.ensureDeviceAccessSync(for: [.audio])
-            log("AudioEngine pre-enable check, device permission: \(isAuthorized)")
-            if !isAuthorized {
-                return kAudioEngineErrorInsufficientDevicePermission
-            }
-
-            #if os(iOS) || os(visionOS) || os(tvOS)
-            // Additional check for audio session category.
-            let session = LKRTCAudioSession.sharedInstance()
-            log("AudioEngine pre-enable check, audio session: \(session.category)")
-            if ![AVAudioSession.Category.playAndRecord.rawValue,
-                 AVAudioSession.Category.record.rawValue].contains(session.category)
-            {
-                return kAudioEngineErrorAudioSessionCategoryRecordingRequired
-            }
-            #endif
-        }
-
-        return result
+        return entryPoint?.engineWillEnable(engine, isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled) ?? 0
     }
 
     func audioDeviceModule(_: LKRTCAudioDeviceModule, willStartEngine engine: AVAudioEngine, isPlayoutEnabled: Bool, isRecordingEnabled: Bool) -> Int {

--- a/Tests/LKTestHost/LKTestHost.xcodeproj/project.pbxproj
+++ b/Tests/LKTestHost/LKTestHost.xcodeproj/project.pbxproj
@@ -387,6 +387,7 @@
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
@@ -431,6 +432,7 @@
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";

--- a/Tests/LiveKitTests/Audio/AudioEngineObserver.swift
+++ b/Tests/LiveKitTests/Audio/AudioEngineObserver.swift
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@preconcurrency import AVFoundation
+@testable import LiveKit
+import XCTest
+
+final class TestEngineObserver: AudioEngineObserver, @unchecked Sendable {
+    var next: (any LiveKit.AudioEngineObserver)?
+    var shouldSucceed: Bool = true
+
+    func engineWillEnable(_: AVAudioEngine, isPlayoutEnabled _: Bool, isRecordingEnabled _: Bool) -> Int {
+        shouldSucceed ? 0 : -1
+    }
+
+    func engineDidStop(_: AVAudioEngine, isPlayoutEnabled _: Bool, isRecordingEnabled _: Bool) -> Int {
+        shouldSucceed ? 0 : -1
+    }
+}
+
+class AudioEngineObserverTests: LKTestCase {
+    // Error codes returned in an `AudioEngineObserver` should propagate through the WebRTC's AudioDeviceModule and
+    // the SDK should throw in such cases for both device and manual rendering modes.
+    func testObserverFail() async throws {
+        //
+        let testObserver = TestEngineObserver()
+
+        // Set test engine observer
+        AudioManager.shared.set(engineObservers: [testObserver])
+
+        // Test without enabling VP
+        try AudioManager.shared.setVoiceProcessingEnabled(false)
+
+        // First check
+        XCTAssertFalse(AudioManager.shared.isEngineRunning)
+
+        #if os(iOS) || os(visionOS) || os(tvOS)
+        try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playAndRecord)
+        #endif
+
+        testObserver.shouldSucceed = true
+
+        // Attempt to start
+        try AudioManager.shared.startLocalRecording()
+        XCTAssertTrue(AudioManager.shared.isEngineRunning)
+
+        testObserver.shouldSucceed = false
+
+        // Stop
+        XCTAssertThrowsError(try AudioManager.shared.stopLocalRecording())
+        XCTAssertFalse(AudioManager.shared.isEngineRunning)
+
+        testObserver.shouldSucceed = true
+
+        try AudioManager.shared.stopLocalRecording()
+        XCTAssertFalse(AudioManager.shared.isEngineRunning)
+
+        testObserver.shouldSucceed = false
+
+        // Attempt to start, should fail
+        XCTAssertThrowsError(try AudioManager.shared.startLocalRecording())
+        XCTAssertFalse(AudioManager.shared.isEngineRunning)
+
+        // Switch to manual mode
+        try AudioManager.shared.setManualRenderingMode(true)
+
+        testObserver.shouldSucceed = true
+
+        // Attempt to start
+        try AudioManager.shared.startLocalRecording()
+        XCTAssertFalse(AudioManager.shared.isEngineRunning)
+    }
+}

--- a/Tests/LiveKitTests/AudioEngineTests.swift
+++ b/Tests/LiveKitTests/AudioEngineTests.swift
@@ -303,16 +303,6 @@ class AudioEngineTests: LKTestCase, @unchecked Sendable {
     }
     #endif
 
-    func testFailingPublish() async throws {
-        AudioManager.shared.set(engineObservers: [FailingEngineObserver()])
-        // Should fail
-        // swiftformat:disable redundantSelf hoistAwait
-        await XCTAssertThrowsErrorAsync(try await withRooms([RoomTestingOptions(canPublish: true)]) { rooms in
-            print("Publishing mic...")
-            try await rooms[0].localParticipant.setMicrophone(enabled: true)
-        })
-    }
-
     // Test if audio engine can start while another AVAudioEngine is running with VP enabled.
     func testMultipleAudioEngine() async throws {
         // Start sample audio engine with VP.
@@ -340,15 +330,6 @@ class AudioEngineTests: LKTestCase, @unchecked Sendable {
 
         // Render for 5 seconds...
         try? await Task.sleep(nanoseconds: 5 * 1_000_000_000)
-    }
-}
-
-final class FailingEngineObserver: AudioEngineObserver, @unchecked Sendable {
-    var next: (any LiveKit.AudioEngineObserver)?
-
-    func engineWillEnable(_: AVAudioEngine, isPlayoutEnabled _: Bool, isRecordingEnabled _: Bool) -> Int {
-        // Fail
-        -4101
     }
 }
 


### PR DESCRIPTION
Move audio recording perms checks from SDK to WebRTC.
Patch: https://github.com/webrtc-sdk/webrtc/pull/200

A simple way to test this would be trying to enable mic while in a phone call.
AVAudioSession activation fail will be detected in the lib, and report error instead of crashing.