### PR TITLE
Bump up RPC timeout to 7 seconds, 15s as total response time

### DIFF
--- a/Sources/LiveKit/Participant/LocalParticipant+RPC.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant+RPC.swift
@@ -30,7 +30,7 @@ public extension LocalParticipant {
     func performRpc(destinationIdentity: Identity,
                     method: String,
                     payload: String,
-                    responseTimeout: TimeInterval = 10) async throws -> String
+                    responseTimeout: TimeInterval = 15) async throws -> String
     {
         let room = try requireRoom()
 
@@ -39,7 +39,7 @@ public extension LocalParticipant {
         }
 
         let requestId = UUID().uuidString
-        let maxRoundTripLatency: TimeInterval = 2
+        let maxRoundTripLatency: TimeInterval = 7
         let effectiveTimeout = responseTimeout - maxRoundTripLatency
 
         try await publishRpcRequest(destinationIdentity: destinationIdentity,


### PR DESCRIPTION
See issue https://linear.app/livekit/issue/CLT-2132/increase-rpc-max-rt-time-to-7s

This is the swift PR for https://github.com/livekit/rust-sdks/pull/729 