### PR TITLE
Fix serial runner cancellation

### DIFF
--- a/.changes/serial-cancellation
+++ b/.changes/serial-cancellation
@@ -1,0 +1,1 @@
+patch type="fixed" "Serial operations cancellation semantics"

--- a/Sources/LiveKit/Support/SerialRunnerActor.swift
+++ b/Sources/LiveKit/Support/SerialRunnerActor.swift
@@ -21,8 +21,8 @@ actor SerialRunnerActor<Value: Sendable> {
 
     func run(block: @Sendable @escaping () async throws -> Value) async throws -> Value {
         let task = Task { [previousTask] in
-            // Wait for the previous task to complete, but cancel it if needed
-            if let previousTask, !Task.isCancelled {
+            // Always wait for the previous task to maintain serial ordering
+            if let previousTask {
                 // If previous task is still running, wait for it
                 _ = try? await previousTask.value
             }


### PR DESCRIPTION
Problem

The testSerialRunnerCancel() test was failing with the counter ending up negative (-1, -8, etc.) instead of the expected 0, indicating a race condition.

Root Cause

The condition !Task.isCancelled was causing cancelled tasks to skip waiting for the previous task to complete. This broke the serial execution guarantee, allowing multiple blocks to run concurrently and causing unsynchronized access to the shared counter.

Fix

Removed the !Task.isCancelled condition to ensure all tasks wait for the previous task, even when cancelled. This maintains the serial ordering guarantee that the actor is designed to provide.