### PR TITLE
Fix crash with 0 video dimensions

### DIFF
--- a/.changes/video-view-crash
+++ b/.changes/video-view-crash
@@ -1,0 +1,1 @@
+patch type="fixed" "Crash in VideoView when video dimensions are both 0"

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -425,6 +425,8 @@ extension LKRTCVideoFrame {
         let sourceRatio = Double(width) / Double(height)
         let targetRatio = Double(scaleWidth) / Double(scaleHeight)
 
+        guard targetRatio.isFinite else { return nil }
+
         // Calculate crop dimensions
         let (cropWidth, cropHeight): (Int32, Int32)
         if sourceRatio > targetRatio {

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -469,7 +469,7 @@ public class VideoView: NativeView, Loggable {
         let hRatio = size.height / hDim
         let ratioDiff = abs(hRatio - wRatio)
 
-        if ratioDiff < CGFloat.aspectRatioTolerance {
+        if !ratioDiff.isFinite || ratioDiff < CGFloat.aspectRatioTolerance {
             // no-op
         } else if state.layoutMode == .fill ? hRatio > wRatio : hRatio < wRatio {
             size.width = size.height / hDim * wDim


### PR DESCRIPTION
Resolves #869 

I see more places where division by 0 can take place, but this is crucial for layout.