### PR TITLE
fix: guard unsupported os for extension builds

### DIFF
--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -23,6 +23,8 @@ import ReplayKit
 
 internal import LiveKitWebRTC
 
+@available(iOSApplicationExtension, unavailable, message: "Camera capture is not supported in app extensions.")
+@available(tvOSApplicationExtension, unavailable, message: "Camera capture is not supported in app extensions.")
 public class CameraCapturer: VideoCapturer, @unchecked Sendable {
     /// Current device used for capturing
     @objc
@@ -284,6 +286,8 @@ class VideoCapturerDelegateAdapter: NSObject, LKRTCVideoCapturerDelegate, Loggab
     }
 }
 
+@available(iOSApplicationExtension, unavailable, message: "Camera capture is not supported in app extensions.")
+@available(tvOSApplicationExtension, unavailable, message: "Camera capture is not supported in app extensions.")
 public extension LocalVideoTrack {
     @objc
     static func createCameraTrack() -> LocalVideoTrack {

--- a/Sources/LiveKit/Views/VideoView+PinchToZoom.swift
+++ b/Sources/LiveKit/Views/VideoView+PinchToZoom.swift
@@ -37,8 +37,12 @@ extension VideoView {
         /// Auto reset to default zoom level when pinch is released.
         public static let resetOnRelease = PinchToZoomOptions(rawValue: 1 << 2)
     }
+}
 
-    #if os(iOS)
+#if os(iOS)
+@available(iOSApplicationExtension, unavailable, message: "Camera capture is not supported in app extensions.")
+@available(tvOSApplicationExtension, unavailable, message: "Camera capture is not supported in app extensions.")
+extension VideoView {
     func _rampZoomFactorToAllowedBounds(options: PinchToZoomOptions) {
         guard let device = _currentCaptureDevice else { return }
 
@@ -112,5 +116,5 @@ extension VideoView {
 
         return lowerBound ... upperBound
     }
-    #endif
 }
+#endif


### PR DESCRIPTION
Fix for:

Build issue when trying to include the LiveKit CocoaPods package inside the broadcast extension (followed this guide for cocoapods https://github.com/livekit/client-sdk-swift/blob/main/Docs/cocoapods.md), and getting the following error: ".../Pods/LiveKitClient/Sources/LiveKit/Track/Capturers/CameraCapturer.swift:97:32 'LKRTCCameraVideoCapturer' is unavailable in application extensions for iOS: Camera not available in app extensions." Looks like it's caused by the camera capture code being compiled into the extension target, which isn't allowed by iOS, even though only the LKSampleHandler is needed.