### PR TITLE
CI: Build docs in-place

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -13,6 +13,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   symbol-graph:
     name: Symbol Graph (${{ matrix.artifact_name }})


### PR DESCRIPTION
It turned out to be a little flaky (artifacts out-of-sync), build cost is still negligible here.

Example: https://github.com/livekit/client-sdk-swift/actions/runs/21626345080

Optionally, we can remove them from CI workflow (it may lead to unpleasant surprises tho).