### PR TITLE
Retry tests once

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ concurrency:
 env:
   TEST_TARGETS: "LiveKitCoreTests LiveKitObjCTests"
   TEST_TIMEOUT_MINUTES: 15
-  TEST_RETRY_ATTEMPTS: 3
+  TEST_RETRY_ATTEMPTS: 2
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Relative stability is achieved, we can surface more errors/timeouts now.