### PR TITLE
Fix ffi module name

### DIFF
--- a/LiveKitClient.podspec
+++ b/LiveKitClient.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
   spec.source_files = "Sources/**/*"
 
   spec.dependency("LiveKitWebRTC", "= 137.7151.10")
-  spec.dependency("LiveKitUniFFI", "= 0.0.2")
+  spec.dependency("LiveKitUniFFI", "= 0.0.3")
   spec.dependency("SwiftProtobuf")
   spec.dependency("DequeModule", "= 1.1.4")
   spec.dependency("OrderedCollections", " = 1.1.4")

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
         .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.10"),
-        .package(url: "https://github.com/livekit/livekit-uniffi-xcframework.git", exact: "0.0.2"),
+        .package(url: "https://github.com/livekit/livekit-uniffi-xcframework.git", exact: "0.0.3"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.0"),
         .package(url: "https://github.com/apple/swift-collections.git", "1.1.0" ..< "1.3.0"),
         // Only used for DocC generation

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -21,7 +21,7 @@ let package = Package(
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
         .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.10"),
-        .package(url: "https://github.com/livekit/livekit-uniffi-xcframework.git", exact: "0.0.2"),
+        .package(url: "https://github.com/livekit/livekit-uniffi-xcframework.git", exact: "0.0.3"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.0"),
         .package(url: "https://github.com/apple/swift-collections.git", "1.1.0" ..< "1.3.0"),
         // Only used for DocC generation


### PR DESCRIPTION
Applies a patch to fix newer Swift versions 6.2+ failing when the module name does not match folder name inside xcframework.

`cargo-swift` fix in progress, https://github.com/livekit/rust-sdks/pull/750#discussion_r2630367469

tests https://github.com/livekit/client-sdk-swift/actions/runs/20334177943/job/58416504807