### PR TITLE
Improve test coverage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,6 +55,7 @@ let package = Package(
             name: "LiveKitTestSupport",
             dependencies: [
                 "LiveKit",
+                .product(name: "LiveKitWebRTC", package: "webrtc-xcframework"),
             ],
             path: "Tests/LiveKitTestSupport"
         ),
@@ -63,6 +64,7 @@ let package = Package(
             dependencies: [
                 "LiveKit",
                 "LiveKitTestSupport",
+                .product(name: "LiveKitWebRTC", package: "webrtc-xcframework"),
             ]
         ),
         .testTarget(

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -269,7 +269,11 @@ private extension SignalClient {
             await self._responseQueue.processIfResumed(response, or: alwaysProcess)
         }
     }
+}
 
+// MARK: - Response Processing
+
+extension SignalClient {
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     func _process(signalResponse: Livekit_SignalResponse) async {
         guard connectionState != .disconnected else {
@@ -378,6 +382,11 @@ extension SignalClient {
     func resumeQueues() async {
         await _responseQueue.resume()
         await _requestQueue.resume()
+    }
+
+    /// Sets connection state. Used internally and for testing.
+    func setConnectionState(_ connectionState: ConnectionState) {
+        _state.mutate { $0.connectionState = connectionState }
     }
 }
 

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -24,6 +24,7 @@ actor SignalClient: Loggable {
     // MARK: - Types
 
     typealias AddTrackRequestPopulator = @Sendable (inout Livekit_AddTrackRequest) throws -> Void
+    typealias WebSocketFactory = @Sendable (URL, String, ConnectOptions?) async throws -> WebSocket
 
     enum ConnectResponse: Sendable {
         case join(Livekit_JoinResponse)
@@ -84,11 +85,12 @@ actor SignalClient: Loggable {
     private let _addTrackCompleters = CompleterMapActor<Livekit_TrackInfo>(label: "Completers for add track", defaultTimeout: .defaultPublish)
     private let _pingIntervalTimer = AsyncTimer(interval: 1)
     private let _pingTimeoutTimer = AsyncTimer(interval: 1)
+    var _webSocketFactory: WebSocketFactory?
 
     struct State {
         var connectionState: ConnectionState = .disconnected
         var disconnectError: LiveKitError?
-        var socket: WebSocket?
+        var socket: (any WebSocketType)?
         var messageLoopTask: AnyTaskCancellable?
         var lastJoinResponse: Livekit_JoinResponse?
         var rtt: Int64 = 0
@@ -140,9 +142,13 @@ actor SignalClient: Loggable {
         _state.mutate { $0.connectionState = (isReconnect ? .reconnecting : .connecting) }
 
         do {
-            let socket = try await WebSocket(url: url,
-                                             token: token,
-                                             connectOptions: connectOptions)
+            let socket = if let factory = _webSocketFactory {
+                try await factory(url, token, connectOptions)
+            } else {
+                try await WebSocket(url: url,
+                                    token: token,
+                                    connectOptions: connectOptions)
+            }
 
             let messageLoopTask = socket.subscribe(self) { observer, message in
                 await observer.onWebSocketMessage(message)
@@ -701,7 +707,7 @@ extension Livekit_SignalRequest {
 }
 
 private extension SignalClient {
-    func requireWebSocket() async throws -> WebSocket {
+    func requireWebSocket() async throws -> any WebSocketType {
         guard let result = _state.socket else {
             log("WebSocket is nil", .error)
             throw LiveKitError(.invalidState, message: "WebSocket is nil")
@@ -709,4 +715,34 @@ private extension SignalClient {
 
         return result
     }
+}
+
+// MARK: - Test Support
+
+extension SignalClient {
+    /// Injects a mock WebSocket for testing send methods.
+    func setWebSocket(_ socket: any WebSocketType) {
+        _state.mutate { $0.socket = socket }
+    }
+
+    /// Injects a WebSocket factory for testing connect().
+    func setWebSocketFactory(_ factory: @escaping WebSocketFactory) {
+        _webSocketFactory = factory
+    }
+
+    /// Test helper: simulates receiving a WebSocket message through the decoding pipeline.
+    func _testHandleWebSocketMessage(_ message: URLSessionWebSocketTask.Message) async {
+        await onWebSocketMessage(message)
+    }
+
+    /// Test helper: triggers the ping send logic.
+    func _testSendPing() async throws {
+        try await _sendPing()
+    }
+
+    /// Test helper: access to the ping interval timer for verification.
+    var _testPingIntervalTimer: AsyncTimer { _pingIntervalTimer }
+
+    /// Test helper: access to the ping timeout timer for verification.
+    var _testPingTimeoutTimer: AsyncTimer { _pingTimeoutTimer }
 }

--- a/Sources/LiveKit/Support/Network/WebSocketType.swift
+++ b/Sources/LiveKit/Support/Network/WebSocketType.swift
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Internal protocol abstracting WebSocket operations for testability.
+protocol WebSocketType: Sendable {
+    func send(data: Data) async throws
+    func close()
+}
+
+extension WebSocket: WebSocketType {}

--- a/Tests/LiveKitCoreTests/Agent/AgentStateTests.swift
+++ b/Tests/LiveKitCoreTests/Agent/AgentStateTests.swift
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+class AgentStateTests: LKTestCase {
+    // MARK: - Initial State (Disconnected)
+
+    func testInitialStateIsDisconnected() {
+        let agent = Agent()
+        XCTAssertTrue(agent.isFinished)
+        XCTAssertFalse(agent.isConnected)
+        XCTAssertFalse(agent.canListen)
+        XCTAssertFalse(agent.isPending)
+    }
+
+    func testInitialStateAccessorsAreNil() {
+        let agent = Agent()
+        XCTAssertNil(agent.agentState)
+        XCTAssertNil(agent.audioTrack)
+        XCTAssertNil(agent.avatarVideoTrack)
+        XCTAssertNil(agent.error)
+    }
+
+    // MARK: - Connecting State (buffering: false)
+
+    func testConnectingWithoutBufferingIsPending() {
+        var agent = Agent()
+        agent.connecting(buffering: false)
+        XCTAssertTrue(agent.isPending)
+        XCTAssertFalse(agent.canListen)
+        XCTAssertFalse(agent.isConnected)
+        XCTAssertFalse(agent.isFinished)
+    }
+
+    // MARK: - Connecting State (buffering: true)
+
+    func testConnectingWithBufferingCanListen() {
+        var agent = Agent()
+        agent.connecting(buffering: true)
+        XCTAssertTrue(agent.canListen)
+        XCTAssertFalse(agent.isPending)
+        XCTAssertFalse(agent.isConnected)
+        XCTAssertFalse(agent.isFinished)
+    }
+
+    func testConnectingAccessorsAreNil() {
+        var agent = Agent()
+        agent.connecting(buffering: true)
+        XCTAssertNil(agent.agentState)
+        XCTAssertNil(agent.audioTrack)
+        XCTAssertNil(agent.avatarVideoTrack)
+        XCTAssertNil(agent.error)
+    }
+
+    // MARK: - Failed State
+
+    func testFailedWithTimeoutError() {
+        var agent = Agent()
+        agent.failed(error: .timeout)
+        XCTAssertTrue(agent.isFinished)
+        XCTAssertFalse(agent.isConnected)
+        XCTAssertFalse(agent.canListen)
+        XCTAssertFalse(agent.isPending)
+    }
+
+    func testFailedWithLeftError() {
+        var agent = Agent()
+        agent.failed(error: .left)
+        XCTAssertTrue(agent.isFinished)
+        XCTAssertNotNil(agent.error)
+    }
+
+    func testFailedErrorAccessor() {
+        var agent = Agent()
+        agent.failed(error: .timeout)
+
+        if case .timeout = agent.error {
+            // Expected
+        } else {
+            XCTFail("Expected .timeout error")
+        }
+    }
+
+    func testFailedErrorDescriptions() {
+        XCTAssertNotNil(Agent.Error.timeout.errorDescription)
+        XCTAssertNotNil(Agent.Error.left.errorDescription)
+    }
+
+    // MARK: - Disconnected Transition
+
+    func testDisconnectedFromConnecting() {
+        var agent = Agent()
+        agent.connecting(buffering: true)
+        XCTAssertFalse(agent.isFinished)
+
+        agent.disconnected()
+        XCTAssertTrue(agent.isFinished)
+        XCTAssertFalse(agent.canListen)
+        XCTAssertNil(agent.error)
+    }
+
+    func testDisconnectedFromFailed() {
+        var agent = Agent()
+        agent.failed(error: .timeout)
+        XCTAssertNotNil(agent.error)
+
+        agent.disconnected()
+        XCTAssertTrue(agent.isFinished)
+        XCTAssertNil(agent.error)
+    }
+
+    // MARK: - State Transition Sequences
+
+    func testFullLifecycle() {
+        var agent = Agent()
+
+        // Start disconnected
+        XCTAssertTrue(agent.isFinished)
+
+        // Begin connecting without buffering
+        agent.connecting(buffering: false)
+        XCTAssertTrue(agent.isPending)
+
+        // Enable buffering
+        agent.connecting(buffering: true)
+        XCTAssertTrue(agent.canListen)
+
+        // Disconnect
+        agent.disconnected()
+        XCTAssertTrue(agent.isFinished)
+    }
+
+    func testFailureFromConnecting() {
+        var agent = Agent()
+        agent.connecting(buffering: true)
+        XCTAssertTrue(agent.canListen)
+
+        agent.failed(error: .timeout)
+        XCTAssertTrue(agent.isFinished)
+        XCTAssertFalse(agent.canListen)
+        XCTAssertNotNil(agent.error)
+    }
+}

--- a/Tests/LiveKitCoreTests/Agent/SessionTests.swift
+++ b/Tests/LiveKitCoreTests/Agent/SessionTests.swift
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+/// Mock token source for testing Session initialization without a real server.
+private struct MockFixedTokenSource: TokenSourceFixed {
+    let response: TokenSourceResponse
+
+    func fetch() async throws -> TokenSourceResponse {
+        response
+    }
+}
+
+private struct MockConfigurableTokenSource: TokenSourceConfigurable {
+    let response: TokenSourceResponse
+
+    func fetch(_: TokenRequestOptions) async throws -> TokenSourceResponse {
+        response
+    }
+}
+
+private struct FailingTokenSource: TokenSourceFixed {
+    func fetch() async throws -> TokenSourceResponse {
+        throw LiveKitError(.network, message: "Mock token fetch failure")
+    }
+}
+
+/// Tests for Agent Session error types, message history, and initialization.
+@MainActor
+class SessionTests: LKTestCase {
+    private let mockResponse = TokenSourceResponse(
+        serverURL: URL(string: "wss://test.livekit.cloud")!,
+        participantToken: "mock-token"
+    )
+
+    // MARK: - Session.Error
+
+    func testSessionErrorConnectionDescription() {
+        let error = Session.Error.connection(LiveKitError(.network, message: "timeout"))
+        XCTAssertNotNil(error.errorDescription)
+        XCTAssertTrue(error.errorDescription!.contains("Connection failed"))
+    }
+
+    func testSessionErrorSenderDescription() {
+        let error = Session.Error.sender(LiveKitError(.invalidState, message: "not connected"))
+        XCTAssertNotNil(error.errorDescription)
+        XCTAssertTrue(error.errorDescription!.contains("Message sender failed"))
+    }
+
+    func testSessionErrorReceiverDescription() {
+        let error = Session.Error.receiver(LiveKitError(.invalidState, message: "stream ended"))
+        XCTAssertNotNil(error.errorDescription)
+        XCTAssertTrue(error.errorDescription!.contains("Message receiver failed"))
+    }
+
+    // MARK: - Initialization
+
+    func testInitWithFixedTokenSource() {
+        let source = MockFixedTokenSource(response: mockResponse)
+        let session = Session(tokenSource: source)
+        XCTAssertNotNil(session.room)
+        XCTAssertFalse(session.isConnected)
+        XCTAssertNil(session.error)
+        XCTAssertTrue(session.messages.isEmpty)
+    }
+
+    func testInitWithConfigurableTokenSource() {
+        let source = MockConfigurableTokenSource(response: mockResponse)
+        let session = Session(tokenSource: source, tokenOptions: .init(agentName: "test-agent"))
+        XCTAssertNotNil(session.room)
+        XCTAssertFalse(session.isConnected)
+    }
+
+    func testWithAgentFactory() {
+        let source = MockConfigurableTokenSource(response: mockResponse)
+        let session = Session.withAgent("my-agent", tokenSource: source)
+        XCTAssertNotNil(session.room)
+        XCTAssertFalse(session.isConnected)
+    }
+
+    func testInitWithCustomSessionOptions() {
+        let source = MockFixedTokenSource(response: mockResponse)
+        let options = SessionOptions(
+            room: Room(),
+            preConnectAudio: false,
+            agentConnectTimeout: 30
+        )
+        let session = Session(tokenSource: source, options: options)
+        XCTAssertNotNil(session.room)
+    }
+
+    // MARK: - isConnected
+
+    func testIsConnectedDefaultFalse() {
+        let source = MockFixedTokenSource(response: mockResponse)
+        let session = Session(tokenSource: source)
+        XCTAssertFalse(session.isConnected)
+    }
+
+    // MARK: - Message History
+
+    func testMessagesInitiallyEmpty() {
+        let source = MockFixedTokenSource(response: mockResponse)
+        let session = Session(tokenSource: source)
+        XCTAssertTrue(session.messages.isEmpty)
+        XCTAssertTrue(session.getMessageHistory().isEmpty)
+    }
+
+    func testRestoreMessageHistory() {
+        let source = MockFixedTokenSource(response: mockResponse)
+        let session = Session(tokenSource: source)
+
+        let messages = [
+            ReceivedMessage(id: "msg-1", timestamp: Date(timeIntervalSince1970: 100), content: .userInput("Hello")),
+            ReceivedMessage(id: "msg-2", timestamp: Date(timeIntervalSince1970: 200), content: .agentTranscript("Hi there")),
+            ReceivedMessage(id: "msg-3", timestamp: Date(timeIntervalSince1970: 300), content: .userTranscript("How are you?")),
+        ]
+
+        session.restoreMessageHistory(messages)
+
+        XCTAssertEqual(session.messages.count, 3)
+        XCTAssertEqual(session.messages[0].id, "msg-1")
+        XCTAssertEqual(session.messages[1].id, "msg-2")
+        XCTAssertEqual(session.messages[2].id, "msg-3")
+    }
+
+    func testRestoreMessageHistorySortsChronologically() {
+        let source = MockFixedTokenSource(response: mockResponse)
+        let session = Session(tokenSource: source)
+
+        // Intentionally out of order
+        let messages = [
+            ReceivedMessage(id: "msg-3", timestamp: Date(timeIntervalSince1970: 300), content: .userInput("Third")),
+            ReceivedMessage(id: "msg-1", timestamp: Date(timeIntervalSince1970: 100), content: .userInput("First")),
+            ReceivedMessage(id: "msg-2", timestamp: Date(timeIntervalSince1970: 200), content: .userInput("Second")),
+        ]
+
+        session.restoreMessageHistory(messages)
+
+        XCTAssertEqual(session.messages[0].id, "msg-1")
+        XCTAssertEqual(session.messages[1].id, "msg-2")
+        XCTAssertEqual(session.messages[2].id, "msg-3")
+    }
+
+    func testRestoreMessageHistoryReplacesExisting() {
+        let source = MockFixedTokenSource(response: mockResponse)
+        let session = Session(tokenSource: source)
+
+        let initial = [ReceivedMessage(id: "old", timestamp: Date(), content: .userInput("old"))]
+        session.restoreMessageHistory(initial)
+        XCTAssertEqual(session.messages.count, 1)
+
+        let replacement = [ReceivedMessage(id: "new", timestamp: Date(), content: .userInput("new"))]
+        session.restoreMessageHistory(replacement)
+        XCTAssertEqual(session.messages.count, 1)
+        XCTAssertEqual(session.messages[0].id, "new")
+    }
+
+    func testGetMessageHistoryReturnsSameAsMessages() {
+        let source = MockFixedTokenSource(response: mockResponse)
+        let session = Session(tokenSource: source)
+
+        let messages = [ReceivedMessage(id: "msg-1", timestamp: Date(), content: .userInput("test"))]
+        session.restoreMessageHistory(messages)
+
+        XCTAssertEqual(session.getMessageHistory().count, session.messages.count)
+        XCTAssertEqual(session.getMessageHistory().first?.id, session.messages.first?.id)
+    }
+
+    // MARK: - dismissError
+
+    func testDismissError() {
+        let source = MockFixedTokenSource(response: mockResponse)
+        let session = Session(tokenSource: source)
+
+        // Verify dismissError clears error
+        session.dismissError()
+        XCTAssertNil(session.error)
+    }
+
+    // MARK: - Agent initial state
+
+    func testAgentInitialState() {
+        let source = MockFixedTokenSource(response: mockResponse)
+        let session = Session(tokenSource: source)
+
+        XCTAssertTrue(session.agent.isFinished)
+        XCTAssertFalse(session.agent.isConnected)
+        XCTAssertNil(session.agent.agentState)
+    }
+
+    // MARK: - start() with failing token source
+
+    func testStartWithFailingTokenSetsError() async {
+        let source = FailingTokenSource()
+        let options = SessionOptions(preConnectAudio: false)
+        let session = Session(tokenSource: source, options: options)
+
+        await session.start()
+
+        // Should have set a connection error
+        if case .connection = session.error {
+            // Expected
+        } else {
+            XCTFail("Expected .connection error, got \(String(describing: session.error))")
+        }
+
+        // Agent should be disconnected after failure
+        XCTAssertTrue(session.agent.isFinished)
+    }
+}

--- a/Tests/LiveKitCoreTests/Core/RoomDataHandlerTests.swift
+++ b/Tests/LiveKitCoreTests/Core/RoomDataHandlerTests.swift
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+/// Lightweight delegate tracker for verifying data/transcription delegate calls.
+private final class DataDelegateTracker: RoomDelegate, @unchecked Sendable {
+    var receivedData: Data?
+    var receivedTopic: String?
+    var receivedParticipant: RemoteParticipant?
+    var receivedEncryptionType: EncryptionType?
+    var transcriptionSegments: [TranscriptionSegment]?
+    var transcriptionParticipant: Participant?
+    var transcriptionPublication: TrackPublication?
+
+    func room(_: Room, participant: RemoteParticipant?, didReceiveData data: Data, forTopic topic: String, encryptionType: EncryptionType) {
+        receivedData = data
+        receivedTopic = topic
+        receivedParticipant = participant
+        receivedEncryptionType = encryptionType
+    }
+
+    func room(_: Room, participant: Participant, trackPublication: TrackPublication, didReceiveTranscriptionSegments segments: [TranscriptionSegment]) {
+        transcriptionSegments = segments
+        transcriptionParticipant = participant
+        transcriptionPublication = trackPublication
+    }
+}
+
+/// Tests for Room's data packet, transcription, and RPC handling
+/// in Room+EngineDelegate.swift.
+class RoomDataHandlerTests: LKTestCase {
+    // MARK: - Helper
+
+    private func makeConnectedRoom() -> (Room, DataDelegateTracker) {
+        let room = Room()
+        room._state.mutate { $0.connectionState = .connected }
+        let localInfo = TestData.participantInfo(sid: "PA_local", identity: "local-user")
+        room.localParticipant.set(info: localInfo, connectionState: .connected)
+        let tracker = DataDelegateTracker()
+        room.delegates.add(delegate: tracker)
+        return (room, tracker)
+    }
+
+    private func addRemoteParticipant(
+        to room: Room,
+        sid: String = "PA_r1",
+        identity: String = "remote-user",
+        tracks: [Livekit_TrackInfo] = []
+    ) -> RemoteParticipant {
+        let info = TestData.participantInfo(sid: sid, identity: identity, tracks: tracks)
+        let participant = RemoteParticipant(info: info, room: room, connectionState: .connected)
+        room._state.mutate {
+            $0.remoteParticipants[Participant.Identity(from: identity)] = participant
+        }
+        return participant
+    }
+
+    /// Wait for MulticastDelegate's async dispatch to complete.
+    private func waitForDelegates() {
+        let exp = expectation(description: "delegate dispatch")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    // MARK: - Data Packet (UserPacket)
+
+    func testReceiveUserPacketFromRemoteParticipant() {
+        let (room, tracker) = makeConnectedRoom()
+        _ = addRemoteParticipant(to: room, identity: "remote-user")
+
+        let payload = Data("test".utf8)
+        let packet = TestData.userPacket(participantIdentity: "remote-user", payload: payload, topic: "chat")
+        room.engine(room, didReceiveUserPacket: packet, encryptionType: .none)
+        waitForDelegates()
+
+        XCTAssertEqual(tracker.receivedData, payload)
+        XCTAssertEqual(tracker.receivedTopic, "chat")
+        XCTAssertNotNil(tracker.receivedParticipant)
+        XCTAssertEqual(tracker.receivedParticipant?.identity?.stringValue, "remote-user")
+        XCTAssertEqual(tracker.receivedEncryptionType, EncryptionType.none)
+    }
+
+    func testReceiveUserPacketFromUnknownParticipant() {
+        let (room, tracker) = makeConnectedRoom()
+
+        // Participant not in room — should still deliver (participant is nil, broadcasted from server)
+        let payload = Data("msg".utf8)
+        let packet = TestData.userPacket(participantIdentity: "unknown", payload: payload, topic: "system")
+        room.engine(room, didReceiveUserPacket: packet, encryptionType: .none)
+        waitForDelegates()
+
+        XCTAssertEqual(tracker.receivedData, payload)
+        XCTAssertEqual(tracker.receivedTopic, "system")
+        XCTAssertNil(tracker.receivedParticipant)
+    }
+
+    func testReceiveUserPacketNotConnectedDoesNotNotify() {
+        let room = Room()
+        let tracker = DataDelegateTracker()
+        room.delegates.add(delegate: tracker)
+
+        // Room not connected — should skip delegate notification
+        let packet = TestData.userPacket()
+        room.engine(room, didReceiveUserPacket: packet, encryptionType: .none)
+        waitForDelegates()
+
+        XCTAssertNil(tracker.receivedData)
+    }
+
+    func testReceiveUserPacketWithEncryption() {
+        let (room, tracker) = makeConnectedRoom()
+        _ = addRemoteParticipant(to: room, identity: "remote-user")
+
+        let packet = TestData.userPacket(participantIdentity: "remote-user")
+        room.engine(room, didReceiveUserPacket: packet, encryptionType: .gcm)
+        waitForDelegates()
+
+        XCTAssertNotNil(tracker.receivedData)
+        XCTAssertEqual(tracker.receivedEncryptionType, .gcm)
+    }
+
+    // MARK: - Transcription
+
+    func testTranscriptionWithValidParticipantAndTrack() {
+        let (room, tracker) = makeConnectedRoom()
+        let audioTrack = TestData.trackInfo(sid: "TR_audio1", name: "mic", type: .audio, source: .microphone)
+        _ = addRemoteParticipant(to: room, identity: "remote-user", tracks: [audioTrack])
+
+        let seg = TestData.transcriptionSegment(id: "seg-1", text: "Hello", isFinal: false)
+        let transcription = TestData.transcription(
+            participantIdentity: "remote-user",
+            trackID: "TR_audio1",
+            segments: [seg]
+        )
+
+        room.room(didReceiveTranscriptionPacket: transcription)
+        waitForDelegates()
+
+        // Verify received time is tracked for non-final segment
+        let receivedTimes = room._state.read { $0.transcriptionReceivedTimes }
+        XCTAssertNotNil(receivedTimes["seg-1"])
+
+        // Verify delegate was called
+        XCTAssertEqual(tracker.transcriptionSegments?.count, 1)
+        XCTAssertEqual(tracker.transcriptionSegments?.first?.text, "Hello")
+        XCTAssertEqual(tracker.transcriptionSegments?.first?.id, "seg-1")
+        XCTAssertEqual(tracker.transcriptionParticipant?.identity?.stringValue, "remote-user")
+    }
+
+    func testTranscriptionFinalSegmentClearsReceivedTime() {
+        let (room, _) = makeConnectedRoom()
+        let audioTrack = TestData.trackInfo(sid: "TR_audio1", name: "mic", type: .audio, source: .microphone)
+        _ = addRemoteParticipant(to: room, identity: "remote-user", tracks: [audioTrack])
+
+        // First, non-final segment
+        let seg1 = TestData.transcriptionSegment(id: "seg-1", text: "Hello", isFinal: false)
+        let t1 = TestData.transcription(participantIdentity: "remote-user", trackID: "TR_audio1", segments: [seg1])
+        room.room(didReceiveTranscriptionPacket: t1)
+        XCTAssertNotNil(room._state.read { $0.transcriptionReceivedTimes["seg-1"] })
+
+        // Final segment — should clear
+        let seg2 = TestData.transcriptionSegment(id: "seg-1", text: "Hello world", isFinal: true)
+        let t2 = TestData.transcription(participantIdentity: "remote-user", trackID: "TR_audio1", segments: [seg2])
+        room.room(didReceiveTranscriptionPacket: t2)
+
+        XCTAssertNil(room._state.read { $0.transcriptionReceivedTimes["seg-1"] })
+    }
+
+    func testTranscriptionMultipleSegments() {
+        let (room, tracker) = makeConnectedRoom()
+        let audioTrack = TestData.trackInfo(sid: "TR_audio1", name: "mic", type: .audio, source: .microphone)
+        _ = addRemoteParticipant(to: room, identity: "remote-user", tracks: [audioTrack])
+
+        let seg1 = TestData.transcriptionSegment(id: "seg-1", text: "Hello", isFinal: false)
+        let seg2 = TestData.transcriptionSegment(id: "seg-2", text: "World", isFinal: true)
+        let transcription = TestData.transcription(
+            participantIdentity: "remote-user",
+            trackID: "TR_audio1",
+            segments: [seg1, seg2]
+        )
+
+        room.room(didReceiveTranscriptionPacket: transcription)
+        waitForDelegates()
+
+        let times = room._state.read { $0.transcriptionReceivedTimes }
+        XCTAssertNotNil(times["seg-1"]) // non-final: tracked
+        XCTAssertNil(times["seg-2"]) // final: removed
+        XCTAssertEqual(tracker.transcriptionSegments?.count, 2)
+    }
+
+    func testTranscriptionUnknownParticipantSkips() {
+        let (room, tracker) = makeConnectedRoom()
+
+        let seg = TestData.transcriptionSegment(id: "seg-1", text: "Hello")
+        let transcription = TestData.transcription(participantIdentity: "nonexistent", trackID: "TR_x", segments: [seg])
+
+        room.room(didReceiveTranscriptionPacket: transcription)
+        waitForDelegates()
+
+        // Should not crash, received times should be empty (early return before processing)
+        let times = room._state.read { $0.transcriptionReceivedTimes }
+        XCTAssertTrue(times.isEmpty)
+        XCTAssertNil(tracker.transcriptionSegments)
+    }
+
+    func testTranscriptionUnknownTrackSkips() {
+        let (room, tracker) = makeConnectedRoom()
+        _ = addRemoteParticipant(to: room, identity: "remote-user")
+
+        let seg = TestData.transcriptionSegment(id: "seg-1", text: "Hello")
+        let transcription = TestData.transcription(participantIdentity: "remote-user", trackID: "TR_unknown", segments: [seg])
+
+        room.room(didReceiveTranscriptionPacket: transcription)
+        waitForDelegates()
+
+        let times = room._state.read { $0.transcriptionReceivedTimes }
+        XCTAssertTrue(times.isEmpty)
+        XCTAssertNil(tracker.transcriptionSegments)
+    }
+
+    func testTranscriptionEmptySegmentsSkips() {
+        let (room, tracker) = makeConnectedRoom()
+        let audioTrack = TestData.trackInfo(sid: "TR_audio1", name: "mic", type: .audio, source: .microphone)
+        _ = addRemoteParticipant(to: room, identity: "remote-user", tracks: [audioTrack])
+
+        let transcription = TestData.transcription(
+            participantIdentity: "remote-user",
+            trackID: "TR_audio1",
+            segments: []
+        )
+
+        room.room(didReceiveTranscriptionPacket: transcription)
+        waitForDelegates()
+
+        let times = room._state.read { $0.transcriptionReceivedTimes }
+        XCTAssertTrue(times.isEmpty)
+        XCTAssertNil(tracker.transcriptionSegments)
+    }
+
+    func testTranscriptionForRemoteWithMultipleUpdates() {
+        let (room, _) = makeConnectedRoom()
+        let audioTrack = TestData.trackInfo(sid: "TR_audio1", name: "mic", type: .audio, source: .microphone)
+        _ = addRemoteParticipant(to: room, identity: "remote-user", tracks: [audioTrack])
+
+        // First non-final update
+        let seg1 = TestData.transcriptionSegment(id: "seg-1", text: "Hel", isFinal: false)
+        let t1 = TestData.transcription(participantIdentity: "remote-user", trackID: "TR_audio1", segments: [seg1])
+        room.room(didReceiveTranscriptionPacket: t1)
+
+        let firstTime = room._state.read { $0.transcriptionReceivedTimes["seg-1"] }
+        XCTAssertNotNil(firstTime)
+
+        // Second non-final update — firstReceivedTime should be preserved
+        let seg2 = TestData.transcriptionSegment(id: "seg-1", text: "Hello", isFinal: false)
+        let t2 = TestData.transcription(participantIdentity: "remote-user", trackID: "TR_audio1", segments: [seg2])
+        room.room(didReceiveTranscriptionPacket: t2)
+
+        let secondTime = room._state.read { $0.transcriptionReceivedTimes["seg-1"] }
+        XCTAssertNotNil(secondTime)
+        // The first received time should be preserved (not overwritten)
+        XCTAssertEqual(firstTime, secondTime)
+    }
+
+    // MARK: - RPC Response
+
+    func testReceiveRpcResponsePayloadExtraction() {
+        let (room, _) = makeConnectedRoom()
+
+        var response = Livekit_RpcResponse()
+        response.requestID = "req-123"
+        response.value = .payload("result-data")
+
+        // Verify the switch statement correctly extracts payload vs error
+        let (payload, error): (String?, RpcError?) = switch response.value {
+        case let .payload(v): (v, nil)
+        case let .error(e): (nil, RpcError.fromProto(e))
+        default: (nil, nil)
+        }
+
+        XCTAssertEqual(payload, "result-data")
+        XCTAssertNil(error)
+
+        // Also verify the handler doesn't crash with no pending completer
+        room.room(didReceiveRpcResponse: response)
+    }
+
+    func testReceiveRpcResponseErrorExtraction() {
+        let (room, _) = makeConnectedRoom()
+
+        var rpcError = Livekit_RpcError()
+        rpcError.code = 500
+        rpcError.message = "Internal error"
+
+        var response = Livekit_RpcResponse()
+        response.requestID = "req-456"
+        response.value = .error(rpcError)
+
+        // Verify error extraction
+        let (payload, error): (String?, RpcError?) = switch response.value {
+        case let .payload(v): (v, nil)
+        case let .error(e): (nil, RpcError.fromProto(e))
+        default: (nil, nil)
+        }
+
+        XCTAssertNil(payload)
+        XCTAssertNotNil(error)
+        XCTAssertEqual(error?.code, 500)
+        XCTAssertEqual(error?.message, "Internal error")
+
+        room.room(didReceiveRpcResponse: response)
+    }
+
+    // MARK: - RPC Ack
+
+    func testReceiveRpcAckExtractsRequestId() {
+        let (room, _) = makeConnectedRoom()
+
+        var ack = Livekit_RpcAck()
+        ack.requestID = "req-789"
+
+        // Verify the request ID is correctly extracted
+        XCTAssertEqual(ack.requestID, "req-789")
+
+        // Handler doesn't crash with no pending completer
+        room.room(didReceiveRpcAck: ack)
+    }
+
+    // MARK: - RPC Request
+
+    func testReceiveRpcRequestParsesFields() async {
+        let (room, _) = makeConnectedRoom()
+
+        var request = Livekit_RpcRequest()
+        request.id = "incoming-req-1"
+        request.method = "greet"
+        request.payload = "{\"name\": \"test\"}"
+        request.responseTimeoutMs = 5000
+        request.version = 1
+
+        // Verify field extraction matches what the handler parses
+        XCTAssertEqual(request.id, "incoming-req-1")
+        XCTAssertEqual(request.method, "greet")
+        XCTAssertEqual(request.payload, "{\"name\": \"test\"}")
+        let responseTimeout = TimeInterval(UInt64(request.responseTimeoutMs) / UInt64(1000))
+        XCTAssertEqual(responseTimeout, 5.0)
+        XCTAssertEqual(Int(request.version), 1)
+
+        room.room(didReceiveRpcRequest: request, from: "remote-user")
+
+        // Allow the Task to dispatch
+        try? await Task.sleep(nanoseconds: 100_000_000)
+    }
+}

--- a/Tests/LiveKitCoreTests/Core/RoomSignalDelegateTests.swift
+++ b/Tests/LiveKitCoreTests/Core/RoomSignalDelegateTests.swift
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+/// Tests for Room's SignalClientDelegate method implementations.
+/// These test the business logic in Room+SignalClientDelegate.swift by calling
+/// the delegate methods directly with test data, bypassing the WebSocket layer.
+class RoomSignalDelegateTests: LKTestCase {
+    // MARK: - Helper
+
+    /// Creates a Room in a simulated connected state suitable for delegate testing.
+    private func makeConnectedRoom() -> Room {
+        let room = Room()
+        room._state.mutate {
+            $0.connectionState = .connected
+        }
+        // Set local participant info so it has a valid identity/sid
+        let localInfo = TestData.participantInfo(sid: "PA_local", identity: "local-user", name: "Local User")
+        room.localParticipant.set(info: localInfo, connectionState: .connected)
+        return room
+    }
+
+    // MARK: - didReceiveConnectResponse (Join)
+
+    func testJoinResponseSetsRoomProperties() async {
+        let room = Room()
+        let joinResponse = TestData.joinResponse(
+            room: TestData.roomInfo(sid: "RM_abc", name: "my-room", metadata: "room-meta", maxParticipants: 50, numParticipants: 3, numPublishers: 1, creationTime: 1_700_000_000),
+            participant: TestData.participantInfo(sid: "PA_local", identity: "local-user"),
+            serverInfo: TestData.serverInfo(version: "1.8.0", region: "us-west-2", nodeID: "node-xyz")
+        )
+
+        await room.signalClient(room.signalClient, didReceiveConnectResponse: .join(joinResponse))
+
+        XCTAssertEqual(room.sid?.stringValue, "RM_abc")
+        XCTAssertEqual(room.name, "my-room")
+        XCTAssertEqual(room.metadata, "room-meta")
+        XCTAssertEqual(room.maxParticipants, 50)
+        XCTAssertEqual(room.participantCount, 3)
+        XCTAssertEqual(room.publishersCount, 1)
+        XCTAssertEqual(room.serverVersion, "1.8.0")
+        XCTAssertEqual(room.serverRegion, "us-west-2")
+        XCTAssertEqual(room.serverNodeId, "node-xyz")
+        XCTAssertNotNil(room.creationTime)
+    }
+
+    func testJoinResponseSetsLocalParticipant() async {
+        let room = Room()
+        let joinResponse = TestData.joinResponse(
+            participant: TestData.participantInfo(sid: "PA_me", identity: "my-identity", name: "My Name")
+        )
+
+        await room.signalClient(room.signalClient, didReceiveConnectResponse: .join(joinResponse))
+
+        XCTAssertEqual(room.localParticipant.sid?.stringValue, "PA_me")
+        XCTAssertEqual(room.localParticipant.identity?.stringValue, "my-identity")
+        XCTAssertEqual(room.localParticipant.name, "My Name")
+    }
+
+    func testJoinResponseAddsOtherParticipants() async {
+        let room = Room()
+        let remote1 = TestData.participantInfo(sid: "PA_r1", identity: "remote-1", name: "Remote 1")
+        let remote2 = TestData.participantInfo(sid: "PA_r2", identity: "remote-2", name: "Remote 2")
+        let joinResponse = TestData.joinResponse(otherParticipants: [remote1, remote2])
+
+        await room.signalClient(room.signalClient, didReceiveConnectResponse: .join(joinResponse))
+
+        XCTAssertEqual(room.remoteParticipants.count, 2)
+        let identity1 = Participant.Identity(from: "remote-1")
+        let identity2 = Participant.Identity(from: "remote-2")
+        XCTAssertNotNil(room.remoteParticipants[identity1])
+        XCTAssertNotNil(room.remoteParticipants[identity2])
+        XCTAssertEqual(room.remoteParticipants[identity1]?.name, "Remote 1")
+    }
+
+    func testJoinResponseWithCreationTimeMs() async {
+        let room = Room()
+        let roomProto = Livekit_Room.with {
+            $0.sid = "RM_test"
+            $0.name = "test"
+            $0.creationTimeMs = 1_700_000_000_500 // ms precision
+        }
+        let joinResponse = TestData.joinResponse(room: roomProto)
+
+        await room.signalClient(room.signalClient, didReceiveConnectResponse: .join(joinResponse))
+
+        let expectedDate = Date(timeIntervalSince1970: 1_700_000_000.5)
+        XCTAssertEqual(room.creationTime?.timeIntervalSince1970 ?? 0, expectedDate.timeIntervalSince1970, accuracy: 0.001)
+    }
+
+    // MARK: - didUpdateRoom
+
+    func testUpdateRoomSetsMetadata() async {
+        let room = makeConnectedRoom()
+        let roomUpdate = Livekit_Room.with {
+            $0.metadata = "updated-meta"
+            $0.activeRecording = true
+            $0.numParticipants = 5
+            $0.numPublishers = 2
+        }
+
+        await room.signalClient(room.signalClient, didUpdateRoom: roomUpdate)
+
+        XCTAssertEqual(room.metadata, "updated-meta")
+        XCTAssertTrue(room.isRecording)
+        XCTAssertEqual(room.participantCount, 5)
+        XCTAssertEqual(room.publishersCount, 2)
+    }
+
+    // MARK: - didUpdateParticipants
+
+    func testUpdateParticipantsAddsNewRemoteParticipant() async {
+        let room = makeConnectedRoom()
+        let newParticipant = TestData.participantInfo(sid: "PA_new", identity: "new-user", name: "New User")
+
+        await room.signalClient(room.signalClient, didUpdateParticipants: [newParticipant])
+
+        let identity = Participant.Identity(from: "new-user")
+        XCTAssertEqual(room.remoteParticipants.count, 1)
+        XCTAssertEqual(room.remoteParticipants[identity]?.name, "New User")
+        XCTAssertEqual(room.remoteParticipants[identity]?.sid?.stringValue, "PA_new")
+    }
+
+    func testUpdateParticipantsUpdatesExistingParticipant() async {
+        let room = makeConnectedRoom()
+        // Add initial participant
+        let initial = TestData.participantInfo(sid: "PA_r1", identity: "remote-1", name: "Old Name", metadata: "old")
+        await room.signalClient(room.signalClient, didUpdateParticipants: [initial])
+
+        // Update the same participant
+        let updated = TestData.participantInfo(sid: "PA_r1", identity: "remote-1", name: "New Name", metadata: "new")
+        await room.signalClient(room.signalClient, didUpdateParticipants: [updated])
+
+        let identity = Participant.Identity(from: "remote-1")
+        XCTAssertEqual(room.remoteParticipants.count, 1)
+        XCTAssertEqual(room.remoteParticipants[identity]?.name, "New Name")
+        XCTAssertEqual(room.remoteParticipants[identity]?.metadata, "new")
+    }
+
+    func testUpdateParticipantsRemovesDisconnectedParticipant() async {
+        let room = makeConnectedRoom()
+        // Add participant first
+        let participant = TestData.participantInfo(sid: "PA_r1", identity: "remote-1", name: "User 1")
+        await room.signalClient(room.signalClient, didUpdateParticipants: [participant])
+        XCTAssertEqual(room.remoteParticipants.count, 1)
+
+        // Disconnect the participant
+        let disconnected = TestData.participantInfo(sid: "PA_r1", identity: "remote-1", state: .disconnected)
+        await room.signalClient(room.signalClient, didUpdateParticipants: [disconnected])
+
+        // Allow async cleanup
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        XCTAssertEqual(room.remoteParticipants.count, 0)
+    }
+
+    func testUpdateParticipantsUpdatesLocalParticipant() async {
+        let room = makeConnectedRoom()
+        // Update local participant metadata
+        let localUpdate = TestData.participantInfo(sid: "PA_local", identity: "local-user", name: "Updated Local", metadata: "new-meta")
+        await room.signalClient(room.signalClient, didUpdateParticipants: [localUpdate])
+
+        XCTAssertEqual(room.localParticipant.name, "Updated Local")
+        XCTAssertEqual(room.localParticipant.metadata, "new-meta")
+        // Should not create a remote participant for local identity
+        XCTAssertEqual(room.remoteParticipants.count, 0)
+    }
+
+    func testUpdateParticipantsAddsMultipleNewParticipants() async {
+        let room = makeConnectedRoom()
+        let p1 = TestData.participantInfo(sid: "PA_1", identity: "user-1", name: "User 1")
+        let p2 = TestData.participantInfo(sid: "PA_2", identity: "user-2", name: "User 2")
+        let p3 = TestData.participantInfo(sid: "PA_3", identity: "user-3", name: "User 3")
+
+        await room.signalClient(room.signalClient, didUpdateParticipants: [p1, p2, p3])
+
+        XCTAssertEqual(room.remoteParticipants.count, 3)
+    }
+
+    // MARK: - didUpdateSpeakers
+
+    func testUpdateSpeakersSetsSpeakingState() async {
+        let room = makeConnectedRoom()
+        // Add remote participant
+        let remoteInfo = TestData.participantInfo(sid: "PA_r1", identity: "remote-1")
+        await room.signalClient(room.signalClient, didUpdateParticipants: [remoteInfo])
+
+        let identity = Participant.Identity(from: "remote-1")
+        let remote = room.remoteParticipants[identity]!
+
+        // Set speaker active
+        let speaker = TestData.speakerInfo(sid: "PA_r1", level: 0.9, active: true)
+        await room.signalClient(room.signalClient, didUpdateSpeakers: [speaker])
+
+        XCTAssertTrue(remote.isSpeaking)
+        XCTAssertEqual(remote.audioLevel, 0.9, accuracy: 0.01)
+        XCTAssertNotNil(remote.lastSpokeAt)
+    }
+
+    func testUpdateSpeakersStopsSpeaking() async {
+        let room = makeConnectedRoom()
+        let remoteInfo = TestData.participantInfo(sid: "PA_r1", identity: "remote-1")
+        await room.signalClient(room.signalClient, didUpdateParticipants: [remoteInfo])
+
+        // Start speaking
+        let speakerOn = TestData.speakerInfo(sid: "PA_r1", level: 0.8, active: true)
+        await room.signalClient(room.signalClient, didUpdateSpeakers: [speakerOn])
+
+        let identity = Participant.Identity(from: "remote-1")
+        let remote = room.remoteParticipants[identity]!
+        XCTAssertTrue(remote.isSpeaking)
+
+        // Stop speaking
+        let speakerOff = TestData.speakerInfo(sid: "PA_r1", level: 0.0, active: false)
+        await room.signalClient(room.signalClient, didUpdateSpeakers: [speakerOff])
+
+        XCTAssertFalse(remote.isSpeaking)
+    }
+
+    func testUpdateSpeakersUpdatesActiveSpeakers() async {
+        let room = makeConnectedRoom()
+        let r1 = TestData.participantInfo(sid: "PA_r1", identity: "remote-1")
+        let r2 = TestData.participantInfo(sid: "PA_r2", identity: "remote-2")
+        await room.signalClient(room.signalClient, didUpdateParticipants: [r1, r2])
+
+        let s1 = TestData.speakerInfo(sid: "PA_r1", level: 0.5, active: true)
+        let s2 = TestData.speakerInfo(sid: "PA_r2", level: 0.9, active: true)
+        await room.signalClient(room.signalClient, didUpdateSpeakers: [s1, s2])
+
+        XCTAssertEqual(room.activeSpeakers.count, 2)
+    }
+
+    func testUpdateSpeakersForLocalParticipant() async {
+        let room = makeConnectedRoom()
+
+        let speaker = TestData.speakerInfo(sid: "PA_local", level: 0.7, active: true)
+        await room.signalClient(room.signalClient, didUpdateSpeakers: [speaker])
+
+        XCTAssertTrue(room.localParticipant.isSpeaking)
+        XCTAssertEqual(room.localParticipant.audioLevel, 0.7, accuracy: 0.01)
+    }
+
+    // MARK: - didUpdateConnectionQuality
+
+    func testUpdateConnectionQualityForRemoteParticipant() async {
+        let room = makeConnectedRoom()
+        let remoteInfo = TestData.participantInfo(sid: "PA_r1", identity: "remote-1")
+        await room.signalClient(room.signalClient, didUpdateParticipants: [remoteInfo])
+
+        let quality = TestData.connectionQualityInfo(participantSid: "PA_r1", quality: .excellent)
+        await room.signalClient(room.signalClient, didUpdateConnectionQuality: [quality])
+
+        let identity = Participant.Identity(from: "remote-1")
+        XCTAssertEqual(room.remoteParticipants[identity]?.connectionQuality, .excellent)
+    }
+
+    func testUpdateConnectionQualityForLocalParticipant() async {
+        let room = makeConnectedRoom()
+
+        let quality = TestData.connectionQualityInfo(participantSid: "PA_local", quality: .poor)
+        await room.signalClient(room.signalClient, didUpdateConnectionQuality: [quality])
+
+        XCTAssertEqual(room.localParticipant.connectionQuality, .poor)
+    }
+
+    func testUpdateConnectionQualityMultipleParticipants() async {
+        let room = makeConnectedRoom()
+        let r1 = TestData.participantInfo(sid: "PA_r1", identity: "remote-1")
+        let r2 = TestData.participantInfo(sid: "PA_r2", identity: "remote-2")
+        await room.signalClient(room.signalClient, didUpdateParticipants: [r1, r2])
+
+        let q1 = TestData.connectionQualityInfo(participantSid: "PA_r1", quality: .good)
+        let q2 = TestData.connectionQualityInfo(participantSid: "PA_r2", quality: .poor)
+        await room.signalClient(room.signalClient, didUpdateConnectionQuality: [q1, q2])
+
+        let id1 = Participant.Identity(from: "remote-1")
+        let id2 = Participant.Identity(from: "remote-2")
+        XCTAssertEqual(room.remoteParticipants[id1]?.connectionQuality, .good)
+        XCTAssertEqual(room.remoteParticipants[id2]?.connectionQuality, .poor)
+    }
+
+    // MARK: - didUpdateToken
+
+    func testUpdateTokenUpdatesRoomToken() async {
+        let room = makeConnectedRoom()
+        room._state.mutate { $0.token = "old-token" }
+
+        await room.signalClient(room.signalClient, didUpdateToken: "new-refreshed-token")
+
+        XCTAssertEqual(room.token, "new-refreshed-token")
+    }
+
+    // MARK: - didReceiveLeave
+
+    func testLeaveDisconnectCleansUpRoom() async {
+        let room = makeConnectedRoom()
+        let remoteInfo = TestData.participantInfo(sid: "PA_r1", identity: "remote-1")
+        await room.signalClient(room.signalClient, didUpdateParticipants: [remoteInfo])
+        XCTAssertEqual(room.remoteParticipants.count, 1)
+
+        await room.signalClient(room.signalClient, didReceiveLeave: .disconnect, reason: .clientInitiated, regions: nil)
+
+        // Allow async cleanup
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        XCTAssertEqual(room.connectionState, .disconnected)
+    }
+
+    func testLeaveReconnectSetsNextReconnectMode() async {
+        let room = makeConnectedRoom()
+
+        await room.signalClient(room.signalClient, didReceiveLeave: .reconnect, reason: .unknownReason, regions: nil)
+
+        // The nextReconnectMode should be set to .full
+        let nextMode = room._state.read { $0.nextReconnectMode }
+        XCTAssertEqual(nextMode, .full)
+    }
+
+    // MARK: - didUpdateParticipants with tracks
+
+    func testUpdateParticipantsWithTracksCreatesPublications() async {
+        let room = makeConnectedRoom()
+        let track = TestData.trackInfo(sid: "TR_audio1", name: "microphone", type: .audio, source: .microphone)
+        let participant = TestData.participantInfo(sid: "PA_r1", identity: "remote-1", tracks: [track])
+
+        await room.signalClient(room.signalClient, didUpdateParticipants: [participant])
+
+        let identity = Participant.Identity(from: "remote-1")
+        let remote = room.remoteParticipants[identity]
+        XCTAssertNotNil(remote)
+        XCTAssertEqual(remote?.trackPublications.count, 1)
+        let trackSid = Track.Sid(from: "TR_audio1")
+        XCTAssertNotNil(remote?.trackPublications[trackSid])
+    }
+}

--- a/Tests/LiveKitCoreTests/Core/RoomSignalDelegateTests.swift
+++ b/Tests/LiveKitCoreTests/Core/RoomSignalDelegateTests.swift
@@ -14,14 +14,32 @@
  * limitations under the License.
  */
 
+// swiftlint:disable file_length
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @testable import LiveKit
 #if canImport(LiveKitTestSupport)
 import LiveKitTestSupport
 #endif
 
-/// Tests for Room's SignalClientDelegate method implementations.
-/// These test the business logic in Room+SignalClientDelegate.swift by calling
-/// the delegate methods directly with test data, bypassing the WebSocket layer.
+// Tests for Room's SignalClientDelegate method implementations.
+// These test the business logic in Room+SignalClientDelegate.swift by calling
+// the delegate methods directly with test data, bypassing the WebSocket layer.
+// swiftlint:disable:next type_body_length
 class RoomSignalDelegateTests: LKTestCase {
     // MARK: - Helper
 

--- a/Tests/LiveKitCoreTests/Core/RoomStateMachineTests.swift
+++ b/Tests/LiveKitCoreTests/Core/RoomStateMachineTests.swift
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+/// Lightweight delegate tracker for verifying Room delegate calls in state machine tests.
+private final class StateMachineDelegateTracker: RoomDelegate, @unchecked Sendable {
+    var didConnect = false
+    var didReconnect = false
+    var isReconnecting = false
+    var didFailToConnect = false
+    var didDisconnect = false
+    var lastDisconnectError: LiveKitError?
+    var didStartReconnectMode: ReconnectMode?
+    var didCompleteReconnectMode: ReconnectMode?
+    var didUpdateReconnectMode: ReconnectMode?
+    var connectionStateUpdates: [(ConnectionState, ConnectionState)] = []
+    var speakingParticipants: [Participant]?
+
+    func roomDidConnect(_: Room) { didConnect = true }
+    func roomDidReconnect(_: Room) { didReconnect = true }
+    func roomIsReconnecting(_: Room) { isReconnecting = true }
+    func room(_: Room, didFailToConnectWithError _: LiveKitError?) { didFailToConnect = true }
+    func room(_: Room, didDisconnectWithError error: LiveKitError?) { didDisconnect = true; lastDisconnectError = error }
+    func room(_: Room, didUpdateConnectionState connectionState: ConnectionState, from oldConnectionState: ConnectionState) {
+        connectionStateUpdates.append((connectionState, oldConnectionState))
+    }
+
+    func room(_: Room, didStartReconnectWithMode reconnectMode: ReconnectMode) { didStartReconnectMode = reconnectMode }
+    func room(_: Room, didCompleteReconnectWithMode reconnectMode: ReconnectMode) { didCompleteReconnectMode = reconnectMode }
+    func room(_: Room, didUpdateReconnectMode reconnectMode: ReconnectMode) { didUpdateReconnectMode = reconnectMode }
+    func room(_: Room, didUpdateSpeakingParticipants participants: [Participant]) { speakingParticipants = participants }
+}
+
+/// Tests for Room's `engine(_:didMutateState:oldState:)` state machine handler.
+/// Validates connection state transitions, reconnection notifications, and cleanup.
+class RoomStateMachineTests: LKTestCase {
+    // MARK: - Helper
+
+    private func makeRoom() -> (Room, StateMachineDelegateTracker) {
+        let room = Room()
+        let localInfo = TestData.participantInfo(sid: "PA_local", identity: "local-user")
+        room.localParticipant.set(info: localInfo, connectionState: .connected)
+        let tracker = StateMachineDelegateTracker()
+        room.delegates.add(delegate: tracker)
+        return (room, tracker)
+    }
+
+    /// Wait for MulticastDelegate's async dispatch to complete.
+    private func waitForDelegates() {
+        let exp = expectation(description: "delegate dispatch")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    // MARK: - Connection State Transitions
+
+    func testConnectedFromConnecting() {
+        let (room, tracker) = makeRoom()
+        let oldState = TestData.roomState(connectionState: .connecting)
+        let newState = TestData.roomState(connectionState: .connected)
+
+        room.engine(room, didMutateState: newState, oldState: oldState)
+        waitForDelegates()
+
+        XCTAssertTrue(tracker.didConnect)
+        XCTAssertFalse(tracker.didReconnect)
+        XCTAssertEqual(tracker.connectionStateUpdates.count, 1)
+        XCTAssertEqual(tracker.connectionStateUpdates.first?.0, .connected)
+        XCTAssertEqual(tracker.connectionStateUpdates.first?.1, .connecting)
+    }
+
+    func testConnectedFromReconnecting() {
+        let (room, tracker) = makeRoom()
+        let oldState = TestData.roomState(connectionState: .reconnecting, isReconnectingWithMode: .quick)
+        let newState = TestData.roomState(connectionState: .connected)
+
+        room.engine(room, didMutateState: newState, oldState: oldState)
+        waitForDelegates()
+
+        XCTAssertTrue(tracker.didReconnect)
+        XCTAssertFalse(tracker.didConnect)
+    }
+
+    func testReconnectingState() {
+        let (room, tracker) = makeRoom()
+        let oldState = TestData.roomState(connectionState: .connected)
+        let newState = TestData.roomState(connectionState: .reconnecting, isReconnectingWithMode: .quick)
+
+        room.engine(room, didMutateState: newState, oldState: oldState)
+        waitForDelegates()
+
+        XCTAssertTrue(tracker.isReconnecting)
+        XCTAssertFalse(tracker.didConnect)
+        XCTAssertFalse(tracker.didDisconnect)
+    }
+
+    func testDisconnectedFromConnecting() {
+        let (room, tracker) = makeRoom()
+        let oldState = TestData.roomState(connectionState: .connecting)
+        let newState = TestData.roomState(connectionState: .disconnected)
+
+        room.engine(room, didMutateState: newState, oldState: oldState)
+        waitForDelegates()
+
+        XCTAssertTrue(tracker.didFailToConnect)
+        XCTAssertFalse(tracker.didDisconnect)
+    }
+
+    func testDisconnectedFromConnected() {
+        let (room, tracker) = makeRoom()
+        let error = LiveKitError(.unknown, message: "test error")
+        let oldState = TestData.roomState(connectionState: .connected)
+        let newState = TestData.roomState(connectionState: .disconnected, disconnectError: error)
+
+        room.engine(room, didMutateState: newState, oldState: oldState)
+        waitForDelegates()
+
+        XCTAssertTrue(tracker.didDisconnect)
+        XCTAssertFalse(tracker.didFailToConnect)
+    }
+
+    func testNoChangeDoesNotTriggerConnectionDelegate() {
+        let (room, tracker) = makeRoom()
+        let state = TestData.roomState(connectionState: .connected)
+
+        // Same state → should not trigger connection-change logic
+        room.engine(room, didMutateState: state, oldState: state)
+        waitForDelegates()
+
+        XCTAssertFalse(tracker.didConnect)
+        XCTAssertFalse(tracker.didReconnect)
+        XCTAssertFalse(tracker.didDisconnect)
+        XCTAssertFalse(tracker.didFailToConnect)
+        XCTAssertTrue(tracker.connectionStateUpdates.isEmpty)
+    }
+
+    // MARK: - Quick Reconnect Resets Track Settings
+
+    func testQuickReconnectResetsTrackSettings() {
+        let (room, _) = makeRoom()
+        // Add a remote participant with a track publication
+        let trackInfo = TestData.trackInfo(sid: "TR_v1", name: "camera", type: .video, source: .camera)
+        let remoteInfo = TestData.participantInfo(sid: "PA_r1", identity: "remote-1", tracks: [trackInfo])
+        room._state.mutate { $0.remoteParticipants[Participant.Identity(from: "remote-1")] =
+            RemoteParticipant(info: remoteInfo, room: room, connectionState: .connected)
+        }
+
+        // Simulate quick reconnect completing
+        let oldState = TestData.roomState(connectionState: .reconnecting, isReconnectingWithMode: .quick)
+        var newState = TestData.roomState(connectionState: .connected)
+        newState.isReconnectingWithMode = .quick
+
+        room.engine(room, didMutateState: newState, oldState: oldState)
+
+        // Track settings should have been reset
+        let identity = Participant.Identity(from: "remote-1")
+        if let pub = room.remoteParticipants[identity]?.trackPublications.values.first as? RemoteTrackPublication {
+            // resetTrackSettings sets enabled based on adaptiveStream (default: false → enabled=true)
+            XCTAssertTrue(pub.isEnabled)
+        }
+    }
+
+    // MARK: - Reconnection Mode Notifications
+
+    func testReconnectionStartNotification() {
+        let (room, tracker) = makeRoom()
+        let oldState = TestData.roomState(connectionState: .connected, isReconnectingWithMode: nil)
+        let newState = TestData.roomState(connectionState: .reconnecting, isReconnectingWithMode: .quick)
+
+        room.engine(room, didMutateState: newState, oldState: oldState)
+        waitForDelegates()
+
+        XCTAssertEqual(tracker.didStartReconnectMode, .quick)
+    }
+
+    func testReconnectionCompleteNotification() {
+        let (room, tracker) = makeRoom()
+        let oldState = TestData.roomState(connectionState: .reconnecting, isReconnectingWithMode: .quick)
+        let newState = TestData.roomState(connectionState: .connected, isReconnectingWithMode: nil)
+
+        room.engine(room, didMutateState: newState, oldState: oldState)
+        waitForDelegates()
+
+        XCTAssertEqual(tracker.didCompleteReconnectMode, .quick)
+    }
+
+    func testReconnectionModeChange() {
+        let (room, tracker) = makeRoom()
+        let oldState = TestData.roomState(connectionState: .reconnecting, isReconnectingWithMode: .quick)
+        let newState = TestData.roomState(connectionState: .reconnecting, isReconnectingWithMode: .full)
+
+        room.engine(room, didMutateState: newState, oldState: oldState)
+        waitForDelegates()
+
+        XCTAssertEqual(tracker.didUpdateReconnectMode, .full)
+    }
+
+    func testFullReconnectCompleteTriggersRepublish() {
+        let (room, tracker) = makeRoom()
+        let oldState = TestData.roomState(connectionState: .reconnecting, isReconnectingWithMode: .full)
+        let newState = TestData.roomState(connectionState: .connected)
+
+        room.engine(room, didMutateState: newState, oldState: oldState)
+        waitForDelegates()
+
+        // Verifies reconnect delegate fired and republish Task was dispatched (no crash)
+        XCTAssertTrue(tracker.didReconnect)
+        XCTAssertEqual(tracker.didCompleteReconnectMode, .full)
+    }
+
+    // MARK: - Disconnected Clears E2EE Manager
+
+    func testDisconnectedClearsE2EEManager() {
+        let (room, tracker) = makeRoom()
+        let oldState = TestData.roomState(connectionState: .connected)
+        let newState = TestData.roomState(connectionState: .disconnected)
+
+        room.engine(room, didMutateState: newState, oldState: oldState)
+        waitForDelegates()
+
+        XCTAssertNil(room.e2eeManager)
+        XCTAssertTrue(tracker.didDisconnect)
+    }
+
+    // MARK: - Speaker Updates via Engine Delegate
+
+    func testSpeakerUpdateSetsLocalParticipantSpeaking() {
+        let (room, tracker) = makeRoom()
+        room._state.mutate { $0.connectionState = .connected }
+
+        let speaker = TestData.speakerInfo(sid: "PA_local", level: 0.85, active: true)
+        room.engine(room, didUpdateSpeakers: [speaker])
+        waitForDelegates()
+
+        XCTAssertTrue(room.localParticipant.isSpeaking)
+        XCTAssertEqual(room.localParticipant.audioLevel, 0.85, accuracy: 0.01)
+        XCTAssertNotNil(tracker.speakingParticipants)
+        XCTAssertEqual(tracker.speakingParticipants?.count, 1)
+    }
+
+    func testSpeakerUpdateSetsRemoteParticipantSpeaking() {
+        let (room, _) = makeRoom()
+        room._state.mutate { $0.connectionState = .connected }
+        let remoteInfo = TestData.participantInfo(sid: "PA_r1", identity: "remote-1")
+        let remote = RemoteParticipant(info: remoteInfo, room: room, connectionState: .connected)
+        room._state.mutate { $0.remoteParticipants[Participant.Identity(from: "remote-1")] = remote }
+
+        let speaker = TestData.speakerInfo(sid: "PA_r1", level: 0.6, active: true)
+        room.engine(room, didUpdateSpeakers: [speaker])
+
+        XCTAssertTrue(remote.isSpeaking)
+        XCTAssertEqual(remote.audioLevel, 0.6, accuracy: 0.01)
+        XCTAssertNotNil(remote.lastSpokeAt)
+    }
+
+    func testSpeakerUpdateResetsNotSpeakingParticipants() {
+        let (room, _) = makeRoom()
+        room._state.mutate { $0.connectionState = .connected }
+        let remoteInfo = TestData.participantInfo(sid: "PA_r1", identity: "remote-1")
+        let remote = RemoteParticipant(info: remoteInfo, room: room, connectionState: .connected)
+        room._state.mutate { $0.remoteParticipants[Participant.Identity(from: "remote-1")] = remote }
+
+        // First, make remote speaking
+        remote._state.mutate {
+            $0.isSpeaking = true
+            $0.audioLevel = 0.9
+        }
+
+        // Update speakers with only local → remote should stop speaking
+        let localSpeaker = TestData.speakerInfo(sid: "PA_local", level: 0.5, active: true)
+        room.engine(room, didUpdateSpeakers: [localSpeaker])
+
+        XCTAssertFalse(remote.isSpeaking)
+        XCTAssertEqual(remote.audioLevel, 0.0, accuracy: 0.01)
+    }
+
+    func testSpeakerUpdateResetsLocalWhenNotInList() {
+        let (room, _) = makeRoom()
+        room._state.mutate { $0.connectionState = .connected }
+
+        // Make local speaking first
+        room.localParticipant._state.mutate {
+            $0.isSpeaking = true
+            $0.audioLevel = 0.8
+        }
+
+        // Remote participant only in speakers
+        let remoteInfo = TestData.participantInfo(sid: "PA_r1", identity: "remote-1")
+        let remote = RemoteParticipant(info: remoteInfo, room: room, connectionState: .connected)
+        room._state.mutate { $0.remoteParticipants[Participant.Identity(from: "remote-1")] = remote }
+
+        let remoteSpeaker = TestData.speakerInfo(sid: "PA_r1", level: 0.7, active: true)
+        room.engine(room, didUpdateSpeakers: [remoteSpeaker])
+
+        // Local should be reset
+        XCTAssertFalse(room.localParticipant.isSpeaking)
+        XCTAssertEqual(room.localParticipant.audioLevel, 0.0, accuracy: 0.01)
+    }
+
+    func testSpeakerUpdateMultipleParticipants() {
+        let (room, tracker) = makeRoom()
+        room._state.mutate { $0.connectionState = .connected }
+        let r1Info = TestData.participantInfo(sid: "PA_r1", identity: "remote-1")
+        let r1 = RemoteParticipant(info: r1Info, room: room, connectionState: .connected)
+        room._state.mutate { $0.remoteParticipants[Participant.Identity(from: "remote-1")] = r1 }
+
+        let s1 = TestData.speakerInfo(sid: "PA_local", level: 0.5)
+        let s2 = TestData.speakerInfo(sid: "PA_r1", level: 0.8)
+        room.engine(room, didUpdateSpeakers: [s1, s2])
+        waitForDelegates()
+
+        // Both participants should have speaking state updated
+        XCTAssertTrue(room.localParticipant.isSpeaking)
+        XCTAssertTrue(r1.isSpeaking)
+        XCTAssertEqual(r1.audioLevel, 0.8, accuracy: 0.01)
+        XCTAssertEqual(tracker.speakingParticipants?.count, 2)
+    }
+
+    func testSpeakerUpdateSetsLastSpokeAtOnlyOnTransition() {
+        let (room, _) = makeRoom()
+        room._state.mutate { $0.connectionState = .connected }
+
+        // First update — should set lastSpokeAt
+        let speaker1 = TestData.speakerInfo(sid: "PA_local", level: 0.5)
+        room.engine(room, didUpdateSpeakers: [speaker1])
+        let firstSpokeAt = room.localParticipant.lastSpokeAt
+
+        XCTAssertNotNil(firstSpokeAt)
+
+        // Second update while still speaking — lastSpokeAt should NOT change
+        let speaker2 = TestData.speakerInfo(sid: "PA_local", level: 0.7)
+        room.engine(room, didUpdateSpeakers: [speaker2])
+        let secondSpokeAt = room.localParticipant.lastSpokeAt
+
+        XCTAssertEqual(firstSpokeAt, secondSpokeAt)
+    }
+}

--- a/Tests/LiveKitCoreTests/Core/SignalClientDispatchTests.swift
+++ b/Tests/LiveKitCoreTests/Core/SignalClientDispatchTests.swift
@@ -14,15 +14,33 @@
  * limitations under the License.
  */
 
+// swiftlint:disable file_length
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @testable import LiveKit
 #if canImport(LiveKitTestSupport)
 import LiveKitTestSupport
 #endif
 
-/// Tests for SignalClient._process response dispatch.
-/// These inject Livekit_SignalResponse messages through SignalClient's _process method,
-/// which dispatches to its delegate (Room), testing the full pipeline:
-/// signalResponse -> SignalClient._process -> delegate notification -> Room handler.
+// Tests for SignalClient._process response dispatch.
+// These inject Livekit_SignalResponse messages through SignalClient's _process method,
+// which dispatches to its delegate (Room), testing the full pipeline:
+// signalResponse -> SignalClient._process -> delegate notification -> Room handler.
+// swiftlint:disable:next type_body_length
 class SignalClientDispatchTests: LKTestCase {
     // MARK: - Helper
 

--- a/Tests/LiveKitCoreTests/Core/SignalClientDispatchTests.swift
+++ b/Tests/LiveKitCoreTests/Core/SignalClientDispatchTests.swift
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+/// Tests for SignalClient._process response dispatch.
+/// These inject Livekit_SignalResponse messages through SignalClient's _process method,
+/// which dispatches to its delegate (Room), testing the full pipeline:
+/// signalResponse -> SignalClient._process -> delegate notification -> Room handler.
+class SignalClientDispatchTests: LKTestCase {
+    // MARK: - Helper
+
+    private func makeHelper() -> RoomTestHelper {
+        RoomTestHelper()
+    }
+
+    /// Wait for AsyncSerialDelegate's detached dispatch.
+    private func waitForDispatch() async {
+        try? await Task.sleep(nanoseconds: 150_000_000)
+    }
+
+    // MARK: - Join Response
+
+    func testProcessJoinResponseSetsRoomProperties() async {
+        let helper = makeHelper()
+        let joinResponse = TestData.joinResponse(
+            room: TestData.roomInfo(sid: "RM_dispatch", name: "dispatch-room"),
+            participant: TestData.participantInfo(sid: "PA_local", identity: "local-user"),
+            serverInfo: TestData.serverInfo(version: "2.0.0", region: "eu-west-1")
+        )
+
+        await helper.processSignalResponse(TestData.signalResponse(join: joinResponse))
+        await waitForDispatch()
+
+        XCTAssertEqual(helper.room.sid?.stringValue, "RM_dispatch")
+        XCTAssertEqual(helper.room.name, "dispatch-room")
+        XCTAssertEqual(helper.room.serverVersion, "2.0.0")
+        XCTAssertEqual(helper.room.serverRegion, "eu-west-1")
+    }
+
+    func testProcessJoinResponseAddsRemoteParticipants() async {
+        let helper = makeHelper()
+        let remote = TestData.participantInfo(sid: "PA_r1", identity: "remote-1", name: "Remote 1")
+        let joinResponse = TestData.joinResponse(
+            participant: TestData.participantInfo(sid: "PA_local", identity: "local-user"),
+            otherParticipants: [remote]
+        )
+
+        await helper.processSignalResponse(TestData.signalResponse(join: joinResponse))
+        await waitForDispatch()
+
+        XCTAssertEqual(helper.room.remoteParticipants.count, 1)
+        XCTAssertNotNil(helper.room.remoteParticipants[Participant.Identity(from: "remote-1")])
+    }
+
+    func testProcessJoinResponseStoresLastJoinResponse() async {
+        let helper = makeHelper()
+        let joinResponse = TestData.joinResponse(
+            room: TestData.roomInfo(sid: "RM_stored", name: "stored-room"),
+            participant: TestData.participantInfo(sid: "PA_local", identity: "local-user")
+        )
+
+        await helper.processSignalResponse(TestData.signalResponse(join: joinResponse))
+        await waitForDispatch()
+
+        // Verify join response was processed by checking room properties set from it
+        XCTAssertEqual(helper.room.sid?.stringValue, "RM_stored")
+        XCTAssertEqual(helper.room.name, "stored-room")
+    }
+
+    // MARK: - Room Update
+
+    func testProcessRoomUpdateSetsMetadata() async {
+        let helper = makeHelper()
+        let roomUpdate = Livekit_Room.with {
+            $0.metadata = "process-meta"
+            $0.activeRecording = true
+            $0.numParticipants = 10
+            $0.numPublishers = 3
+        }
+
+        await helper.processSignalResponse(TestData.signalResponse(roomUpdate: roomUpdate))
+        await waitForDispatch()
+
+        XCTAssertEqual(helper.room.metadata, "process-meta")
+        XCTAssertTrue(helper.room.isRecording)
+        XCTAssertEqual(helper.room.participantCount, 10)
+        XCTAssertEqual(helper.room.publishersCount, 3)
+    }
+
+    // MARK: - Participant Update
+
+    func testProcessParticipantUpdateAddsParticipant() async {
+        let helper = makeHelper()
+        let participant = TestData.participantInfo(sid: "PA_new", identity: "new-user", name: "New User")
+
+        await helper.processSignalResponse(TestData.signalResponse(participantUpdate: [participant]))
+        await waitForDispatch()
+
+        XCTAssertEqual(helper.room.remoteParticipants.count, 1)
+        let identity = Participant.Identity(from: "new-user")
+        XCTAssertEqual(helper.room.remoteParticipants[identity]?.name, "New User")
+    }
+
+    func testProcessParticipantUpdateRemovesDisconnected() async {
+        let helper = makeHelper()
+        // Add participant first
+        let participant = TestData.participantInfo(sid: "PA_r1", identity: "remote-1")
+        await helper.processSignalResponse(TestData.signalResponse(participantUpdate: [participant]))
+        await waitForDispatch()
+        XCTAssertEqual(helper.room.remoteParticipants.count, 1)
+
+        // Disconnect
+        let disconnected = TestData.participantInfo(sid: "PA_r1", identity: "remote-1", state: .disconnected)
+        await helper.processSignalResponse(TestData.signalResponse(participantUpdate: [disconnected]))
+        await waitForDispatch()
+
+        XCTAssertEqual(helper.room.remoteParticipants.count, 0)
+    }
+
+    // MARK: - Speaker Update
+
+    func testProcessSpeakerUpdateSetsSpeakingState() async {
+        let helper = makeHelper()
+        // Add remote participant
+        let participant = TestData.participantInfo(sid: "PA_r1", identity: "remote-1")
+        await helper.processSignalResponse(TestData.signalResponse(participantUpdate: [participant]))
+        await waitForDispatch()
+
+        let speaker = TestData.speakerInfo(sid: "PA_r1", level: 0.85, active: true)
+        await helper.processSignalResponse(TestData.signalResponse(speakersChanged: [speaker]))
+        await waitForDispatch()
+
+        let identity = Participant.Identity(from: "remote-1")
+        let remote = helper.room.remoteParticipants[identity]
+        XCTAssertTrue(remote?.isSpeaking ?? false)
+        XCTAssertEqual(remote?.audioLevel ?? 0, 0.85, accuracy: 0.01)
+    }
+
+    // MARK: - Connection Quality
+
+    func testProcessConnectionQualityUpdatesParticipant() async {
+        let helper = makeHelper()
+        let participant = TestData.participantInfo(sid: "PA_r1", identity: "remote-1")
+        await helper.processSignalResponse(TestData.signalResponse(participantUpdate: [participant]))
+        await waitForDispatch()
+
+        let quality = TestData.connectionQualityInfo(participantSid: "PA_r1", quality: .excellent)
+        await helper.processSignalResponse(TestData.signalResponse(connectionQuality: [quality]))
+        await waitForDispatch()
+
+        let identity = Participant.Identity(from: "remote-1")
+        XCTAssertEqual(helper.room.remoteParticipants[identity]?.connectionQuality, .excellent)
+    }
+
+    func testProcessConnectionQualityUpdatesLocalParticipant() async {
+        let helper = makeHelper()
+
+        let quality = TestData.connectionQualityInfo(participantSid: "PA_local", quality: .poor)
+        await helper.processSignalResponse(TestData.signalResponse(connectionQuality: [quality]))
+        await waitForDispatch()
+
+        XCTAssertEqual(helper.room.localParticipant.connectionQuality, .poor)
+    }
+
+    // MARK: - Token Refresh
+
+    func testProcessTokenRefreshUpdatesToken() async {
+        let helper = makeHelper()
+        helper.room._state.mutate { $0.token = "old-token" }
+
+        await helper.processSignalResponse(TestData.signalResponse(refreshToken: "refreshed-token"))
+        await waitForDispatch()
+
+        XCTAssertEqual(helper.room.token, "refreshed-token")
+    }
+
+    // MARK: - Leave
+
+    func testProcessLeaveDisconnectCleansUp() async {
+        let helper = makeHelper()
+
+        await helper.processSignalResponse(TestData.signalResponse(leave: .disconnect, reason: .clientInitiated))
+        await waitForDispatch()
+
+        XCTAssertEqual(helper.room.connectionState, .disconnected)
+    }
+
+    func testProcessLeaveReconnectSetsFullMode() async {
+        let helper = makeHelper()
+
+        await helper.processSignalResponse(TestData.signalResponse(leave: .reconnect))
+        await waitForDispatch()
+
+        let nextMode = helper.room._state.read { $0.nextReconnectMode }
+        XCTAssertEqual(nextMode, .full)
+    }
+
+    // MARK: - Stream State Update
+
+    func testProcessStreamStateUpdateSetsStreamState() async {
+        let helper = makeHelper()
+        let trackInfo = TestData.trackInfo(sid: "TR_v1", name: "camera", type: .video, source: .camera)
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1", tracks: [trackInfo])
+
+        let stateInfo = TestData.streamStateInfo(participantSid: "PA_r1", trackSid: "TR_v1", state: .active)
+        await helper.processSignalResponse(TestData.signalResponse(streamStates: [stateInfo]))
+        await waitForDispatch()
+
+        let pub = participant.trackPublications[Track.Sid(from: "TR_v1")] as? RemoteTrackPublication
+        XCTAssertEqual(pub?.streamState, .active)
+    }
+
+    // MARK: - Subscription Permission Update
+
+    func testProcessSubscriptionPermissionUpdateSetsAllowed() async {
+        let helper = makeHelper()
+        let trackInfo = TestData.trackInfo(sid: "TR_v1", name: "camera", type: .video, source: .camera)
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1", tracks: [trackInfo])
+
+        let permUpdate = TestData.subscriptionPermissionUpdate(participantSid: "PA_r1", trackSid: "TR_v1", allowed: false)
+        await helper.processSignalResponse(TestData.signalResponse(subscriptionPermission: permUpdate))
+        await waitForDispatch()
+
+        let pub = participant.trackPublications[Track.Sid(from: "TR_v1")] as? RemoteTrackPublication
+        XCTAssertFalse(pub?.isSubscriptionAllowed ?? true)
+        XCTAssertEqual(pub?.subscriptionState, .notAllowed)
+    }
+
+    // MARK: - Mute Update
+
+    func testProcessMuteUpdateNoPublicationIsNoOp() async {
+        let helper = makeHelper()
+        let metadataBefore = helper.room.metadata
+
+        // Remote mute targets local publications — without a real published track, it's a no-op
+        await helper.processSignalResponse(TestData.signalResponse(mute: "TR_nonexistent", muted: true))
+        await waitForDispatch()
+
+        // State unchanged
+        XCTAssertEqual(helper.room.metadata, metadataBefore)
+    }
+
+    // MARK: - Pong
+
+    func testProcessPongDoesNotCrash() async {
+        let helper = makeHelper()
+        let connectionState = helper.room.connectionState
+
+        await helper.processSignalResponse(TestData.signalResponse(pong: 1_700_000_000_000))
+        await waitForDispatch()
+
+        // Connection state should remain unchanged
+        XCTAssertEqual(helper.room.connectionState, connectionState)
+    }
+
+    // MARK: - Guards
+
+    func testProcessSkipsWhenDisconnected() async {
+        let helper = makeHelper()
+        // Set signal client to disconnected
+        await helper.room.signalClient.setConnectionState(.disconnected)
+
+        let roomUpdate = Livekit_Room.with { $0.metadata = "should-not-apply" }
+        // Call _process directly (not through processSignalResponse which sets connected)
+        await helper.room.signalClient._process(signalResponse: TestData.signalResponse(roomUpdate: roomUpdate))
+        await waitForDispatch()
+
+        // Room metadata should NOT have changed
+        XCTAssertNotEqual(helper.room.metadata, "should-not-apply")
+    }
+
+    func testProcessSkipsEmptyMessage() async {
+        let helper = makeHelper()
+        let participantCount = helper.room.remoteParticipants.count
+
+        // Empty signal response with no message set
+        let emptyResponse = Livekit_SignalResponse()
+        await helper.processSignalResponse(emptyResponse)
+        await waitForDispatch()
+
+        // State unchanged
+        XCTAssertEqual(helper.room.remoteParticipants.count, participantCount)
+    }
+
+    // MARK: - Room Moved
+
+    func testProcessRoomMovedUpdatesState() async {
+        let helper = makeHelper()
+        let newRoom = TestData.roomInfo(sid: "RM_new", name: "new-room", metadata: "moved-meta")
+        let movedResponse = TestData.roomMovedResponse(
+            room: newRoom,
+            token: "moved-token",
+            participant: TestData.participantInfo(sid: "PA_local", identity: "local-user", name: "Updated Local")
+        )
+
+        await helper.processSignalResponse(TestData.signalResponse(roomMoved: movedResponse))
+        await waitForDispatch()
+
+        XCTAssertEqual(helper.room.sid?.stringValue, "RM_new")
+        XCTAssertEqual(helper.room.name, "new-room")
+        XCTAssertEqual(helper.room.token, "moved-token")
+    }
+
+    // MARK: - Track Subscribed
+
+    func testProcessTrackSubscribedNoPublicationIsNoOp() async {
+        let helper = makeHelper()
+        let connectionState = helper.room.connectionState
+
+        // Without a real local track publication, this is a no-op
+        await helper.processSignalResponse(TestData.signalResponse(trackSubscribed: "TR_nonexistent"))
+        await waitForDispatch()
+
+        // State unchanged
+        XCTAssertEqual(helper.room.connectionState, connectionState)
+    }
+
+    // MARK: - Multiple Responses in Sequence
+
+    func testProcessMultipleResponsesInSequence() async {
+        let helper = makeHelper()
+
+        // 1. Join
+        let joinResponse = TestData.joinResponse(
+            room: TestData.roomInfo(sid: "RM_seq", name: "seq-room"),
+            participant: TestData.participantInfo(sid: "PA_local", identity: "local-user")
+        )
+        await helper.processSignalResponse(TestData.signalResponse(join: joinResponse))
+        await waitForDispatch()
+
+        // 2. Participant update
+        let remote = TestData.participantInfo(sid: "PA_r1", identity: "remote-1")
+        await helper.processSignalResponse(TestData.signalResponse(participantUpdate: [remote]))
+        await waitForDispatch()
+
+        // 3. Speaker update
+        let speaker = TestData.speakerInfo(sid: "PA_r1", level: 0.7, active: true)
+        await helper.processSignalResponse(TestData.signalResponse(speakersChanged: [speaker]))
+        await waitForDispatch()
+
+        // 4. Connection quality
+        let quality = TestData.connectionQualityInfo(participantSid: "PA_r1", quality: .good)
+        await helper.processSignalResponse(TestData.signalResponse(connectionQuality: [quality]))
+        await waitForDispatch()
+
+        // Verify cumulative state
+        XCTAssertEqual(helper.room.name, "seq-room")
+        let identity = Participant.Identity(from: "remote-1")
+        let participant = helper.room.remoteParticipants[identity]
+        XCTAssertNotNil(participant)
+        XCTAssertTrue(participant?.isSpeaking ?? false)
+        XCTAssertEqual(participant?.connectionQuality, .good)
+    }
+}

--- a/Tests/LiveKitCoreTests/Core/SignalClientSendTests.swift
+++ b/Tests/LiveKitCoreTests/Core/SignalClientSendTests.swift
@@ -1,0 +1,793 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+/// Tests for SignalClient send methods using MockWebSocket.
+/// Verifies that each send method produces the correct protobuf message.
+class SignalClientSendTests: LKTestCase {
+    private var signalClient: SignalClient!
+    private var mockSocket: MockWebSocket!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        signalClient = SignalClient()
+        mockSocket = MockWebSocket()
+        await signalClient.setWebSocket(mockSocket)
+        await signalClient.setConnectionState(.connected)
+        await signalClient.resumeQueues()
+    }
+
+    /// Wait for the request queue to process.
+    private func waitForQueue() async {
+        try? await Task.sleep(nanoseconds: 100_000_000)
+    }
+
+    // MARK: - sendMuteTrack
+
+    func testSendMuteTrackProducesCorrectRequest() async throws {
+        try await signalClient.sendMuteTrack(trackSid: Track.Sid(from: "TR_audio1"), muted: true)
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        let request = mockSocket.sentRequests[0]
+        guard case .mute = request.message else {
+            return XCTFail("Expected .mute message, got \(String(describing: request.message))")
+        }
+        XCTAssertEqual(request.mute.sid, "TR_audio1")
+        XCTAssertTrue(request.mute.muted)
+    }
+
+    func testSendMuteTrackUnmute() async throws {
+        try await signalClient.sendMuteTrack(trackSid: Track.Sid(from: "TR_audio1"), muted: false)
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        XCTAssertFalse(mockSocket.sentRequests[0].mute.muted)
+    }
+
+    // MARK: - sendUpdateTrackSettings
+
+    func testSendUpdateTrackSettings() async throws {
+        let settings = TrackSettings(
+            enabled: true,
+            dimensions: Dimensions(width: 1280, height: 720),
+            videoQuality: .high,
+            preferredFPS: 30
+        )
+
+        try await signalClient.sendUpdateTrackSettings(trackSid: Track.Sid(from: "TR_video1"), settings: settings)
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        let request = mockSocket.sentRequests[0]
+        guard case .trackSetting = request.message else {
+            return XCTFail("Expected .trackSetting message")
+        }
+        XCTAssertEqual(request.trackSetting.trackSids, ["TR_video1"])
+        XCTAssertFalse(request.trackSetting.disabled) // isEnabled = true → disabled = false
+        XCTAssertEqual(request.trackSetting.width, 1280)
+        XCTAssertEqual(request.trackSetting.height, 720)
+        XCTAssertEqual(request.trackSetting.fps, 30)
+    }
+
+    func testSendUpdateTrackSettingsDisabled() async throws {
+        let settings = TrackSettings(
+            enabled: false,
+            dimensions: .zero,
+            videoQuality: .low,
+            preferredFPS: 0
+        )
+
+        try await signalClient.sendUpdateTrackSettings(trackSid: Track.Sid(from: "TR_video1"), settings: settings)
+        await waitForQueue()
+
+        let request = mockSocket.sentRequests[0]
+        XCTAssertTrue(request.trackSetting.disabled)
+    }
+
+    // MARK: - sendUpdateVideoLayers
+
+    func testSendUpdateVideoLayers() async throws {
+        let layers = [
+            Livekit_VideoLayer.with {
+                $0.quality = .high
+                $0.width = 1920
+                $0.height = 1080
+            },
+            Livekit_VideoLayer.with {
+                $0.quality = .low
+                $0.width = 480
+                $0.height = 270
+            },
+        ]
+
+        try await signalClient.sendUpdateVideoLayers(trackSid: Track.Sid(from: "TR_v1"), layers: layers)
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        let request = mockSocket.sentRequests[0]
+        guard case .updateLayers = request.message else {
+            return XCTFail("Expected .updateLayers message")
+        }
+        XCTAssertEqual(request.updateLayers.trackSid, "TR_v1")
+        XCTAssertEqual(request.updateLayers.layers.count, 2)
+        XCTAssertEqual(request.updateLayers.layers[0].quality, .high)
+        XCTAssertEqual(request.updateLayers.layers[1].width, 480)
+    }
+
+    // MARK: - sendUpdateSubscription
+
+    func testSendUpdateSubscription() async throws {
+        try await signalClient.sendUpdateSubscription(
+            participantSid: Participant.Sid(from: "PA_r1"),
+            trackSid: Track.Sid(from: "TR_v1"),
+            isSubscribed: true
+        )
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        let request = mockSocket.sentRequests[0]
+        guard case .subscription = request.message else {
+            return XCTFail("Expected .subscription message")
+        }
+        XCTAssertTrue(request.subscription.subscribe)
+        XCTAssertEqual(request.subscription.trackSids, ["TR_v1"])
+        XCTAssertEqual(request.subscription.participantTracks.count, 1)
+        XCTAssertEqual(request.subscription.participantTracks[0].participantSid, "PA_r1")
+    }
+
+    func testSendUpdateSubscriptionUnsubscribe() async throws {
+        try await signalClient.sendUpdateSubscription(
+            participantSid: Participant.Sid(from: "PA_r1"),
+            trackSid: Track.Sid(from: "TR_v1"),
+            isSubscribed: false
+        )
+        await waitForQueue()
+
+        XCTAssertFalse(mockSocket.sentRequests[0].subscription.subscribe)
+    }
+
+    // MARK: - sendUpdateParticipant
+
+    func testSendUpdateParticipantMetadata() async throws {
+        try await signalClient.sendUpdateParticipant(
+            name: "New Name",
+            metadata: "{\"role\":\"admin\"}",
+            attributes: ["team": "engineering"]
+        )
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        let request = mockSocket.sentRequests[0]
+        guard case .updateMetadata = request.message else {
+            return XCTFail("Expected .updateMetadata message")
+        }
+        XCTAssertEqual(request.updateMetadata.name, "New Name")
+        XCTAssertEqual(request.updateMetadata.metadata, "{\"role\":\"admin\"}")
+        XCTAssertEqual(request.updateMetadata.attributes["team"], "engineering")
+    }
+
+    func testSendUpdateParticipantNilValues() async throws {
+        try await signalClient.sendUpdateParticipant(name: nil, metadata: nil, attributes: nil)
+        await waitForQueue()
+
+        let request = mockSocket.sentRequests[0]
+        XCTAssertEqual(request.updateMetadata.name, "")
+        XCTAssertEqual(request.updateMetadata.metadata, "")
+        XCTAssertTrue(request.updateMetadata.attributes.isEmpty)
+    }
+
+    // MARK: - sendUpdateSubscriptionPermission
+
+    func testSendUpdateSubscriptionPermissionEmpty() async throws {
+        try await signalClient.sendUpdateSubscriptionPermission(
+            allParticipants: false,
+            trackPermissions: []
+        )
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        let request = mockSocket.sentRequests[0]
+        guard case .subscriptionPermission = request.message else {
+            return XCTFail("Expected .subscriptionPermission message")
+        }
+        XCTAssertFalse(request.subscriptionPermission.allParticipants)
+    }
+
+    func testSendUpdateSubscriptionPermissionWithTracks() async throws {
+        let permissions = [
+            ParticipantTrackPermission(
+                participantSid: "PA_r1",
+                allTracksAllowed: false,
+                allowedTrackSids: ["TR_v1", "TR_a1"]
+            ),
+        ]
+
+        try await signalClient.sendUpdateSubscriptionPermission(
+            allParticipants: false,
+            trackPermissions: permissions
+        )
+        await waitForQueue()
+
+        let request = mockSocket.sentRequests[0]
+        XCTAssertEqual(request.subscriptionPermission.trackPermissions.count, 1)
+        XCTAssertEqual(request.subscriptionPermission.trackPermissions[0].participantSid, "PA_r1")
+        XCTAssertFalse(request.subscriptionPermission.trackPermissions[0].allTracks)
+        XCTAssertEqual(request.subscriptionPermission.trackPermissions[0].trackSids, ["TR_v1", "TR_a1"])
+    }
+
+    // MARK: - sendUpdateLocalAudioTrack
+
+    func testSendUpdateLocalAudioTrack() async throws {
+        try await signalClient.sendUpdateLocalAudioTrack(
+            trackSid: Track.Sid(from: "TR_mic1"),
+            features: [.tfEnhancedNoiseCancellation]
+        )
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        let request = mockSocket.sentRequests[0]
+        guard case .updateAudioTrack = request.message else {
+            return XCTFail("Expected .updateAudioTrack message")
+        }
+        XCTAssertEqual(request.updateAudioTrack.trackSid, "TR_mic1")
+        XCTAssertEqual(request.updateAudioTrack.features.count, 1)
+    }
+
+    // MARK: - sendLeave
+
+    func testSendLeave() async throws {
+        try await signalClient.sendLeave()
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        let request = mockSocket.sentRequests[0]
+        guard case .leave = request.message else {
+            return XCTFail("Expected .leave message")
+        }
+        XCTAssertFalse(request.leave.canReconnect)
+        XCTAssertEqual(request.leave.reason, .clientInitiated)
+    }
+
+    // MARK: - sendSyncState
+
+    func testSendSyncState() async throws {
+        let subscription = Livekit_UpdateSubscription.with {
+            $0.trackSids = ["TR_v1", "TR_a1"]
+            $0.subscribe = true
+        }
+
+        try await signalClient.sendSyncState(
+            answer: nil,
+            offer: nil,
+            subscription: subscription,
+            publishTracks: [],
+            dataChannels: [],
+            dataChannelReceiveStates: []
+        )
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        let request = mockSocket.sentRequests[0]
+        guard case .syncState = request.message else {
+            return XCTFail("Expected .syncState message")
+        }
+        XCTAssertEqual(request.syncState.subscription.trackSids, ["TR_v1", "TR_a1"])
+        XCTAssertTrue(request.syncState.subscription.subscribe)
+    }
+
+    func testSendSyncStateWithAnswer() async throws {
+        let answer = Livekit_SessionDescription.with {
+            $0.type = "answer"
+            $0.sdp = "v=0\r\n..."
+        }
+
+        try await signalClient.sendSyncState(
+            answer: answer,
+            offer: nil,
+            subscription: Livekit_UpdateSubscription()
+        )
+        await waitForQueue()
+
+        let request = mockSocket.sentRequests[0]
+        XCTAssertTrue(request.syncState.hasAnswer)
+        XCTAssertEqual(request.syncState.answer.type, "answer")
+    }
+
+    // MARK: - sendSimulate
+
+    func testSendSimulateNodeFailure() async throws {
+        try await signalClient.sendSimulate(scenario: .nodeFailure)
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        let request = mockSocket.sentRequests[0]
+        guard case .simulate = request.message else {
+            return XCTFail("Expected .simulate message")
+        }
+        XCTAssertTrue(request.simulate.nodeFailure)
+    }
+
+    func testSendSimulateMigration() async throws {
+        try await signalClient.sendSimulate(scenario: .migration)
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        guard case .simulate = mockSocket.sentRequests[0].message else {
+            return XCTFail("Expected .simulate message")
+        }
+        XCTAssertTrue(mockSocket.sentRequests[0].simulate.migration)
+    }
+
+    func testSendSimulateServerLeave() async throws {
+        try await signalClient.sendSimulate(scenario: .serverLeave)
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        guard case .simulate = mockSocket.sentRequests[0].message else {
+            return XCTFail("Expected .simulate message")
+        }
+        XCTAssertTrue(mockSocket.sentRequests[0].simulate.serverLeave)
+    }
+
+    func testSendSimulateSpeakerUpdate() async throws {
+        try await signalClient.sendSimulate(scenario: .speakerUpdate(seconds: 5))
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        guard case .simulate = mockSocket.sentRequests[0].message else {
+            return XCTFail("Expected .simulate message")
+        }
+        XCTAssertEqual(mockSocket.sentRequests[0].simulate.speakerUpdate, 5)
+    }
+
+    func testSendSimulateForceTCPTriggersCleanup() async throws {
+        try await signalClient.sendSimulate(scenario: .forceTCP)
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        let request = mockSocket.sentRequests[0]
+        XCTAssertEqual(request.simulate.switchCandidateProtocol, .tcp)
+
+        // Wait for the deferred Task.detached cleanUp to fire
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        XCTAssertTrue(mockSocket.isClosed)
+    }
+
+    func testSendSimulateForceTLSTriggersCleanup() async throws {
+        try await signalClient.sendSimulate(scenario: .forceTLS)
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+        let request = mockSocket.sentRequests[0]
+        XCTAssertEqual(request.simulate.switchCandidateProtocol, .tls)
+
+        // Wait for the deferred Task.detached cleanUp to fire
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        XCTAssertTrue(mockSocket.isClosed)
+    }
+
+    // MARK: - requireWebSocket nil path
+
+    func testSendWithoutSocketThrowsViaQueue() async throws {
+        // Create a fresh signal client without setting a socket
+        let freshClient = SignalClient()
+        await freshClient.setConnectionState(.connected)
+        await freshClient.resumeQueues()
+
+        // The queue's onProcess will call requireWebSocket which should throw
+        // The error is caught and logged internally — this verifies it doesn't crash
+        try await freshClient.sendMuteTrack(trackSid: Track.Sid(from: "TR_1"), muted: true)
+        await waitForQueue()
+
+        // Nothing should have been sent (no socket)
+        XCTAssertEqual(mockSocket.sentRequests.count, 0)
+    }
+
+    // MARK: - connect() error paths
+
+    func testConnectWithFactoryError() async {
+        let client = SignalClient()
+        await client.setWebSocketFactory { _, _, _ in
+            throw LiveKitError(.network, message: "Connection refused")
+        }
+
+        do {
+            try await client.connect(
+                URL(string: "wss://example.com")!,
+                "test-token",
+                adaptiveStream: false
+            )
+            XCTFail("Should have thrown")
+        } catch {
+            // Verify it was cleaned up properly
+            let state = await client.connectionState
+            XCTAssertEqual(state, .disconnected)
+        }
+    }
+
+    func testConnectSetsReconnectingState() async {
+        let client = SignalClient()
+        await client.setWebSocketFactory { _, _, _ in
+            throw LiveKitError(.network, message: "Reconnect failed")
+        }
+
+        do {
+            try await client.connect(
+                URL(string: "wss://example.com")!,
+                "test-token",
+                reconnectMode: .quick,
+                adaptiveStream: false
+            )
+            XCTFail("Should have thrown")
+        } catch {
+            // After failure, should be disconnected
+            let state = await client.connectionState
+            XCTAssertEqual(state, .disconnected)
+            XCTAssertTrue(error is LiveKitError)
+        }
+    }
+
+    // MARK: - Error Handling
+
+    func testSendWhenDisconnectedThrows() async {
+        await signalClient.setConnectionState(.disconnected)
+
+        do {
+            try await signalClient.sendMuteTrack(trackSid: Track.Sid(from: "TR_1"), muted: true)
+            XCTFail("Should have thrown")
+        } catch {
+            XCTAssertTrue(error is LiveKitError)
+        }
+    }
+
+    func testSendWithSocketErrorDoesNotCrash() async throws {
+        mockSocket.setSendError(LiveKitError(.network, message: "Mock send failure"))
+
+        // The request queue catches send errors internally (logged as warning).
+        // This verifies the error path doesn't crash.
+        try await signalClient.sendMuteTrack(trackSid: Track.Sid(from: "TR_1"), muted: true)
+        await waitForQueue()
+
+        // The mock doesn't store data on error, so sentData should be empty
+        XCTAssertEqual(mockSocket.sentData.count, 0)
+    }
+
+    // MARK: - canBeQueued
+
+    func testCanBeQueuedForQueueableRequests() {
+        let mute = Livekit_SignalRequest.with { $0.mute = Livekit_MuteTrackRequest() }
+        XCTAssertTrue(mute.canBeQueued())
+
+        let trackSetting = Livekit_SignalRequest.with { $0.trackSetting = Livekit_UpdateTrackSettings() }
+        XCTAssertTrue(trackSetting.canBeQueued())
+
+        let subscription = Livekit_SignalRequest.with { $0.subscription = Livekit_UpdateSubscription() }
+        XCTAssertTrue(subscription.canBeQueued())
+    }
+
+    func testCanBeQueuedForNonQueueableRequests() {
+        let syncState = Livekit_SignalRequest.with { $0.syncState = Livekit_SyncState() }
+        XCTAssertFalse(syncState.canBeQueued())
+
+        let trickle = Livekit_SignalRequest.with { $0.trickle = Livekit_TrickleRequest() }
+        XCTAssertFalse(trickle.canBeQueued())
+
+        let offer = Livekit_SignalRequest.with { $0.offer = Livekit_SessionDescription() }
+        XCTAssertFalse(offer.canBeQueued())
+
+        let answer = Livekit_SignalRequest.with { $0.answer = Livekit_SessionDescription() }
+        XCTAssertFalse(answer.canBeQueued())
+
+        let leave = Livekit_SignalRequest.with { $0.leave = Livekit_LeaveRequest() }
+        XCTAssertFalse(leave.canBeQueued())
+
+        let simulate = Livekit_SignalRequest.with { $0.simulate = Livekit_SimulateScenario() }
+        XCTAssertFalse(simulate.canBeQueued())
+    }
+
+    // MARK: - Multiple Sends
+
+    func testMultipleSendsAreCaptured() async throws {
+        try await signalClient.sendMuteTrack(trackSid: Track.Sid(from: "TR_1"), muted: true)
+        try await signalClient.sendMuteTrack(trackSid: Track.Sid(from: "TR_2"), muted: false)
+        try await signalClient.sendLeave()
+        await waitForQueue()
+
+        XCTAssertEqual(mockSocket.sentRequests.count, 3)
+        XCTAssertNotNil(mockSocket.sentRequests[0].message)
+        XCTAssertNotNil(mockSocket.sentRequests[1].message)
+        if case .mute = mockSocket.sentRequests[0].message {} else { XCTFail("Expected .mute") }
+        if case .mute = mockSocket.sentRequests[1].message {} else { XCTFail("Expected .mute") }
+        if case .leave = mockSocket.sentRequests[2].message {} else { XCTFail("Expected .leave") }
+    }
+
+    // MARK: - MockWebSocket Reset
+
+    func testMockWebSocketReset() async throws {
+        try await signalClient.sendLeave()
+        await waitForQueue()
+        XCTAssertEqual(mockSocket.sentRequests.count, 1)
+
+        mockSocket.reset()
+        XCTAssertEqual(mockSocket.sentRequests.count, 0)
+        XCTAssertFalse(mockSocket.isClosed)
+    }
+
+    // MARK: - Close
+
+    func testCleanUpClosesSocket() async {
+        await signalClient.cleanUp()
+
+        XCTAssertTrue(mockSocket.isClosed)
+    }
+
+    // MARK: - connect() CancellationError path
+
+    func testConnectCancellationErrorPath() async {
+        let client = SignalClient()
+        await client.setWebSocketFactory { _, _, _ in
+            throw CancellationError()
+        }
+
+        do {
+            try await client.connect(
+                URL(string: "wss://example.com")!,
+                "test-token",
+                adaptiveStream: false
+            )
+            XCTFail("Should have thrown")
+        } catch {
+            // CancellationError is re-thrown directly, not wrapped in LiveKitError
+            XCTAssertTrue(error is CancellationError)
+            let state = await client.connectionState
+            XCTAssertEqual(state, .disconnected)
+        }
+    }
+
+    // MARK: - connect() validation fallback path
+
+    func testConnectValidationPathWhenHTTPFails() async {
+        let client = SignalClient()
+        await client.setWebSocketFactory { _, _, _ in
+            throw LiveKitError(.network, message: "WebSocket refused")
+        }
+
+        do {
+            // Non-reconnect mode: will try HTTP validation after WebSocket failure.
+            // Uses 127.0.0.1 with a random port to ensure fast failure.
+            try await client.connect(
+                URL(string: "wss://127.0.0.1:1")!,
+                "test-token",
+                adaptiveStream: false
+            )
+            XCTFail("Should have thrown")
+        } catch {
+            // The error should be a LiveKitError wrapping the validation failure
+            XCTAssertTrue(error is LiveKitError)
+            let state = await client.connectionState
+            XCTAssertEqual(state, .disconnected)
+        }
+    }
+
+    // MARK: - WebSocket message decoding
+
+    func testHandleWebSocketMessageWithStringJSON() async {
+        // Create a signal response and encode as JSON string
+        let response = Livekit_SignalResponse.with { $0.pong = 12345 }
+        let jsonString = try! response.jsonString()
+
+        // Process through the string message path
+        await signalClient._testHandleWebSocketMessage(.string(jsonString))
+        // Give the detached task time to process
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // The pong should have been processed (cancels timeout timer)
+        // No crash means the string path decoded successfully
+    }
+
+    func testHandleWebSocketMessageWithInvalidData() async {
+        // Invalid data that can't be decoded as a SignalResponse
+        let invalidData = Data([0xFF, 0xFE, 0x00, 0x01])
+        await signalClient._testHandleWebSocketMessage(.data(invalidData))
+        // Give time for processing
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // No crash — the guard should have caught the decode failure
+    }
+
+    func testHandleWebSocketMessageWithInvalidString() async {
+        await signalClient._testHandleWebSocketMessage(.string("not valid json at all {{{"))
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // No crash — guard catches decode failure for string messages
+    }
+
+    // MARK: - Ping Timer Accessors
+
+    func testPingTimerAccessors() async {
+        // Simply accessing these verifies the test helper getters work
+        let intervalTimer = await signalClient._testPingIntervalTimer
+        let timeoutTimer = await signalClient._testPingTimeoutTimer
+        XCTAssertNotNil(intervalTimer)
+        XCTAssertNotNil(timeoutTimer)
+    }
+
+    // MARK: - sendPing
+
+    func testSendPingProducesPingAndPingReq() async throws {
+        // Set up a lastJoinResponse (required by _onPingIntervalTimer)
+        await signalClient._state.mutate { $0.lastJoinResponse = TestData.joinResponse(pingInterval: 5, pingTimeout: 10) }
+
+        try await signalClient._testSendPing()
+        await waitForQueue()
+
+        // _sendPing sends two requests: a .ping and a .pingReq
+        XCTAssertEqual(mockSocket.sentRequests.count, 2)
+
+        let firstRequest = mockSocket.sentRequests[0]
+        guard case .ping = firstRequest.message else {
+            return XCTFail("Expected .ping message, got \(String(describing: firstRequest.message))")
+        }
+        XCTAssertGreaterThan(firstRequest.ping, 0)
+
+        let secondRequest = mockSocket.sentRequests[1]
+        guard case .pingReq = secondRequest.message else {
+            return XCTFail("Expected .pingReq message, got \(String(describing: secondRequest.message))")
+        }
+        XCTAssertGreaterThan(secondRequest.pingReq.timestamp, 0)
+    }
+
+    // MARK: - Ping timer fires after join response
+
+    func testPingTimerFiresAfterJoinResponse() async throws {
+        // Process a join response with a very short ping interval
+        let joinResponse = TestData.joinResponse(pingInterval: 1, pingTimeout: 5)
+        let joinSignal = Livekit_SignalResponse.with { $0.join = joinResponse }
+        await signalClient._process(signalResponse: joinSignal)
+
+        // Wait for the ping interval timer to fire (~1 second + buffer)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+
+        // The timer should have sent ping requests via the mock socket
+        let pingRequests = mockSocket.sentRequests.filter {
+            if case .ping = $0.message { return true }
+            return false
+        }
+        XCTAssertGreaterThanOrEqual(pingRequests.count, 1, "Expected at least one ping to be sent")
+    }
+
+    // MARK: - Ping timeout triggers cleanup
+
+    func testPingTimeoutTriggersCleanup() async throws {
+        // Process a join response with very short ping interval AND timeout
+        let joinResponse = TestData.joinResponse(pingInterval: 1, pingTimeout: 1)
+        let joinSignal = Livekit_SignalResponse.with { $0.join = joinResponse }
+        await signalClient._process(signalResponse: joinSignal)
+
+        // Wait for ping interval (1s) + timeout (1s) + buffer
+        try await Task.sleep(nanoseconds: 3_000_000_000)
+
+        // The timeout should have triggered cleanUp, setting state to disconnected
+        let state = await signalClient.connectionState
+        XCTAssertEqual(state, .disconnected)
+
+        // The disconnect error should be serverPingTimedOut
+        let error = await signalClient.disconnectError
+        XCTAssertEqual(error?.type, .serverPingTimedOut)
+    }
+
+    // MARK: - sendSyncState with offer
+
+    func testSendSyncStateWithOffer() async throws {
+        let offer = Livekit_SessionDescription.with {
+            $0.type = "offer"
+            $0.sdp = "v=0\r\noffer-sdp"
+        }
+
+        try await signalClient.sendSyncState(
+            answer: nil,
+            offer: offer,
+            subscription: Livekit_UpdateSubscription()
+        )
+        await waitForQueue()
+
+        let request = mockSocket.sentRequests[0]
+        XCTAssertTrue(request.syncState.hasOffer)
+        XCTAssertEqual(request.syncState.offer.type, "offer")
+    }
+
+    func testSendSyncStateWithPublishTracksAndDataChannels() async throws {
+        let publishTrack = Livekit_TrackPublishedResponse.with {
+            $0.cid = "test-cid"
+            $0.track = TestData.trackInfo(sid: "TR_v1", name: "camera", type: .video, source: .camera)
+        }
+        let dataChannel = Livekit_DataChannelInfo.with {
+            $0.label = "test-dc"
+            $0.id = 1
+            $0.target = .publisher
+        }
+
+        try await signalClient.sendSyncState(
+            answer: nil,
+            offer: nil,
+            subscription: Livekit_UpdateSubscription(),
+            publishTracks: [publishTrack],
+            dataChannels: [dataChannel],
+            dataChannelReceiveStates: []
+        )
+        await waitForQueue()
+
+        let request = mockSocket.sentRequests[0]
+        XCTAssertEqual(request.syncState.publishTracks.count, 1)
+        XCTAssertEqual(request.syncState.publishTracks[0].cid, "test-cid")
+        XCTAssertEqual(request.syncState.dataChannels.count, 1)
+        XCTAssertEqual(request.syncState.dataChannels[0].label, "test-dc")
+    }
+
+    // MARK: - sendAddTrack with completer
+
+    func testSendAddTrackSendsCorrectRequest() async throws {
+        // We'll test just the request sending, not the completer wait
+        // (waiting would block forever without a trackPublished response)
+        let client = signalClient!
+        let addTrackTask = Task<Livekit_TrackInfo, Error> {
+            try await client.sendAddTrack(
+                cid: "test-cid-123",
+                name: "camera",
+                type: .video,
+                source: .camera,
+                encryption: .none
+            ) { request in
+                request.width = 1920
+                request.height = 1080
+            }
+        }
+
+        // Wait for the request to be sent
+        await waitForQueue()
+
+        // Verify the add track request was sent
+        let addTrackRequests = mockSocket.sentRequests.filter {
+            if case .addTrack = $0.message { return true }
+            return false
+        }
+        XCTAssertEqual(addTrackRequests.count, 1)
+        XCTAssertEqual(addTrackRequests[0].addTrack.cid, "test-cid-123")
+        XCTAssertEqual(addTrackRequests[0].addTrack.name, "camera")
+        XCTAssertEqual(addTrackRequests[0].addTrack.type, .video)
+        XCTAssertEqual(addTrackRequests[0].addTrack.source, .camera)
+        XCTAssertEqual(addTrackRequests[0].addTrack.width, 1920)
+
+        // Now simulate the server responding with trackPublished to resolve the completer
+        let trackInfo = TestData.trackInfo(sid: "TR_pub1", name: "camera", type: .video, source: .camera)
+        let publishedResponse = Livekit_SignalResponse.with {
+            $0.trackPublished = Livekit_TrackPublishedResponse.with {
+                $0.cid = "test-cid-123"
+                $0.track = trackInfo
+            }
+        }
+        await signalClient._process(signalResponse: publishedResponse)
+
+        // The task should now complete
+        let result = try await addTrackTask.value
+        XCTAssertEqual(result.sid, "TR_pub1")
+    }
+}

--- a/Tests/LiveKitCoreTests/Core/SignalClientSendTests.swift
+++ b/Tests/LiveKitCoreTests/Core/SignalClientSendTests.swift
@@ -14,13 +14,31 @@
  * limitations under the License.
  */
 
+// swiftlint:disable file_length
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @testable import LiveKit
 #if canImport(LiveKitTestSupport)
 import LiveKitTestSupport
 #endif
 
-/// Tests for SignalClient send methods using MockWebSocket.
-/// Verifies that each send method produces the correct protobuf message.
+// Tests for SignalClient send methods using MockWebSocket.
+// Verifies that each send method produces the correct protobuf message.
+// swiftlint:disable:next type_body_length
 class SignalClientSendTests: LKTestCase {
     private var signalClient: SignalClient!
     private var mockSocket: MockWebSocket!
@@ -589,10 +607,10 @@ class SignalClientSendTests: LKTestCase {
 
     // MARK: - WebSocket message decoding
 
-    func testHandleWebSocketMessageWithStringJSON() async {
+    func testHandleWebSocketMessageWithStringJSON() async throws {
         // Create a signal response and encode as JSON string
         let response = Livekit_SignalResponse.with { $0.pong = 12345 }
-        let jsonString = try! response.jsonString()
+        let jsonString = try response.jsonString()
 
         // Process through the string message path
         await signalClient._testHandleWebSocketMessage(.string(jsonString))

--- a/Tests/LiveKitCoreTests/Extensions/URLTests.swift
+++ b/Tests/LiveKitCoreTests/Extensions/URLTests.swift
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+class URLTests: LKTestCase {
+    // MARK: - isValidForConnect
+
+    func testIsValidForConnectWithWS() {
+        let url = URL(string: "ws://localhost:7880")!
+        XCTAssertTrue(url.isValidForConnect)
+    }
+
+    func testIsValidForConnectWithWSS() {
+        let url = URL(string: "wss://example.livekit.cloud")!
+        XCTAssertTrue(url.isValidForConnect)
+    }
+
+    func testIsValidForConnectWithHTTP() {
+        let url = URL(string: "http://localhost:7880")!
+        XCTAssertTrue(url.isValidForConnect)
+    }
+
+    func testIsValidForConnectWithHTTPS() {
+        let url = URL(string: "https://example.livekit.cloud")!
+        XCTAssertTrue(url.isValidForConnect)
+    }
+
+    func testIsNotValidForConnectWithFTP() {
+        let url = URL(string: "ftp://example.com")!
+        XCTAssertFalse(url.isValidForConnect)
+    }
+
+    func testIsNotValidForConnectWithoutHost() {
+        let url = URL(string: "ws://")!
+        XCTAssertFalse(url.isValidForConnect)
+    }
+
+    // MARK: - isValidForSocket
+
+    func testIsValidForSocketWithWS() {
+        let url = URL(string: "ws://localhost:7880")!
+        XCTAssertTrue(url.isValidForSocket)
+    }
+
+    func testIsValidForSocketWithWSS() {
+        let url = URL(string: "wss://example.com")!
+        XCTAssertTrue(url.isValidForSocket)
+    }
+
+    func testIsNotValidForSocketWithHTTP() {
+        let url = URL(string: "http://localhost:7880")!
+        XCTAssertFalse(url.isValidForSocket)
+    }
+
+    // MARK: - isSecure
+
+    func testIsSecureWSS() {
+        XCTAssertTrue(URL(string: "wss://example.com")!.isSecure)
+    }
+
+    func testIsSecureHTTPS() {
+        XCTAssertTrue(URL(string: "https://example.com")!.isSecure)
+    }
+
+    func testIsNotSecureWS() {
+        XCTAssertFalse(URL(string: "ws://localhost")!.isSecure)
+    }
+
+    func testIsNotSecureHTTP() {
+        XCTAssertFalse(URL(string: "http://localhost")!.isSecure)
+    }
+
+    // MARK: - isCloud
+
+    func testIsCloudLiveKitCloud() {
+        let url = URL(string: "wss://myapp.livekit.cloud")!
+        XCTAssertTrue(url.isCloud)
+    }
+
+    func testIsCloudLiveKitRun() {
+        let url = URL(string: "wss://myapp.livekit.run")!
+        XCTAssertTrue(url.isCloud)
+    }
+
+    func testIsNotCloudLocalhost() {
+        let url = URL(string: "ws://localhost:7880")!
+        XCTAssertFalse(url.isCloud)
+    }
+
+    func testIsNotCloudCustomDomain() {
+        let url = URL(string: "wss://livekit.example.com")!
+        XCTAssertFalse(url.isCloud)
+    }
+
+    // MARK: - Protocol Conversion
+
+    func testToSocketUrlFromHTTP() {
+        let url = URL(string: "http://localhost:7880")!
+        XCTAssertEqual(url.toSocketUrl().scheme, "ws")
+    }
+
+    func testToSocketUrlFromHTTPS() {
+        let url = URL(string: "https://example.livekit.cloud")!
+        XCTAssertEqual(url.toSocketUrl().scheme, "wss")
+    }
+
+    func testToSocketUrlPreservesPath() {
+        let url = URL(string: "https://example.com/custom/path")!
+        let socketUrl = url.toSocketUrl()
+        XCTAssertEqual(socketUrl.path, "/custom/path")
+    }
+
+    func testToHTTPUrlFromWS() {
+        let url = URL(string: "ws://localhost:7880")!
+        XCTAssertEqual(url.toHTTPUrl().scheme, "http")
+    }
+
+    func testToHTTPUrlFromWSS() {
+        let url = URL(string: "wss://example.livekit.cloud")!
+        XCTAssertEqual(url.toHTTPUrl().scheme, "https")
+    }
+
+    func testToHTTPUrlPreservesHost() {
+        let url = URL(string: "wss://example.livekit.cloud:443/path")!
+        let httpUrl = url.toHTTPUrl()
+        XCTAssertEqual(httpUrl.host, "example.livekit.cloud")
+        XCTAssertEqual(httpUrl.path, "/path")
+    }
+
+    // MARK: - Cloud Config URL
+
+    func testCloudConfigUrl() {
+        let url = URL(string: "wss://myapp.livekit.cloud")!
+        let configUrl = url.cloudConfigUrl()
+        XCTAssertEqual(configUrl.scheme, "https")
+        XCTAssertEqual(configUrl.path, "/settings")
+        XCTAssertEqual(configUrl.host, "myapp.livekit.cloud")
+    }
+
+    func testCloudConfigUrlStripsQueryAndFragment() {
+        let url = URL(string: "wss://myapp.livekit.cloud?token=abc#section")!
+        let configUrl = url.cloudConfigUrl()
+        XCTAssertNil(configUrl.query)
+        XCTAssertNil(configUrl.fragment)
+    }
+
+    func testRegionSettingsUrl() {
+        let url = URL(string: "wss://myapp.livekit.cloud")!
+        let regionUrl = url.regionSettingsUrl()
+        XCTAssertTrue(regionUrl.path.contains("/settings/regions"))
+    }
+
+    // MARK: - Region Manager Key URL
+
+    func testRegionManagerKeyUrlStripsRtcSuffix() {
+        let url = URL(string: "wss://example.com/rtc")!
+        let keyUrl = url.regionManagerKeyURL()
+        XCTAssertFalse(keyUrl.path.contains("rtc"))
+    }
+
+    func testRegionManagerKeyUrlStripsValidateSuffix() {
+        let url = URL(string: "wss://example.com/validate")!
+        let keyUrl = url.regionManagerKeyURL()
+        XCTAssertFalse(keyUrl.path.contains("validate"))
+    }
+
+    func testRegionManagerKeyUrlPreservesSubPaths() {
+        let url = URL(string: "wss://example.com/custom/rtc")!
+        let keyUrl = url.regionManagerKeyURL()
+        XCTAssertTrue(keyUrl.path.contains("custom"))
+        XCTAssertFalse(keyUrl.path.contains("rtc"))
+    }
+
+    func testMatchesRegionManagerKey() {
+        let a = URL(string: "wss://example.com/rtc")!
+        let b = URL(string: "wss://example.com/validate")!
+        XCTAssertTrue(a.matchesRegionManagerKey(of: b))
+    }
+
+    func testDoesNotMatchDifferentRegionManagerKey() {
+        let a = URL(string: "wss://example.com/path1/rtc")!
+        let b = URL(string: "wss://other.com/rtc")!
+        XCTAssertFalse(a.matchesRegionManagerKey(of: b))
+    }
+}

--- a/Tests/LiveKitCoreTests/Participant/ParticipantConvenienceTests.swift
+++ b/Tests/LiveKitCoreTests/Participant/ParticipantConvenienceTests.swift
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+/// Tests for Participant convenience properties (firstCameraPublication, etc.)
+/// and Participant+Agent extensions (isAgent, agentState, etc.).
+class ParticipantConvenienceTests: LKTestCase {
+    private func makeHelper() -> RoomTestHelper {
+        RoomTestHelper()
+    }
+
+    // MARK: - firstCameraPublication
+
+    func testFirstCameraPublicationWithCamera() {
+        let helper = makeHelper()
+        let cameraTrack = TestData.trackInfo(sid: "TR_cam", name: "camera", type: .video, source: .camera)
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1", tracks: [cameraTrack])
+
+        XCTAssertNotNil(participant.firstCameraPublication)
+        XCTAssertEqual(participant.firstCameraPublication?.sid, Track.Sid(from: "TR_cam"))
+    }
+
+    func testFirstCameraPublicationWithNoCameraTracks() {
+        let helper = makeHelper()
+        let audioTrack = TestData.trackInfo(sid: "TR_mic", name: "mic", type: .audio, source: .microphone)
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1", tracks: [audioTrack])
+
+        XCTAssertNil(participant.firstCameraPublication)
+    }
+
+    func testFirstCameraPublicationWithNoTracks() {
+        let helper = makeHelper()
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1", tracks: [])
+
+        XCTAssertNil(participant.firstCameraPublication)
+    }
+
+    // MARK: - firstScreenSharePublication
+
+    func testFirstScreenSharePublicationWithScreenShare() {
+        let helper = makeHelper()
+        let screenTrack = TestData.trackInfo(sid: "TR_screen", name: "screen", type: .video, source: .screenShare)
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1", tracks: [screenTrack])
+
+        XCTAssertNotNil(participant.firstScreenSharePublication)
+        XCTAssertEqual(participant.firstScreenSharePublication?.sid, Track.Sid(from: "TR_screen"))
+    }
+
+    func testFirstScreenSharePublicationWithNoScreenShare() {
+        let helper = makeHelper()
+        let cameraTrack = TestData.trackInfo(sid: "TR_cam", name: "camera", type: .video, source: .camera)
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1", tracks: [cameraTrack])
+
+        XCTAssertNil(participant.firstScreenSharePublication)
+    }
+
+    // MARK: - firstAudioPublication
+
+    func testFirstAudioPublication() {
+        let helper = makeHelper()
+        let audioTrack = TestData.trackInfo(sid: "TR_mic", name: "mic", type: .audio, source: .microphone)
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1", tracks: [audioTrack])
+
+        XCTAssertNotNil(participant.firstAudioPublication)
+        XCTAssertEqual(participant.firstAudioPublication?.sid, Track.Sid(from: "TR_mic"))
+    }
+
+    func testFirstAudioPublicationWithNoAudioTracks() {
+        let helper = makeHelper()
+        let videoTrack = TestData.trackInfo(sid: "TR_cam", name: "camera", type: .video, source: .camera)
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1", tracks: [videoTrack])
+
+        XCTAssertNil(participant.firstAudioPublication)
+    }
+
+    // MARK: - firstTrackEncryptionType
+
+    func testFirstTrackEncryptionTypeWithNoTracks() {
+        let helper = makeHelper()
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1", tracks: [])
+
+        XCTAssertEqual(participant.firstTrackEncryptionType, .none)
+    }
+
+    func testFirstTrackEncryptionTypeFallsThroughSources() {
+        let helper = makeHelper()
+        // Only audio track — fallthrough from camera → screenShare → audio
+        let audioTrack = TestData.trackInfo(sid: "TR_mic", name: "mic", type: .audio, source: .microphone)
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1", tracks: [audioTrack])
+
+        // Default encryption is .none
+        XCTAssertEqual(participant.firstTrackEncryptionType, .none)
+    }
+
+    // MARK: - firstCameraVideoTrack / firstScreenShareVideoTrack / firstAudioTrack
+
+    func testFirstCameraVideoTrackNilWhenNoTrackAttached() {
+        let helper = makeHelper()
+        let cameraTrack = TestData.trackInfo(sid: "TR_cam", name: "camera", type: .video, source: .camera)
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1", tracks: [cameraTrack])
+
+        // Publication exists but no real track is attached, so returns nil
+        XCTAssertNil(participant.firstCameraVideoTrack)
+    }
+
+    func testFirstScreenShareVideoTrackNilWhenNoTrackAttached() {
+        let helper = makeHelper()
+        let screenTrack = TestData.trackInfo(sid: "TR_screen", name: "screen", type: .video, source: .screenShare)
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1", tracks: [screenTrack])
+
+        XCTAssertNil(participant.firstScreenShareVideoTrack)
+    }
+
+    func testFirstAudioTrackNilWhenNoTrackAttached() {
+        let helper = makeHelper()
+        let audioTrack = TestData.trackInfo(sid: "TR_mic", name: "mic", type: .audio, source: .microphone)
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1", tracks: [audioTrack])
+
+        XCTAssertNil(participant.firstAudioTrack)
+    }
+
+    // MARK: - Multiple tracks
+
+    func testMultiplePublicationsSelectCorrectSource() {
+        let helper = makeHelper()
+        let camera = TestData.trackInfo(sid: "TR_cam", name: "camera", type: .video, source: .camera)
+        let screen = TestData.trackInfo(sid: "TR_screen", name: "screen", type: .video, source: .screenShare)
+        let audio = TestData.trackInfo(sid: "TR_mic", name: "mic", type: .audio, source: .microphone)
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1", tracks: [camera, screen, audio])
+
+        XCTAssertEqual(participant.firstCameraPublication?.sid, Track.Sid(from: "TR_cam"))
+        XCTAssertEqual(participant.firstScreenSharePublication?.sid, Track.Sid(from: "TR_screen"))
+        XCTAssertEqual(participant.firstAudioPublication?.sid, Track.Sid(from: "TR_mic"))
+    }
+
+    // MARK: - Participant+Agent: isAgent
+
+    func testIsAgentTrueForAgentKind() {
+        let helper = makeHelper()
+        let info = TestData.participantInfo(
+            sid: "PA_agent", identity: "agent-1", name: "Agent",
+            kind: .agent
+        )
+        let participant = RemoteParticipant(info: info, room: helper.room, connectionState: .connected)
+
+        XCTAssertTrue(participant.isAgent)
+    }
+
+    func testIsAgentFalseForStandardKind() {
+        let helper = makeHelper()
+        let info = TestData.participantInfo(
+            sid: "PA_std", identity: "user-1", name: "User",
+            kind: .standard
+        )
+        let participant = RemoteParticipant(info: info, room: helper.room, connectionState: .connected)
+
+        XCTAssertFalse(participant.isAgent)
+    }
+
+    func testIsAgentFalseForUnknownKind() {
+        let helper = makeHelper()
+        let participant = helper.addRemoteParticipant(sid: "PA_r1", identity: "remote-1")
+
+        // Default kind from TestData is .standard
+        XCTAssertFalse(participant.isAgent)
+    }
+
+    // MARK: - Participant+Agent: agentState
+
+    func testAgentStateDefaultsToIdle() {
+        let helper = makeHelper()
+        let info = TestData.participantInfo(sid: "PA_agent", identity: "agent-1", kind: .agent)
+        let participant = RemoteParticipant(info: info, room: helper.room, connectionState: .connected)
+
+        // No agent attributes set — defaults to .idle
+        XCTAssertEqual(participant.agentState, .idle)
+    }
+
+    func testAgentStateFromAttributes() {
+        let helper = makeHelper()
+        let info = TestData.participantInfo(
+            sid: "PA_agent", identity: "agent-1",
+            attributes: ["lk.agent.state": "listening"],
+            kind: .agent
+        )
+        let participant = RemoteParticipant(info: info, room: helper.room, connectionState: .connected)
+
+        XCTAssertEqual(participant.agentState, .listening)
+    }
+
+    func testAgentStateSpeaking() {
+        let helper = makeHelper()
+        let info = TestData.participantInfo(
+            sid: "PA_agent", identity: "agent-1",
+            attributes: ["lk.agent.state": "speaking"],
+            kind: .agent
+        )
+        let participant = RemoteParticipant(info: info, room: helper.room, connectionState: .connected)
+
+        XCTAssertEqual(participant.agentState, .speaking)
+    }
+
+    func testAgentStateThinking() {
+        let helper = makeHelper()
+        let info = TestData.participantInfo(
+            sid: "PA_agent", identity: "agent-1",
+            attributes: ["lk.agent.state": "thinking"],
+            kind: .agent
+        )
+        let participant = RemoteParticipant(info: info, room: helper.room, connectionState: .connected)
+
+        XCTAssertEqual(participant.agentState, .thinking)
+    }
+
+    // MARK: - Participant+Agent: agentStateString
+
+    func testAgentStateStringMatchesRawValue() {
+        let helper = makeHelper()
+        let info = TestData.participantInfo(
+            sid: "PA_agent", identity: "agent-1",
+            attributes: ["lk.agent.state": "speaking"],
+            kind: .agent
+        )
+        let participant = RemoteParticipant(info: info, room: helper.room, connectionState: .connected)
+
+        XCTAssertEqual(participant.agentStateString, "speaking")
+    }
+
+    // MARK: - AgentState description
+
+    func testAgentStateDescription() {
+        XCTAssertEqual(AgentState.idle.description, "Idle")
+        XCTAssertEqual(AgentState.listening.description, "Listening")
+        XCTAssertEqual(AgentState.thinking.description, "Thinking")
+        XCTAssertEqual(AgentState.speaking.description, "Speaking")
+        XCTAssertEqual(AgentState.initializing.description, "Initializing")
+    }
+
+    // MARK: - Participant.Kind description
+
+    func testParticipantKindDescriptions() {
+        XCTAssertEqual(Participant.Kind.unknown.description, "unknown")
+        XCTAssertEqual(Participant.Kind.standard.description, "standard")
+        XCTAssertEqual(Participant.Kind.ingress.description, "ingress")
+        XCTAssertEqual(Participant.Kind.egress.description, "egress")
+        XCTAssertEqual(Participant.Kind.sip.description, "sip")
+        XCTAssertEqual(Participant.Kind.agent.description, "agent")
+    }
+
+    // MARK: - Participant+Agent: avatarWorker
+
+    func testAvatarWorkerNilWhenNoPublishingOnBehalf() {
+        let helper = makeHelper()
+        let info = TestData.participantInfo(sid: "PA_agent", identity: "agent-1", kind: .agent)
+        let participant = RemoteParticipant(info: info, room: helper.room, connectionState: .connected)
+        helper.room._state.mutate {
+            $0.remoteParticipants[Participant.Identity(from: "agent-1")] = participant
+        }
+
+        XCTAssertNil(participant.avatarWorker)
+    }
+}

--- a/Tests/LiveKitCoreTests/Participant/ParticipantStateTests.swift
+++ b/Tests/LiveKitCoreTests/Participant/ParticipantStateTests.swift
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+/// Tests for Participant and RemoteParticipant state management.
+class ParticipantStateTests: LKTestCase {
+    // MARK: - Helper
+
+    private func makeRoom() -> Room {
+        let room = Room()
+        room._state.mutate { $0.connectionState = .connected }
+        let localInfo = TestData.participantInfo(sid: "PA_local", identity: "local-user")
+        room.localParticipant.set(info: localInfo, connectionState: .connected)
+        return room
+    }
+
+    private func makeRemoteParticipant(
+        sid: String = "PA_remote",
+        identity: String = "remote-user",
+        name: String = "Remote User",
+        room: Room? = nil
+    ) -> RemoteParticipant {
+        let room = room ?? makeRoom()
+        let info = TestData.participantInfo(sid: sid, identity: identity, name: name)
+        return RemoteParticipant(info: info, room: room, connectionState: .connected)
+    }
+
+    // MARK: - RemoteParticipant Init
+
+    func testRemoteParticipantInitSetsBasicProperties() {
+        let participant = makeRemoteParticipant(sid: "PA_abc", identity: "alice", name: "Alice")
+
+        XCTAssertEqual(participant.sid?.stringValue, "PA_abc")
+        XCTAssertEqual(participant.identity?.stringValue, "alice")
+        XCTAssertEqual(participant.name, "Alice")
+    }
+
+    func testRemoteParticipantInitSetsState() {
+        let room = makeRoom()
+        let info = TestData.participantInfo(sid: "PA_1", identity: "user-1", state: .active)
+        let participant = RemoteParticipant(info: info, room: room, connectionState: .connected)
+
+        XCTAssertEqual(participant.state, .active)
+    }
+
+    func testRemoteParticipantInitSetsKind() {
+        let room = makeRoom()
+        let info = TestData.participantInfo(sid: "PA_agent", identity: "agent-1", kind: .agent)
+        let participant = RemoteParticipant(info: info, room: room, connectionState: .connected)
+
+        XCTAssertEqual(participant.kind, .agent)
+    }
+
+    // MARK: - set(info:) Updates
+
+    func testSetInfoUpdatesMetadata() {
+        let participant = makeRemoteParticipant()
+
+        let updated = TestData.participantInfo(
+            sid: "PA_remote",
+            identity: "remote-user",
+            metadata: "new-metadata"
+        )
+        participant.set(info: updated, connectionState: .connected)
+
+        XCTAssertEqual(participant.metadata, "new-metadata")
+    }
+
+    func testSetInfoUpdatesName() {
+        let participant = makeRemoteParticipant()
+
+        let updated = TestData.participantInfo(
+            sid: "PA_remote",
+            identity: "remote-user",
+            name: "Updated Name"
+        )
+        participant.set(info: updated, connectionState: .connected)
+
+        XCTAssertEqual(participant.name, "Updated Name")
+    }
+
+    func testSetInfoUpdatesAttributes() {
+        let participant = makeRemoteParticipant()
+
+        let updated = TestData.participantInfo(
+            sid: "PA_remote",
+            identity: "remote-user",
+            attributes: ["role": "speaker", "color": "blue"]
+        )
+        participant.set(info: updated, connectionState: .connected)
+
+        XCTAssertEqual(participant.attributes["role"], "speaker")
+        XCTAssertEqual(participant.attributes["color"], "blue")
+    }
+
+    func testSetInfoUpdatesPermissions() {
+        let room = makeRoom()
+        let info = TestData.participantInfo(
+            sid: "PA_remote",
+            identity: "remote-user",
+            canPublish: false,
+            canSubscribe: false,
+            canPublishData: false
+        )
+        let participant = RemoteParticipant(info: info, room: room, connectionState: .connected)
+
+        XCTAssertFalse(participant.permissions.canPublish)
+        XCTAssertFalse(participant.permissions.canSubscribe)
+        XCTAssertFalse(participant.permissions.canPublishData)
+
+        // Update to grant permissions
+        let updated = TestData.participantInfo(
+            sid: "PA_remote",
+            identity: "remote-user",
+            canPublish: true,
+            canSubscribe: true,
+            canPublishData: true
+        )
+        participant.set(info: updated, connectionState: .connected)
+
+        XCTAssertTrue(participant.permissions.canPublish)
+        XCTAssertTrue(participant.permissions.canSubscribe)
+        XCTAssertTrue(participant.permissions.canPublishData)
+    }
+
+    func testSetInfoUpdatesJoinedAt() {
+        let room = makeRoom()
+        let info = TestData.participantInfo(sid: "PA_1", identity: "user-1", joinedAt: 1_700_000_000)
+        let participant = RemoteParticipant(info: info, room: room, connectionState: .connected)
+
+        XCTAssertNotNil(participant.joinedAt)
+        XCTAssertEqual(participant.joinedAt?.timeIntervalSince1970 ?? 0, 1_700_000_000, accuracy: 1.0)
+    }
+
+    func testSetInfoWithJoinedAtMs() {
+        let room = makeRoom()
+        var info = TestData.participantInfo(sid: "PA_1", identity: "user-1")
+        info.joinedAt = 0
+        info.joinedAtMs = 1_700_000_000_500
+        let participant = RemoteParticipant(info: info, room: room, connectionState: .connected)
+
+        XCTAssertNotNil(participant.joinedAt)
+        XCTAssertEqual(participant.joinedAt?.timeIntervalSince1970 ?? 0, 1_700_000_000.5, accuracy: 0.001)
+    }
+
+    // MARK: - Track Publications from Info
+
+    func testSetInfoCreatesTrackPublications() {
+        let room = makeRoom()
+        let track1 = TestData.trackInfo(sid: "TR_a1", name: "mic", type: .audio, source: .microphone)
+        let track2 = TestData.trackInfo(sid: "TR_v1", name: "camera", type: .video, source: .camera)
+        let info = TestData.participantInfo(sid: "PA_1", identity: "user-1", tracks: [track1, track2])
+        let participant = RemoteParticipant(info: info, room: room, connectionState: .connected)
+
+        XCTAssertEqual(participant.trackPublications.count, 2)
+
+        let audioSid = Track.Sid(from: "TR_a1")
+        let videoSid = Track.Sid(from: "TR_v1")
+        XCTAssertNotNil(participant.trackPublications[audioSid])
+        XCTAssertNotNil(participant.trackPublications[videoSid])
+    }
+
+    func testSetInfoRemovesUnpublishedTracks() {
+        let room = makeRoom()
+        let track1 = TestData.trackInfo(sid: "TR_a1", name: "mic", type: .audio)
+        let track2 = TestData.trackInfo(sid: "TR_v1", name: "camera", type: .video)
+        let info = TestData.participantInfo(sid: "PA_1", identity: "user-1", tracks: [track1, track2])
+        let participant = RemoteParticipant(info: info, room: room, connectionState: .connected)
+        XCTAssertEqual(participant.trackPublications.count, 2)
+
+        // Update with only one track — the other should be removed
+        let updatedInfo = TestData.participantInfo(sid: "PA_1", identity: "user-1", tracks: [track1])
+        participant.set(info: updatedInfo, connectionState: .connected)
+
+        // Allow async unpublish
+        let expectation = expectation(description: "track unpublish")
+        Task {
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2)
+
+        XCTAssertEqual(participant.trackPublications.count, 1)
+        let audioSid = Track.Sid(from: "TR_a1")
+        XCTAssertNotNil(participant.trackPublications[audioSid])
+    }
+
+    func testSetInfoUpdatesExistingTrackPublications() {
+        let room = makeRoom()
+        let track = TestData.trackInfo(sid: "TR_a1", name: "mic", type: .audio, muted: false)
+        let info = TestData.participantInfo(sid: "PA_1", identity: "user-1", tracks: [track])
+        let participant = RemoteParticipant(info: info, room: room, connectionState: .connected)
+        XCTAssertEqual(participant.trackPublications.count, 1)
+
+        // Update with same track but muted
+        let mutedTrack = TestData.trackInfo(sid: "TR_a1", name: "mic", type: .audio, muted: true)
+        let updatedInfo = TestData.participantInfo(sid: "PA_1", identity: "user-1", tracks: [mutedTrack])
+        participant.set(info: updatedInfo, connectionState: .connected)
+
+        // Should still have 1 publication (updated, not replaced)
+        XCTAssertEqual(participant.trackPublications.count, 1)
+    }
+
+    // MARK: - Audio Tracks / Video Tracks Convenience
+
+    func testAudioTracksFilter() {
+        let room = makeRoom()
+        let audioTrack = TestData.trackInfo(sid: "TR_a1", name: "mic", type: .audio)
+        let videoTrack = TestData.trackInfo(sid: "TR_v1", name: "camera", type: .video)
+        let info = TestData.participantInfo(sid: "PA_1", identity: "user-1", tracks: [audioTrack, videoTrack])
+        let participant = RemoteParticipant(info: info, room: room, connectionState: .connected)
+
+        XCTAssertEqual(participant.audioTracks.count, 1)
+        XCTAssertEqual(participant.videoTracks.count, 1)
+    }
+
+    // MARK: - Participant State Transitions
+
+    func testParticipantStateTransitions() {
+        let room = makeRoom()
+        let info = TestData.participantInfo(sid: "PA_1", identity: "user-1", state: .joining)
+        let participant = RemoteParticipant(info: info, room: room, connectionState: .connected)
+
+        XCTAssertEqual(participant.state, .joining)
+
+        // Transition to active
+        let activeInfo = TestData.participantInfo(sid: "PA_1", identity: "user-1", state: .active)
+        participant.set(info: activeInfo, connectionState: .connected)
+
+        XCTAssertEqual(participant.state, .active)
+    }
+
+    // MARK: - Speaker State (via _state direct)
+
+    func testSpeakerStateMutation() {
+        let participant = makeRemoteParticipant()
+
+        XCTAssertFalse(participant.isSpeaking)
+        XCTAssertEqual(participant.audioLevel, 0.0)
+
+        participant._state.mutate {
+            $0.isSpeaking = true
+            $0.audioLevel = 0.75
+            $0.lastSpokeAt = Date()
+        }
+
+        XCTAssertTrue(participant.isSpeaking)
+        XCTAssertEqual(participant.audioLevel, 0.75, accuracy: 0.01)
+        XCTAssertNotNil(participant.lastSpokeAt)
+    }
+
+    // MARK: - Connection Quality
+
+    func testConnectionQualityMutation() {
+        let participant = makeRemoteParticipant()
+
+        XCTAssertEqual(participant.connectionQuality, .unknown)
+
+        participant._state.mutate { $0.connectionQuality = .excellent }
+        XCTAssertEqual(participant.connectionQuality, .excellent)
+
+        participant._state.mutate { $0.connectionQuality = .poor }
+        XCTAssertEqual(participant.connectionQuality, .poor)
+    }
+
+    // MARK: - Multiple Kinds
+
+    func testParticipantKinds() {
+        let room = makeRoom()
+        let kinds: [(Livekit_ParticipantInfo.Kind, Participant.Kind)] = [
+            (.standard, .standard),
+            (.agent, .agent),
+            (.ingress, .ingress),
+            (.egress, .egress),
+            (.sip, .sip),
+        ]
+
+        for (protoKind, expectedKind) in kinds {
+            let info = TestData.participantInfo(sid: "PA_\(protoKind)", identity: "user-\(protoKind)", kind: protoKind)
+            let participant = RemoteParticipant(info: info, room: room, connectionState: .connected)
+            XCTAssertEqual(participant.kind, expectedKind, "Kind mismatch for proto \(protoKind)")
+        }
+    }
+
+    // MARK: - Local Participant set(info:)
+
+    func testLocalParticipantSetInfo() {
+        let room = makeRoom()
+        let info = TestData.participantInfo(
+            sid: "PA_local2",
+            identity: "local-2",
+            name: "Local Two",
+            metadata: "local-meta",
+            attributes: ["key": "value"],
+            canPublish: true,
+            canSubscribe: true,
+            canPublishData: true
+        )
+
+        room.localParticipant.set(info: info, connectionState: .connected)
+
+        XCTAssertEqual(room.localParticipant.sid?.stringValue, "PA_local2")
+        XCTAssertEqual(room.localParticipant.identity?.stringValue, "local-2")
+        XCTAssertEqual(room.localParticipant.name, "Local Two")
+        XCTAssertEqual(room.localParticipant.metadata, "local-meta")
+        XCTAssertEqual(room.localParticipant.attributes["key"], "value")
+        XCTAssertTrue(room.localParticipant.permissions.canPublish)
+    }
+}

--- a/Tests/LiveKitCoreTests/Participant/ParticipantStateTests.swift
+++ b/Tests/LiveKitCoreTests/Participant/ParticipantStateTests.swift
@@ -14,12 +14,30 @@
  * limitations under the License.
  */
 
+// swiftlint:disable file_length
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @testable import LiveKit
 #if canImport(LiveKitTestSupport)
 import LiveKitTestSupport
 #endif
 
-/// Tests for Participant and RemoteParticipant state management.
+// Tests for Participant and RemoteParticipant state management.
+// swiftlint:disable:next type_body_length
 class ParticipantStateTests: LKTestCase {
     // MARK: - Helper
 

--- a/Tests/LiveKitCoreTests/Room/RoomConnectionTests.swift
+++ b/Tests/LiveKitCoreTests/Room/RoomConnectionTests.swift
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+class RoomConnectionTests: LKTestCase, @unchecked Sendable {
+    // MARK: - Connection State
+
+    func testRoomIsConnectedAfterJoin() async throws {
+        try await withRooms([RoomTestingOptions()]) { rooms in
+            let room = rooms[0]
+            XCTAssertEqual(room.connectionState, .connected)
+        }
+    }
+
+    func testRoomHasServerVersion() async throws {
+        try await withRooms([RoomTestingOptions()]) { rooms in
+            let room = rooms[0]
+            XCTAssertNotNil(room.serverVersion)
+        }
+    }
+
+    func testRoomHasCreationTime() async throws {
+        try await withRooms([RoomTestingOptions()]) { rooms in
+            let room = rooms[0]
+            XCTAssertNotNil(room.creationTime)
+        }
+    }
+
+    func testRoomHasName() async throws {
+        try await withRooms([RoomTestingOptions()]) { rooms in
+            let room = rooms[0]
+            XCTAssertNotNil(room.name)
+            XCTAssertFalse(room.name!.isEmpty)
+        }
+    }
+
+    func testRoomSidStartsWithRM() async throws {
+        try await withRooms([RoomTestingOptions()]) { rooms in
+            let room = rooms[0]
+            let sid = try await room.sid()
+            XCTAssertTrue(sid.stringValue.starts(with: "RM_"))
+        }
+    }
+
+    // MARK: - Disconnect
+
+    func testRoomDisconnectReturnsToDisconnectedState() async throws {
+        try await withRooms([RoomTestingOptions()]) { rooms in
+            let room = rooms[0]
+            XCTAssertEqual(room.connectionState, .connected)
+            await room.disconnect()
+            XCTAssertEqual(room.connectionState, .disconnected)
+        }
+    }
+
+    func testRoomDisconnectClearsRemoteParticipants() async throws {
+        try await withRooms([RoomTestingOptions(), RoomTestingOptions()]) { rooms in
+            let room1 = rooms[0]
+            XCTAssertEqual(room1.remoteParticipants.count, 1)
+            await room1.disconnect()
+            XCTAssertEqual(room1.remoteParticipants.count, 0)
+        }
+    }
+
+    // MARK: - Local Participant
+
+    func testLocalParticipantHasIdentity() async throws {
+        try await withRooms([RoomTestingOptions()]) { rooms in
+            let room = rooms[0]
+            XCTAssertNotNil(room.localParticipant.identity)
+        }
+    }
+
+    func testLocalParticipantHasSid() async throws {
+        try await withRooms([RoomTestingOptions()]) { rooms in
+            let room = rooms[0]
+            XCTAssertNotNil(room.localParticipant.sid)
+        }
+    }
+
+    // MARK: - Multi-Participant Discovery
+
+    func testTwoParticipantDiscovery() async throws {
+        try await withRooms([RoomTestingOptions(), RoomTestingOptions()]) { rooms in
+            XCTAssertEqual(rooms[0].remoteParticipants.count, 1)
+            XCTAssertEqual(rooms[1].remoteParticipants.count, 1)
+        }
+    }
+
+    func testThreeParticipantDiscovery() async throws {
+        try await withRooms([
+            RoomTestingOptions(),
+            RoomTestingOptions(),
+            RoomTestingOptions(),
+        ]) { rooms in
+            XCTAssertEqual(rooms[0].remoteParticipants.count, 2)
+            XCTAssertEqual(rooms[1].remoteParticipants.count, 2)
+            XCTAssertEqual(rooms[2].remoteParticipants.count, 2)
+        }
+    }
+
+    func testRemoteParticipantHasIdentity() async throws {
+        try await withRooms([RoomTestingOptions(), RoomTestingOptions()]) { rooms in
+            let remote = rooms[0].remoteParticipants.values.first
+            XCTAssertNotNil(remote)
+            XCTAssertNotNil(remote?.identity)
+        }
+    }
+
+    // MARK: - Participant Disconnect Delegate
+
+    private var participantDisconnectExpectation: XCTestExpectation?
+
+    func testParticipantDisconnectDelegateFiresWithIdentity() async throws {
+        participantDisconnectExpectation = expectation(description: "participantDidDisconnect should fire")
+
+        try await withRooms([RoomTestingOptions(delegate: self), RoomTestingOptions()]) { rooms in
+            // Room 2 disconnects, room 1 should get the delegate callback
+            await rooms[1].disconnect()
+            await self.fulfillment(of: [self.participantDisconnectExpectation!], timeout: 10)
+        }
+    }
+}
+
+extension RoomConnectionTests: RoomDelegate {
+    func room(_: Room, participantDidDisconnect participant: RemoteParticipant) {
+        XCTAssertNotNil(participant.identity, "identity should not be nil in participantDidDisconnect")
+        participantDisconnectExpectation?.fulfill()
+    }
+}

--- a/Tests/LiveKitCoreTests/Room/RoomParticipantTests.swift
+++ b/Tests/LiveKitCoreTests/Room/RoomParticipantTests.swift
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+class RoomParticipantTests: LKTestCase, @unchecked Sendable {
+    // MARK: - Participant Connected Event
+
+    private var participantConnectedExpectation: XCTestExpectation?
+    private var connectedParticipantIdentity: Participant.Identity?
+
+    func testParticipantConnectedEventFires() async throws {
+        participantConnectedExpectation = expectation(description: "participantDidConnect should fire")
+
+        // Room 1 connects first with delegate, then room 2 joins
+        let room1 = Room(delegate: self, connectOptions: ConnectOptions())
+        let roomName = UUID().uuidString
+
+        let token1 = try liveKitServerToken(
+            for: roomName,
+            identity: "observer",
+            canPublish: false,
+            canPublishData: false,
+            canPublishSources: [],
+            canSubscribe: true
+        )
+
+        try await room1.connect(url: liveKitServerUrl(), token: token1)
+
+        // Now connect a second room
+        let room2 = Room(connectOptions: ConnectOptions())
+        let token2 = try liveKitServerToken(
+            for: roomName,
+            identity: "joiner",
+            canPublish: false,
+            canPublishData: false,
+            canPublishSources: [],
+            canSubscribe: false
+        )
+
+        try await room2.connect(url: liveKitServerUrl(), token: token2)
+
+        await fulfillment(of: [participantConnectedExpectation!], timeout: 10)
+        XCTAssertEqual(connectedParticipantIdentity?.stringValue, "joiner")
+
+        // Cleanup
+        await room1.disconnect()
+        await room2.disconnect()
+    }
+
+    // MARK: - Participant Permissions
+
+    func testLocalParticipantPermissions() async throws {
+        try await withRooms([RoomTestingOptions(canPublish: true, canPublishData: true, canSubscribe: true)]) { rooms in
+            let perms = rooms[0].localParticipant.permissions
+            XCTAssertTrue(perms.canPublish)
+            XCTAssertTrue(perms.canPublishData)
+            XCTAssertTrue(perms.canSubscribe)
+        }
+    }
+
+    func testLocalParticipantRestrictedPermissions() async throws {
+        try await withRooms([RoomTestingOptions(canPublish: false, canPublishData: false, canSubscribe: false)]) { rooms in
+            let perms = rooms[0].localParticipant.permissions
+            XCTAssertFalse(perms.canPublish)
+            XCTAssertFalse(perms.canPublishData)
+            XCTAssertFalse(perms.canSubscribe)
+        }
+    }
+
+    // MARK: - Remote Participant Properties
+
+    func testRemoteParticipantIdentityMatchesToken() async throws {
+        try await withRooms([RoomTestingOptions(), RoomTestingOptions()]) { rooms in
+            let room1 = rooms[0]
+            let room2 = rooms[1]
+
+            // Room1's remote participant should be room2's local participant
+            let remote = room1.remoteParticipants.values.first
+            XCTAssertNotNil(remote)
+            XCTAssertEqual(remote?.identity, room2.localParticipant.identity)
+        }
+    }
+
+    func testRemoteParticipantHasSid() async throws {
+        try await withRooms([RoomTestingOptions(), RoomTestingOptions()]) { rooms in
+            let remote = rooms[0].remoteParticipants.values.first
+            XCTAssertNotNil(remote?.sid)
+        }
+    }
+}
+
+extension RoomParticipantTests: RoomDelegate {
+    func room(_: Room, participantDidConnect participant: RemoteParticipant) {
+        connectedParticipantIdentity = participant.identity
+        participantConnectedExpectation?.fulfill()
+    }
+}

--- a/Tests/LiveKitCoreTests/Room/RoomTests.swift
+++ b/Tests/LiveKitCoreTests/Room/RoomTests.swift
@@ -48,7 +48,7 @@ class RoomTests: LKTestCase, @unchecked Sendable {
             let room = rooms[0]
 
             self.noLeaks(of: room.signalClient)
-            let socket = await room.signalClient._state.socket
+            let socket = await room.signalClient._state.socket as? WebSocket
             try self.noLeaks(of: XCTUnwrap(socket))
 
             let (publisher, subscriber) = room._state.read { ($0.publisher, $0.subscriber) }

--- a/Tests/LiveKitCoreTests/Support/AsyncTryMapSequenceTests.swift
+++ b/Tests/LiveKitCoreTests/Support/AsyncTryMapSequenceTests.swift
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+/// Tests for the AsyncTryMapSequence extension on AsyncSequence.
+class AsyncTryMapSequenceTests: LKTestCase {
+    func testTryMapTransformsElements() async throws {
+        let source = AsyncStream<Int> { continuation in
+            continuation.yield(1)
+            continuation.yield(2)
+            continuation.yield(3)
+            continuation.finish()
+        }
+
+        let mapped = source.tryMap { $0 * 2 }
+        var results = [Int]()
+        for try await value in mapped {
+            results.append(value)
+        }
+        XCTAssertEqual(results, [2, 4, 6])
+    }
+
+    func testTryMapPropagatesError() async {
+        struct TestError: Error {}
+
+        let source = AsyncStream<Int> { continuation in
+            continuation.yield(1)
+            continuation.yield(2)
+            continuation.finish()
+        }
+
+        let mapped = source.tryMap { (value: Int) -> Int in
+            if value == 2 { throw TestError() }
+            return value
+        }
+
+        var results = [Int]()
+        do {
+            for try await value in mapped {
+                results.append(value)
+            }
+            XCTFail("Should have thrown")
+        } catch {
+            XCTAssertTrue(error is TestError)
+        }
+        XCTAssertEqual(results, [1])
+    }
+
+    func testTryMapWithEmptySequence() async throws {
+        let source = AsyncStream<Int> { $0.finish() }
+        let mapped = source.tryMap { $0 * 2 }
+        var results = [Int]()
+        for try await value in mapped {
+            results.append(value)
+        }
+        XCTAssertTrue(results.isEmpty)
+    }
+}

--- a/Tests/LiveKitCoreTests/Support/HTTPTests.swift
+++ b/Tests/LiveKitCoreTests/Support/HTTPTests.swift
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+/// Tests for the HTTP utility class.
+/// Uses fast-failing connections (unreachable localhost ports) to test error paths
+/// without requiring a real server.
+class HTTPTests: LKTestCase {
+    // MARK: - requestValidation error paths
+
+    func testRequestValidationConnectionRefused() async {
+        // Port 1 is almost certainly not listening — connection will be refused quickly
+        let url = URL(string: "http://127.0.0.1:1/rtc/validate")!
+        do {
+            try await HTTP.requestValidation(from: url, token: "test-token")
+            XCTFail("Should have thrown for unreachable server")
+        } catch {
+            // Should throw a URLError or similar network error
+            XCTAssertFalse(error is LiveKitError, "Connection failure should throw URLError, not LiveKitError")
+        }
+    }
+
+    // MARK: - prewarmConnection
+
+    func testPrewarmConnectionDoesNotThrow() async {
+        // prewarmConnection silently fails — verify it doesn't crash
+        let url = URL(string: "wss://127.0.0.1:1")!
+        await HTTP.prewarmConnection(url: url)
+        // If we get here, it didn't crash (best-effort connection warming)
+    }
+}

--- a/Tests/LiveKitCoreTests/Support/MapTableTests.swift
+++ b/Tests/LiveKitCoreTests/Support/MapTableTests.swift
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+/// Tests for MapTable — a thin Sendable wrapper around NSMapTable.
+class MapTableTests: LKTestCase {
+    func testWeakToStrongObjectsCreation() {
+        let table = MapTable<NSString, NSNumber>.weakToStrongObjects()
+        XCTAssertEqual(table.count, 0)
+    }
+
+    func testSetAndGetObject() {
+        let table = MapTable<NSString, NSNumber>.weakToStrongObjects()
+        let key: NSString = "key1"
+        let value = NSNumber(value: 42)
+        table.setObject(value, forKey: key)
+        XCTAssertEqual(table.object(forKey: key), value)
+        XCTAssertEqual(table.count, 1)
+    }
+
+    func testRemoveObject() {
+        let table = MapTable<NSString, NSNumber>.weakToStrongObjects()
+        let key: NSString = "key1"
+        table.setObject(NSNumber(value: 1), forKey: key)
+        XCTAssertEqual(table.count, 1)
+        table.removeObject(forKey: key)
+        XCTAssertNil(table.object(forKey: key))
+    }
+
+    func testRemoveAllObjects() {
+        let table = MapTable<NSString, NSNumber>.weakToStrongObjects()
+        table.setObject(NSNumber(value: 1), forKey: "a")
+        table.setObject(NSNumber(value: 2), forKey: "b")
+        XCTAssertEqual(table.count, 2)
+        table.removeAllObjects()
+        XCTAssertEqual(table.count, 0)
+    }
+
+    func testObjectForNilKey() {
+        let table = MapTable<NSString, NSNumber>.weakToStrongObjects()
+        XCTAssertNil(table.object(forKey: nil))
+    }
+
+    func testObjectEnumerator() {
+        let table = MapTable<NSString, NSNumber>.weakToStrongObjects()
+        table.setObject(NSNumber(value: 10), forKey: "x")
+        table.setObject(NSNumber(value: 20), forKey: "y")
+        let enumerator = table.objectEnumerator()
+        XCTAssertNotNil(enumerator)
+        var values = [Int]()
+        while let obj = enumerator?.nextObject() as? NSNumber {
+            values.append(obj.intValue)
+        }
+        XCTAssertEqual(values.sorted(), [10, 20])
+    }
+}

--- a/Tests/LiveKitCoreTests/Support/RingBufferTests.swift
+++ b/Tests/LiveKitCoreTests/Support/RingBufferTests.swift
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+class RingBufferTests: LKTestCase {
+    // MARK: - Init
+
+    func testInitCreatesZeroFilledBuffer() {
+        let buffer = RingBuffer<Int>(size: 4)
+
+        // Buffer not full yet, read returns nil
+        XCTAssertNil(buffer.read())
+    }
+
+    // MARK: - Write Single Values
+
+    func testWriteBeforeFullReturnsNil() {
+        let buffer = RingBuffer<Int>(size: 4)
+        buffer.write(1)
+        buffer.write(2)
+        buffer.write(3)
+
+        XCTAssertNil(buffer.read(), "Should return nil before buffer is full")
+    }
+
+    func testWriteExactlyFillsBuffer() {
+        let buffer = RingBuffer<Int>(size: 4)
+        buffer.write(10)
+        buffer.write(20)
+        buffer.write(30)
+        buffer.write(40)
+
+        let result = buffer.read()
+        XCTAssertEqual(result, [10, 20, 30, 40])
+    }
+
+    func testWriteWrapsAroundBuffer() {
+        let buffer = RingBuffer<Int>(size: 3)
+        buffer.write(1)
+        buffer.write(2)
+        buffer.write(3) // Buffer now full, head at 0
+
+        // Write one more — overwrites index 0
+        buffer.write(4) // head now at 1
+
+        let result = buffer.read()
+        XCTAssertEqual(result, [2, 3, 4])
+    }
+
+    func testWriteMultipleWraps() {
+        let buffer = RingBuffer<Int>(size: 3)
+        // Fill 7 values into size-3 buffer
+        for i in 1 ... 7 {
+            buffer.write(i)
+        }
+
+        let result = buffer.read()
+        XCTAssertEqual(result, [5, 6, 7])
+    }
+
+    // MARK: - Write Sequence
+
+    func testWriteSequenceFillsBuffer() {
+        let buffer = RingBuffer<Int>(size: 4)
+        buffer.write([10, 20, 30, 40])
+
+        let result = buffer.read()
+        XCTAssertEqual(result, [10, 20, 30, 40])
+    }
+
+    func testWriteSequenceWraps() {
+        let buffer = RingBuffer<Int>(size: 3)
+        buffer.write([1, 2, 3, 4, 5])
+
+        let result = buffer.read()
+        XCTAssertEqual(result, [3, 4, 5])
+    }
+
+    func testWriteSequencePartialThenFull() {
+        let buffer = RingBuffer<Int>(size: 4)
+        buffer.write([1, 2])
+        XCTAssertNil(buffer.read())
+
+        buffer.write([3, 4])
+        let result = buffer.read()
+        XCTAssertEqual(result, [1, 2, 3, 4])
+    }
+
+    // MARK: - Read Order
+
+    func testReadReturnsCorrectOrderAfterWrap() {
+        let buffer = RingBuffer<Int>(size: 5)
+        // Write 8 values into size-5 buffer
+        for i in 1 ... 8 {
+            buffer.write(i)
+        }
+
+        let result = buffer.read()
+        // Should return the last 5 values in order
+        XCTAssertEqual(result, [4, 5, 6, 7, 8])
+    }
+
+    func testReadWhenHeadAtZeroReturnsEntireBuffer() {
+        let buffer = RingBuffer<Int>(size: 3)
+        // Write exactly one full cycle + another full cycle
+        buffer.write([1, 2, 3])
+        buffer.write([4, 5, 6]) // head back at 0
+
+        let result = buffer.read()
+        XCTAssertEqual(result, [4, 5, 6])
+    }
+
+    // MARK: - Float Type
+
+    func testWorksWithFloats() {
+        let buffer = RingBuffer<Float>(size: 3)
+        buffer.write([0.1, 0.5, 0.9])
+
+        let result = buffer.read()
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.count, 3)
+        XCTAssertEqual(result![0], 0.1, accuracy: 0.001)
+        XCTAssertEqual(result![1], 0.5, accuracy: 0.001)
+        XCTAssertEqual(result![2], 0.9, accuracy: 0.001)
+    }
+
+    // MARK: - Size 1
+
+    func testSizeOneBuffer() {
+        let buffer = RingBuffer<Int>(size: 1)
+        buffer.write(42)
+
+        let result = buffer.read()
+        XCTAssertEqual(result, [42])
+
+        buffer.write(99)
+        let result2 = buffer.read()
+        XCTAssertEqual(result2, [99])
+    }
+}

--- a/Tests/LiveKitCoreTests/Support/StopwatchTests.swift
+++ b/Tests/LiveKitCoreTests/Support/StopwatchTests.swift
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+/// Tests for the Stopwatch utility type.
+class StopwatchTests: LKTestCase {
+    func testStopwatchInitialization() {
+        let sw = Stopwatch(label: "test")
+        XCTAssertEqual(sw.label, "test")
+        XCTAssertTrue(sw.splits.isEmpty)
+        XCTAssertTrue(sw.start > 0)
+    }
+
+    func testTotalWithNoSplitsReturnsZero() {
+        let sw = Stopwatch(label: "empty")
+        XCTAssertEqual(sw.total(), 0)
+    }
+
+    func testSplitAddsEntry() {
+        var sw = Stopwatch(label: "test")
+        sw.split(label: "first")
+        XCTAssertEqual(sw.splits.count, 1)
+        XCTAssertEqual(sw.splits[0].label, "first")
+    }
+
+    func testMultipleSplits() {
+        var sw = Stopwatch(label: "test")
+        sw.split(label: "a")
+        sw.split(label: "b")
+        sw.split(label: "c")
+        XCTAssertEqual(sw.splits.count, 3)
+    }
+
+    func testTotalIsNonNegative() {
+        var sw = Stopwatch(label: "test")
+        sw.split(label: "end")
+        XCTAssertTrue(sw.total() >= 0)
+    }
+
+    func testEquality() {
+        let sw1 = Stopwatch(label: "test")
+        let sw2 = sw1 // Copy (value type)
+        XCTAssertEqual(sw1, sw2)
+    }
+
+    func testInequalityAfterSplit() {
+        var sw1 = Stopwatch(label: "test")
+        let sw2 = sw1
+        sw1.split(label: "modified")
+        XCTAssertNotEqual(sw1, sw2)
+    }
+
+    func testDescription() {
+        var sw = Stopwatch(label: "connect")
+        sw.split(label: "ws")
+        let desc = sw.description
+        XCTAssertTrue(desc.contains("Stopwatch(connect"))
+        XCTAssertTrue(desc.contains("ws"))
+        XCTAssertTrue(desc.contains("total"))
+    }
+
+    func testEntryEquality() {
+        let a = Stopwatch.Entry(label: "test", time: 100.0)
+        let b = Stopwatch.Entry(label: "test", time: 100.0)
+        XCTAssertEqual(a, b)
+
+        let c = Stopwatch.Entry(label: "other", time: 100.0)
+        XCTAssertNotEqual(a, c)
+    }
+}

--- a/Tests/LiveKitCoreTests/Support/UtilsTests.swift
+++ b/Tests/LiveKitCoreTests/Support/UtilsTests.swift
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+class UtilsTests: LKTestCase {
+    // MARK: - computeAttributesDiff
+
+    func testAttributesDiffWithAddedKey() {
+        let old = ["a": "1"]
+        let new: [String: String] = ["a": "1", "b": "2"]
+
+        let diff = computeAttributesDiff(oldValues: old, newValues: new)
+
+        XCTAssertEqual(diff.count, 1)
+        XCTAssertEqual(diff["b"], "2")
+    }
+
+    func testAttributesDiffWithRemovedKey() {
+        let old: [String: String] = ["a": "1", "b": "2"]
+        let new = ["a": "1"]
+
+        let diff = computeAttributesDiff(oldValues: old, newValues: new)
+
+        XCTAssertEqual(diff.count, 1)
+        XCTAssertEqual(diff["b"], "") // removed keys get empty string
+    }
+
+    func testAttributesDiffWithChangedValue() {
+        let old = ["a": "1"]
+        let new = ["a": "2"]
+
+        let diff = computeAttributesDiff(oldValues: old, newValues: new)
+
+        XCTAssertEqual(diff.count, 1)
+        XCTAssertEqual(diff["a"], "2")
+    }
+
+    func testAttributesDiffNoChanges() {
+        let old: [String: String] = ["a": "1", "b": "2"]
+        let new: [String: String] = ["a": "1", "b": "2"]
+
+        let diff = computeAttributesDiff(oldValues: old, newValues: new)
+
+        XCTAssertTrue(diff.isEmpty)
+    }
+
+    func testAttributesDiffBothEmpty() {
+        let diff = computeAttributesDiff(oldValues: [:], newValues: [:])
+        XCTAssertTrue(diff.isEmpty)
+    }
+
+    func testAttributesDiffMultipleChanges() {
+        let old: [String: String] = ["a": "1", "b": "2", "c": "3"]
+        let new: [String: String] = ["a": "changed", "c": "3", "d": "new"]
+
+        let diff = computeAttributesDiff(oldValues: old, newValues: new)
+
+        XCTAssertEqual(diff.count, 3)
+        XCTAssertEqual(diff["a"], "changed")
+        XCTAssertEqual(diff["b"], "") // removed
+        XCTAssertEqual(diff["d"], "new")
+    }
+}

--- a/Tests/LiveKitCoreTests/Token/TokenSourceTests.swift
+++ b/Tests/LiveKitCoreTests/Token/TokenSourceTests.swift
@@ -14,12 +14,30 @@
  * limitations under the License.
  */
 
+// swiftlint:disable file_length
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @testable import LiveKit
 #if canImport(LiveKitTestSupport)
 import LiveKitTestSupport
 #endif
 import LiveKitUniFFI
 
+// swiftlint:disable:next type_body_length
 class TokenSourceTests: LKTestCase {
     actor MockValidJWTSource: TokenSourceConfigurable {
         let serverURL = URL(string: "wss://test.livekit.io")!

--- a/Tests/LiveKitCoreTests/Token/TokenSourceTests.swift
+++ b/Tests/LiveKitCoreTests/Token/TokenSourceTests.swift
@@ -287,4 +287,249 @@ class TokenSourceTests: LKTestCase {
         let finalCallCount = await mockSource.callCount
         XCTAssertEqual(finalCallCount, 1)
     }
+
+    // MARK: - LiteralTokenSource
+
+    func testLiteralTokenSourceReturnsFixedCredentials() async throws {
+        let serverURL = URL(string: "wss://my-server.livekit.cloud")!
+        let source = LiteralTokenSource(
+            serverURL: serverURL,
+            participantToken: "test-token-123",
+            participantName: "Alice",
+            roomName: "test-room"
+        )
+
+        let response = try await source.fetch()
+        XCTAssertEqual(response.serverURL, serverURL)
+        XCTAssertEqual(response.participantToken, "test-token-123")
+        XCTAssertEqual(response.participantName, "Alice")
+        XCTAssertEqual(response.roomName, "test-room")
+    }
+
+    func testLiteralTokenSourceWithOptionalFieldsNil() async throws {
+        let serverURL = URL(string: "wss://example.com")!
+        let source = LiteralTokenSource(
+            serverURL: serverURL,
+            participantToken: "token"
+        )
+
+        let response = try await source.fetch()
+        XCTAssertEqual(response.serverURL, serverURL)
+        XCTAssertEqual(response.participantToken, "token")
+        XCTAssertNil(response.participantName)
+        XCTAssertNil(response.roomName)
+    }
+
+    func testLiteralTokenSourceReturnsSameValueEveryTime() async throws {
+        let source = LiteralTokenSource(
+            serverURL: URL(string: "wss://example.com")!,
+            participantToken: "fixed-token"
+        )
+
+        let response1 = try await source.fetch()
+        let response2 = try await source.fetch()
+        XCTAssertEqual(response1.participantToken, response2.participantToken)
+        XCTAssertEqual(response1.serverURL, response2.serverURL)
+    }
+
+    // MARK: - SandboxTokenSource
+
+    func testSandboxTokenSourceURL() {
+        let source = SandboxTokenSource(id: "test-sandbox-id")
+        XCTAssertEqual(source.url.absoluteString, "https://cloud-api.livekit.io/api/v2/sandbox/connection-details")
+    }
+
+    func testSandboxTokenSourceHeaders() {
+        let source = SandboxTokenSource(id: "my-sandbox-id")
+        XCTAssertEqual(source.headers["X-Sandbox-ID"], "my-sandbox-id")
+    }
+
+    func testSandboxTokenSourceTrimsNonAlphanumericCharacters() {
+        // trimmingCharacters(in: .alphanumerics.inverted) strips non-alphanumeric from edges
+        let source = SandboxTokenSource(id: "  test-id  ")
+        XCTAssertEqual(source.id, "test-id")
+
+        let source2 = SandboxTokenSource(id: "abc123")
+        XCTAssertEqual(source2.id, "abc123")
+    }
+
+    func testSandboxTokenSourceMethodIsPOST() {
+        let source = SandboxTokenSource(id: "test")
+        XCTAssertEqual(source.method, "POST")
+    }
+
+    // MARK: - TokenSourceResponse Decoding
+
+    func testTokenSourceResponseDecoding() throws {
+        let json = """
+        {
+            "server_url": "wss://example.livekit.cloud",
+            "participant_token": "jwt-token-here",
+            "participant_name": "Alice",
+            "room_name": "test-room"
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let response = try JSONDecoder().decode(TokenSourceResponse.self, from: data)
+        XCTAssertEqual(response.serverURL.absoluteString, "wss://example.livekit.cloud")
+        XCTAssertEqual(response.participantToken, "jwt-token-here")
+        XCTAssertEqual(response.participantName, "Alice")
+        XCTAssertEqual(response.roomName, "test-room")
+    }
+
+    func testTokenSourceResponseDecodingMinimalFields() throws {
+        let json = """
+        {
+            "server_url": "wss://example.com",
+            "participant_token": "token"
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let response = try JSONDecoder().decode(TokenSourceResponse.self, from: data)
+        XCTAssertEqual(response.serverURL.absoluteString, "wss://example.com")
+        XCTAssertEqual(response.participantToken, "token")
+        XCTAssertNil(response.participantName)
+        XCTAssertNil(response.roomName)
+    }
+
+    // MARK: - Token Validation
+
+    func testHasValidTokenWithValidJWT() async throws {
+        let mockSource = MockValidJWTSource()
+        let request = TokenRequestOptions(
+            roomName: "room",
+            participantName: "user",
+            participantIdentity: "user-id"
+        )
+        let response = try await mockSource.fetch(request)
+        XCTAssertTrue(response.hasValidToken())
+    }
+
+    func testHasValidTokenWithInvalidJWT() {
+        let response = TokenSourceResponse(
+            serverURL: URL(string: "wss://example.com")!,
+            participantToken: "not-a-jwt"
+        )
+        XCTAssertFalse(response.hasValidToken())
+    }
+
+    func testHasValidTokenWithExpiredJWT() async throws {
+        let mockSource = MockExpiredJWTSource()
+        let request = TokenRequestOptions(
+            roomName: "room",
+            participantName: "user",
+            participantIdentity: "user-id"
+        )
+        let response = try await mockSource.fetch(request)
+        XCTAssertFalse(response.hasValidToken())
+    }
+
+    func testDispatchesAgentWithNoAgents() async throws {
+        let mockSource = MockValidJWTSource()
+        let request = TokenRequestOptions(
+            roomName: "room",
+            participantName: "user",
+            participantIdentity: "user-id"
+        )
+        let response = try await mockSource.fetch(request)
+        // MockValidJWTSource sets agents to empty array
+        XCTAssertFalse(response.dispatchesAgent())
+    }
+
+    func testDispatchesAgentWithInvalidToken() {
+        let response = TokenSourceResponse(
+            serverURL: URL(string: "wss://example.com")!,
+            participantToken: "invalid"
+        )
+        XCTAssertFalse(response.dispatchesAgent())
+    }
+
+    // MARK: - TokenRequestOptions
+
+    func testTokenRequestOptionsEquality() {
+        let a = TokenRequestOptions(roomName: "room", participantName: "alice")
+        let b = TokenRequestOptions(roomName: "room", participantName: "alice")
+        XCTAssertEqual(a, b)
+    }
+
+    func testTokenRequestOptionsInequality() {
+        let a = TokenRequestOptions(roomName: "room1")
+        let b = TokenRequestOptions(roomName: "room2")
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testTokenRequestOptionsToRequest() {
+        let options = TokenRequestOptions(
+            roomName: "my-room",
+            participantName: "alice",
+            participantIdentity: "alice-id",
+            agentName: "my-agent"
+        )
+
+        let request = options.toRequest()
+        XCTAssertEqual(request.roomName, "my-room")
+        XCTAssertEqual(request.participantName, "alice")
+        XCTAssertEqual(request.participantIdentity, "alice-id")
+        XCTAssertNotNil(request.roomConfiguration?.agents)
+        XCTAssertEqual(request.roomConfiguration?.agents?.count, 1)
+    }
+
+    func testTokenRequestOptionsToRequestWithoutAgent() {
+        let options = TokenRequestOptions(
+            roomName: "my-room",
+            participantName: "alice"
+        )
+
+        let request = options.toRequest()
+        XCTAssertNil(request.roomConfiguration?.agents)
+    }
+
+    // MARK: - InMemoryTokenStore
+
+    func testInMemoryTokenStore() async {
+        let store = InMemoryTokenStore()
+
+        // Initially empty
+        let initial = await store.retrieve()
+        XCTAssertNil(initial)
+
+        // Store and retrieve
+        let options = TokenRequestOptions(roomName: "room")
+        let response = TokenSourceResponse(
+            serverURL: URL(string: "wss://example.com")!,
+            participantToken: "token"
+        )
+        await store.store((options, response))
+        let cached = await store.retrieve()
+        XCTAssertNotNil(cached)
+        XCTAssertEqual(cached?.0, options)
+        XCTAssertEqual(cached?.1.participantToken, "token")
+
+        // Clear
+        await store.clear()
+        let afterClear = await store.retrieve()
+        XCTAssertNil(afterClear)
+    }
+
+    // MARK: - CachingTokenSource.cachedResponse
+
+    func testCachedResponseReturnsNilBeforeFetch() async {
+        let mockSource = MockValidJWTSource()
+        let cachingSource = CachingTokenSource(mockSource)
+        let cached = await cachingSource.cachedResponse()
+        XCTAssertNil(cached)
+    }
+
+    func testCachedResponseReturnsValueAfterFetch() async throws {
+        let mockSource = MockValidJWTSource()
+        let cachingSource = CachingTokenSource(mockSource)
+        let request = TokenRequestOptions(
+            roomName: "room",
+            participantName: "user",
+            participantIdentity: "user-id"
+        )
+        let response = try await cachingSource.fetch(request)
+        let cached = await cachingSource.cachedResponse()
+        XCTAssertEqual(cached?.participantToken, response.participantToken)
+    }
 }

--- a/Tests/LiveKitCoreTests/Track/RemoteTrackPublicationTests.swift
+++ b/Tests/LiveKitCoreTests/Track/RemoteTrackPublicationTests.swift
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+/// Tests for RemoteTrackPublication internal state management and computed properties.
+class RemoteTrackPublicationTests: LKTestCase {
+    // MARK: - Helper
+
+    private func makeRoom() -> Room {
+        let room = Room()
+        room._state.mutate { $0.connectionState = .connected }
+        let localInfo = TestData.participantInfo(sid: "PA_local", identity: "local-user")
+        room.localParticipant.set(info: localInfo, connectionState: .connected)
+        return room
+    }
+
+    private func makeRemoteParticipantWithTrack(
+        room: Room,
+        participantSid: String = "PA_r1",
+        identity: String = "remote-1",
+        trackSid: String = "TR_audio1",
+        trackName: String = "mic",
+        trackType: Livekit_TrackType = .audio,
+        trackSource: Livekit_TrackSource = .microphone,
+        muted: Bool = false
+    ) -> (RemoteParticipant, RemoteTrackPublication) {
+        let trackInfo = TestData.trackInfo(sid: trackSid, name: trackName, type: trackType, source: trackSource, muted: muted)
+        let info = TestData.participantInfo(sid: participantSid, identity: identity, tracks: [trackInfo])
+        let participant = RemoteParticipant(info: info, room: room, connectionState: .connected)
+        room._state.mutate {
+            $0.remoteParticipants[Participant.Identity(from: identity)] = participant
+        }
+        let pub = participant.trackPublications[Track.Sid(from: trackSid)]! as! RemoteTrackPublication
+        return (participant, pub)
+    }
+
+    // MARK: - Init and Computed Properties
+
+    func testInitFromTrackInfoSetsProperties() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(
+            room: room,
+            trackSid: "TR_v1",
+            trackName: "camera",
+            trackType: .video,
+            trackSource: .camera
+        )
+
+        XCTAssertEqual(pub.sid, Track.Sid(from: "TR_v1"))
+        XCTAssertEqual(pub.kind, .video)
+        XCTAssertEqual(pub.source, .camera)
+        XCTAssertEqual(pub.name, "camera")
+    }
+
+    func testSubscriptionStateDefault() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(room: room)
+
+        // No track attached, subscription allowed by default
+        XCTAssertTrue(pub.isSubscriptionAllowed)
+        XCTAssertFalse(pub.isSubscribed) // no track set
+        XCTAssertEqual(pub.subscriptionState, .unsubscribed)
+    }
+
+    func testSubscriptionStateNotAllowed() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(room: room)
+
+        pub.set(subscriptionAllowed: false)
+
+        XCTAssertFalse(pub.isSubscriptionAllowed)
+        XCTAssertFalse(pub.isSubscribed)
+        XCTAssertEqual(pub.subscriptionState, .notAllowed)
+    }
+
+    func testIsDesiredDefault() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(room: room)
+
+        XCTAssertTrue(pub.isDesired)
+    }
+
+    func testIsMutedFallsBackToMetadata() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(room: room, muted: true)
+
+        // No track attached — isMuted should fall back to isMetadataMuted
+        XCTAssertTrue(pub.isMuted)
+    }
+
+    func testIsMutedWhenNotMuted() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(room: room, muted: false)
+
+        XCTAssertFalse(pub.isMuted)
+    }
+
+    // MARK: - set(metadataMuted:)
+
+    func testSetMetadataMutedUpdatesState() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(room: room, muted: false)
+
+        XCTAssertFalse(pub._state.read { $0.isMetadataMuted })
+
+        pub.set(metadataMuted: true)
+
+        XCTAssertTrue(pub._state.read { $0.isMetadataMuted })
+        XCTAssertTrue(pub.isMuted) // falls back to metadata since no track
+    }
+
+    func testSetMetadataMutedNoOpWhenSameValue() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(room: room, muted: true)
+
+        // Already muted — should be a no-op
+        pub.set(metadataMuted: true)
+
+        XCTAssertTrue(pub._state.read { $0.isMetadataMuted })
+    }
+
+    func testSetMetadataMutedUnmutes() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(room: room, muted: true)
+
+        pub.set(metadataMuted: false)
+
+        XCTAssertFalse(pub._state.read { $0.isMetadataMuted })
+        XCTAssertFalse(pub.isMuted)
+    }
+
+    // MARK: - set(subscriptionAllowed:)
+
+    func testSetSubscriptionAllowedUpdatesState() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(room: room)
+
+        XCTAssertTrue(pub.isSubscriptionAllowed)
+
+        pub.set(subscriptionAllowed: false)
+
+        XCTAssertFalse(pub.isSubscriptionAllowed)
+        XCTAssertEqual(pub.subscriptionState, .notAllowed)
+    }
+
+    func testSetSubscriptionAllowedNoOpWhenSameValue() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(room: room)
+
+        pub.set(subscriptionAllowed: true) // already true
+
+        XCTAssertTrue(pub.isSubscriptionAllowed)
+    }
+
+    func testSetSubscriptionAllowedReEnables() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(room: room)
+
+        pub.set(subscriptionAllowed: false)
+        XCTAssertFalse(pub.isSubscriptionAllowed)
+
+        pub.set(subscriptionAllowed: true)
+        XCTAssertTrue(pub.isSubscriptionAllowed)
+    }
+
+    // MARK: - resetTrackSettings
+
+    func testResetTrackSettingsDefaultsToEnabled() {
+        let room = makeRoom()
+        // Default RoomOptions has adaptiveStream = false
+        let (_, pub) = makeRemoteParticipantWithTrack(room: room, trackType: .video, trackSource: .camera)
+
+        // Manually set track settings to disabled
+        pub._state.mutate { $0.trackSettings = TrackSettings(enabled: false) }
+        XCTAssertFalse(pub.isEnabled)
+
+        pub.resetTrackSettings()
+
+        // With adaptiveStream disabled, reset should set enabled = true
+        XCTAssertTrue(pub.isEnabled)
+    }
+
+    func testResetTrackSettingsWithAdaptiveStreamDisablesTrack() {
+        let room = Room(roomOptions: RoomOptions(adaptiveStream: true))
+        room._state.mutate { $0.connectionState = .connected }
+        let localInfo = TestData.participantInfo(sid: "PA_local", identity: "local-user")
+        room.localParticipant.set(info: localInfo, connectionState: .connected)
+
+        let trackInfo = TestData.trackInfo(sid: "TR_v1", name: "camera", type: .video, source: .camera)
+        let pInfo = TestData.participantInfo(sid: "PA_r1", identity: "remote-1", tracks: [trackInfo])
+        let participant = RemoteParticipant(info: pInfo, room: room, connectionState: .connected)
+        room._state.mutate { $0.remoteParticipants[Participant.Identity(from: "remote-1")] = participant }
+
+        let pub = participant.trackPublications[Track.Sid(from: "TR_v1")]! as! RemoteTrackPublication
+
+        pub.resetTrackSettings()
+
+        // With adaptiveStream enabled on a video track, initially disabled
+        XCTAssertFalse(pub.isEnabled)
+    }
+
+    func testResetTrackSettingsAudioNotAffectedByAdaptiveStream() {
+        let room = Room(roomOptions: RoomOptions(adaptiveStream: true))
+        room._state.mutate { $0.connectionState = .connected }
+        let localInfo = TestData.participantInfo(sid: "PA_local", identity: "local-user")
+        room.localParticipant.set(info: localInfo, connectionState: .connected)
+
+        let trackInfo = TestData.trackInfo(sid: "TR_a1", name: "mic", type: .audio, source: .microphone)
+        let pInfo = TestData.participantInfo(sid: "PA_r1", identity: "remote-1", tracks: [trackInfo])
+        let participant = RemoteParticipant(info: pInfo, room: room, connectionState: .connected)
+        room._state.mutate { $0.remoteParticipants[Participant.Identity(from: "remote-1")] = participant }
+
+        let pub = participant.trackPublications[Track.Sid(from: "TR_a1")]! as! RemoteTrackPublication
+
+        pub.resetTrackSettings()
+
+        // Audio tracks are not affected by adaptiveStream — should be enabled
+        XCTAssertTrue(pub.isEnabled)
+    }
+
+    // MARK: - updateFromInfo
+
+    func testUpdateFromInfoUpdatesNameAndMuted() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(room: room, trackSid: "TR_a1", trackName: "mic", muted: false)
+
+        XCTAssertEqual(pub.name, "mic")
+        XCTAssertFalse(pub._state.read { $0.isMetadataMuted })
+
+        // Update with new info
+        var updatedInfo = TestData.trackInfo(sid: "TR_a1", name: "microphone-updated", type: .audio, muted: true)
+        updatedInfo.simulcast = true
+        updatedInfo.mimeType = "audio/opus"
+        pub.updateFromInfo(info: updatedInfo)
+
+        XCTAssertEqual(pub.name, "microphone-updated")
+        XCTAssertTrue(pub.isSimulcasted)
+        XCTAssertEqual(pub.mimeType, "audio/opus")
+        XCTAssertTrue(pub._state.read { $0.isMetadataMuted })
+    }
+
+    func testUpdateFromInfoSetsDimensionsForVideo() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(
+            room: room, trackSid: "TR_v1", trackName: "camera",
+            trackType: .video, trackSource: .camera
+        )
+
+        var updatedInfo = Livekit_TrackInfo.with {
+            $0.sid = "TR_v1"
+            $0.name = "camera"
+            $0.type = .video
+            $0.source = .camera
+            $0.width = 1920
+            $0.height = 1080
+        }
+        pub.updateFromInfo(info: updatedInfo)
+
+        XCTAssertEqual(pub.dimensions?.width, 1920)
+        XCTAssertEqual(pub.dimensions?.height, 1080)
+    }
+
+    // MARK: - TrackPublication Base
+
+    func testTrackPublicationRequireParticipantWithNilThrows() async {
+        let room = makeRoom()
+        let trackInfo = TestData.trackInfo(sid: "TR_orphan")
+        let pub = RemoteTrackPublication(info: trackInfo, participant: room.localParticipant)
+        // Detach participant
+        pub.participant = nil
+
+        do {
+            _ = try await pub.requireParticipant()
+            XCTFail("Should have thrown")
+        } catch {
+            XCTAssertTrue(error is LiveKitError)
+        }
+    }
+
+    func testTrackPublicationEncryptionTypeDefault() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(room: room)
+
+        XCTAssertEqual(pub.encryptionType, .none)
+    }
+
+    func testStreamStateDefault() {
+        let room = makeRoom()
+        let (_, pub) = makeRemoteParticipantWithTrack(room: room)
+
+        XCTAssertEqual(pub.streamState, .paused)
+    }
+}

--- a/Tests/LiveKitCoreTests/Track/TrackPublicationTests.swift
+++ b/Tests/LiveKitCoreTests/Track/TrackPublicationTests.swift
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+class TrackPublicationTests: LKTestCase {
+    // MARK: - Audio Track Publication
+
+    func testPublishAudioTrackCreatesPublication() async throws {
+        try await withRooms([RoomTestingOptions(canPublish: true)]) { rooms in
+            let room = rooms[0]
+            let audioTrack = LocalAudioTrack.createTrack()
+
+            let publication = try await room.localParticipant.publish(audioTrack: audioTrack)
+            XCTAssertEqual(publication.source, .microphone)
+            XCTAssertNotNil(publication.sid)
+            XCTAssertNotNil(publication.track)
+        }
+    }
+
+    func testPublishAudioTrackAppearsInTrackPublications() async throws {
+        try await withRooms([RoomTestingOptions(canPublish: true)]) { rooms in
+            let room = rooms[0]
+
+            let initialCount = room.localParticipant.trackPublications.count
+            let audioTrack = LocalAudioTrack.createTrack()
+            _ = try await room.localParticipant.publish(audioTrack: audioTrack)
+
+            XCTAssertEqual(room.localParticipant.trackPublications.count, initialCount + 1)
+        }
+    }
+
+    // MARK: - Unpublish
+
+    func testUnpublishRemovesPublication() async throws {
+        try await withRooms([RoomTestingOptions(canPublish: true)]) { rooms in
+            let room = rooms[0]
+            let audioTrack = LocalAudioTrack.createTrack()
+
+            let publication = try await room.localParticipant.publish(audioTrack: audioTrack)
+            let countAfterPublish = room.localParticipant.trackPublications.count
+
+            try await room.localParticipant.unpublish(publication: publication)
+
+            XCTAssertEqual(room.localParticipant.trackPublications.count, countAfterPublish - 1)
+        }
+    }
+
+    // MARK: - Mute / Unmute
+
+    func testAudioTrackMuteUnmute() async throws {
+        try await withRooms([RoomTestingOptions(canPublish: true, canPublishSources: [.microphone])]) { rooms in
+            let room = rooms[0]
+            let audioTrack = LocalAudioTrack.createTrack()
+
+            let publication: LocalTrackPublication
+            do {
+                publication = try await room.localParticipant.publish(audioTrack: audioTrack)
+            } catch {
+                // Audio engine may not be available in CI/headless environments
+                print("Skipping mute/unmute test: audio engine not available - \(error)")
+                return
+            }
+
+            XCTAssertFalse(publication.isMuted)
+
+            try await publication.mute()
+            XCTAssertTrue(publication.isMuted)
+
+            try await publication.unmute()
+            XCTAssertFalse(publication.isMuted)
+        }
+    }
+
+    // MARK: - Permission Errors
+
+    func testPublishAudioWithoutPermissionFails() async throws {
+        try await withRooms([RoomTestingOptions(canPublish: false)]) { rooms in
+            let room = rooms[0]
+            let audioTrack = LocalAudioTrack.createTrack()
+
+            do {
+                try await room.localParticipant.publish(audioTrack: audioTrack)
+                XCTFail("Should throw insufficient permissions")
+            } catch let error as LiveKitError {
+                XCTAssertEqual(error.type, .insufficientPermissions)
+            }
+        }
+    }
+
+    func testPublishWithWrongSourcePermissionFails() async throws {
+        // Only camera allowed, try to publish microphone
+        try await withRooms([RoomTestingOptions(canPublish: true, canPublishSources: [.camera])]) { rooms in
+            let room = rooms[0]
+            let audioTrack = LocalAudioTrack.createTrack()
+
+            do {
+                try await room.localParticipant.publish(audioTrack: audioTrack)
+                XCTFail("Should throw insufficient permissions for wrong source")
+            } catch let error as LiveKitError {
+                XCTAssertEqual(error.type, .insufficientPermissions)
+            }
+        }
+    }
+
+    // MARK: - Remote Track Subscription
+
+    func testRemoteParticipantReceivesPublishedTrack() async throws {
+        try await withRooms([
+            RoomTestingOptions(canPublish: true),
+            RoomTestingOptions(canSubscribe: true),
+        ]) { rooms in
+            let publisher = rooms[0]
+            let subscriber = rooms[1]
+
+            let audioTrack = LocalAudioTrack.createTrack()
+            _ = try await publisher.localParticipant.publish(audioTrack: audioTrack)
+
+            // Wait for remote participant to see the track
+            try await Task.sleep(nanoseconds: 2_000_000_000)
+
+            let remote = subscriber.remoteParticipants.values.first
+            XCTAssertNotNil(remote)
+            XCTAssertGreaterThan(remote?.trackPublications.count ?? 0, 0)
+        }
+    }
+}

--- a/Tests/LiveKitCoreTests/Track/VideoEncodingTests.swift
+++ b/Tests/LiveKitCoreTests/Track/VideoEncodingTests.swift
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+class VideoEncodingTests: LKTestCase {
+    // MARK: - Preset Selection by Aspect Ratio
+
+    func testPresetSelection169Landscape() {
+        let dims = Dimensions(width: 1920, height: 1080)
+        let presets = dims.computeSuggestedPresets(isScreenShare: false)
+        XCTAssertEqual(presets, VideoParameters.presets169)
+    }
+
+    func testPresetSelection169Portrait() {
+        // Portrait 9:16 should still use 16:9 presets (aspectRatio is max/min)
+        let dims = Dimensions(width: 1080, height: 1920)
+        let presets = dims.computeSuggestedPresets(isScreenShare: false)
+        XCTAssertEqual(presets, VideoParameters.presets169)
+    }
+
+    func testPresetSelection43() {
+        let dims = Dimensions(width: 640, height: 480)
+        let presets = dims.computeSuggestedPresets(isScreenShare: false)
+        XCTAssertEqual(presets, VideoParameters.presets43)
+    }
+
+    func testPresetSelectionScreenShare() {
+        let dims = Dimensions(width: 1920, height: 1080)
+        let presets = dims.computeSuggestedPresets(isScreenShare: true)
+        XCTAssertEqual(presets, VideoParameters.presetsScreenShare)
+    }
+
+    // MARK: - Encoding Selection by Resolution
+
+    func testEncodingFor720p() {
+        let dims = Dimensions(width: 1280, height: 720)
+        let encoding = dims.computeSuggestedPreset(in: VideoParameters.presets169)
+        XCTAssertEqual(encoding.maxBitrate, VideoParameters.presetH720_169.encoding.maxBitrate)
+        XCTAssertEqual(encoding.maxFps, VideoParameters.presetH720_169.encoding.maxFps)
+    }
+
+    func testEncodingFor1080p() {
+        let dims = Dimensions(width: 1920, height: 1080)
+        let encoding = dims.computeSuggestedPreset(in: VideoParameters.presets169)
+        XCTAssertEqual(encoding.maxBitrate, VideoParameters.presetH1080_169.encoding.maxBitrate)
+    }
+
+    func testEncodingFor360p() {
+        let dims = Dimensions(width: 640, height: 360)
+        let encoding = dims.computeSuggestedPreset(in: VideoParameters.presets169)
+        XCTAssertEqual(encoding.maxBitrate, VideoParameters.presetH360_169.encoding.maxBitrate)
+    }
+
+    func testEncodingForVerySmallResolution() {
+        let dims = Dimensions(width: 80, height: 45)
+        let encoding = dims.computeSuggestedPreset(in: VideoParameters.presets169)
+        // Smaller than smallest preset → gets first preset
+        XCTAssertEqual(encoding.maxBitrate, VideoParameters.presetH90_169.encoding.maxBitrate)
+    }
+
+    func testEncodingForVeryLargeResolution() {
+        let dims = Dimensions(width: 5120, height: 2880)
+        let encoding = dims.computeSuggestedPreset(in: VideoParameters.presets169)
+        // Larger than largest preset → gets last preset
+        XCTAssertEqual(encoding.maxBitrate, VideoParameters.presetH2160_169.encoding.maxBitrate)
+    }
+
+    // MARK: - VideoParameters Preset Arrays
+
+    func test169PresetsCount() {
+        XCTAssertEqual(VideoParameters.presets169.count, 9)
+    }
+
+    func test43PresetsCount() {
+        XCTAssertEqual(VideoParameters.presets43.count, 9)
+    }
+
+    func testScreenSharePresetsCount() {
+        XCTAssertEqual(VideoParameters.presetsScreenShare.count, 5)
+    }
+
+    func testDefaultSimulcastPresets169() {
+        let presets = VideoParameters.defaultSimulcastPresets169
+        XCTAssertEqual(presets.count, 2)
+        XCTAssertEqual(presets[0].dimensions, Dimensions.h180_169)
+        XCTAssertEqual(presets[1].dimensions, Dimensions.h360_169)
+    }
+
+    func testDefaultSimulcastPresets43() {
+        let presets = VideoParameters.defaultSimulcastPresets43
+        XCTAssertEqual(presets.count, 2)
+        XCTAssertEqual(presets[0].dimensions, Dimensions.h180_43)
+        XCTAssertEqual(presets[1].dimensions, Dimensions.h360_43)
+    }
+
+    // MARK: - Simulcast Layer Selection
+
+    func testDefaultSimulcastLayers169() {
+        let dims = Dimensions(width: 1280, height: 720)
+        let params = VideoParameters(dimensions: dims, encoding: VideoEncoding(maxBitrate: 1_700_000, maxFps: 30))
+        let layers = params.defaultSimulcastLayers(isScreenShare: false)
+        XCTAssertEqual(layers.count, 2) // default simulcast = 2 layers
+    }
+
+    func testDefaultSimulcastLayers43() {
+        let dims = Dimensions(width: 640, height: 480)
+        let params = VideoParameters(dimensions: dims, encoding: VideoEncoding(maxBitrate: 500_000, maxFps: 20))
+        let layers = params.defaultSimulcastLayers(isScreenShare: false)
+        XCTAssertEqual(layers.count, 2)
+    }
+
+    func testDefaultScreenShareSimulcastLayers() {
+        let dims = Dimensions(width: 1920, height: 1080)
+        let params = VideoParameters(dimensions: dims, encoding: VideoEncoding(maxBitrate: 3_000_000, maxFps: 30))
+        let layers = params.defaultSimulcastLayers(isScreenShare: true)
+        XCTAssertEqual(layers.count, 1) // screenShare default = 1 extra layer
+    }
+
+    // MARK: - VideoEncoding Equality
+
+    func testVideoEncodingEquality() {
+        let a = VideoEncoding(maxBitrate: 1_000_000, maxFps: 30)
+        let b = VideoEncoding(maxBitrate: 1_000_000, maxFps: 30)
+        XCTAssertEqual(a, b)
+    }
+
+    func testVideoEncodingInequality() {
+        let a = VideoEncoding(maxBitrate: 1_000_000, maxFps: 30)
+        let b = VideoEncoding(maxBitrate: 2_000_000, maxFps: 30)
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testVideoEncodingWithPriorities() {
+        let a = VideoEncoding(maxBitrate: 1_000_000, maxFps: 30, bitratePriority: .high, networkPriority: .low)
+        let b = VideoEncoding(maxBitrate: 1_000_000, maxFps: 30, bitratePriority: .high, networkPriority: .low)
+        XCTAssertEqual(a, b)
+
+        let c = VideoEncoding(maxBitrate: 1_000_000, maxFps: 30, bitratePriority: .low, networkPriority: .low)
+        XCTAssertNotEqual(a, c)
+    }
+
+    // MARK: - VideoParameters Equality
+
+    func testVideoParametersEquality() {
+        let a = VideoParameters(dimensions: .h720_169, encoding: VideoEncoding(maxBitrate: 1_700_000, maxFps: 30))
+        let b = VideoParameters(dimensions: .h720_169, encoding: VideoEncoding(maxBitrate: 1_700_000, maxFps: 30))
+        XCTAssertEqual(a, b)
+    }
+
+    func testVideoParametersInequality() {
+        let a = VideoParameters(dimensions: .h720_169, encoding: VideoEncoding(maxBitrate: 1_700_000, maxFps: 30))
+        let b = VideoParameters(dimensions: .h1080_169, encoding: VideoEncoding(maxBitrate: 3_000_000, maxFps: 30))
+        XCTAssertNotEqual(a, b)
+    }
+
+    // MARK: - VideoQuality RIDs
+
+    func testVideoQualityRIDs() {
+        XCTAssertEqual(VideoQuality.RIDs, ["q", "h", "f"])
+    }
+
+    func testVideoQualityFromRID() {
+        XCTAssertEqual(Livekit_VideoQuality.from(rid: "q"), .low)
+        XCTAssertEqual(Livekit_VideoQuality.from(rid: "h"), .medium)
+        XCTAssertEqual(Livekit_VideoQuality.from(rid: "f"), .high)
+        XCTAssertNil(Livekit_VideoQuality.from(rid: "x"))
+        XCTAssertNil(Livekit_VideoQuality.from(rid: nil))
+    }
+
+    // MARK: - suggestedPresetIndex
+
+    func testSuggestedPresetIndexByDimensions() {
+        let presets = VideoParameters.presets169
+        // 720p should match 6 presets (h90 through h720)
+        let index = presets.suggestedPresetIndex(dimensions: .h720_169)
+        XCTAssertEqual(index, 6) // h90, h180, h216, h360, h540, h720
+    }
+
+    func testSuggestedPresetIndexSmallDimensions() {
+        let presets = VideoParameters.presets169
+        // Tiny dimensions should have index 0
+        let index = presets.suggestedPresetIndex(dimensions: Dimensions(width: 10, height: 6))
+        XCTAssertEqual(index, 0)
+    }
+}

--- a/Tests/LiveKitCoreTests/Types/AudioEncodingTests.swift
+++ b/Tests/LiveKitCoreTests/Types/AudioEncodingTests.swift
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+/// Tests for AudioEncoding, VideoEncoding+Comparable, and VideoParameters+Comparable.
+class AudioEncodingTests: LKTestCase {
+    // MARK: - AudioEncoding init
+
+    func testAudioEncodingSimpleInit() {
+        let enc = AudioEncoding(maxBitrate: 48000)
+        XCTAssertEqual(enc.maxBitrate, 48000)
+        XCTAssertNil(enc.bitratePriority)
+        XCTAssertNil(enc.networkPriority)
+    }
+
+    func testAudioEncodingFullInit() {
+        let enc = AudioEncoding(maxBitrate: 96000, bitratePriority: .high, networkPriority: .medium)
+        XCTAssertEqual(enc.maxBitrate, 96000)
+        XCTAssertEqual(enc.bitratePriority, .high)
+        XCTAssertEqual(enc.networkPriority, .medium)
+    }
+
+    // MARK: - AudioEncoding equality
+
+    func testAudioEncodingEquality() {
+        let a = AudioEncoding(maxBitrate: 48000)
+        let b = AudioEncoding(maxBitrate: 48000)
+        XCTAssertEqual(a, b)
+    }
+
+    func testAudioEncodingInequality() {
+        let a = AudioEncoding(maxBitrate: 48000)
+        let b = AudioEncoding(maxBitrate: 64000)
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testAudioEncodingEqualityWithPriorities() {
+        let a = AudioEncoding(maxBitrate: 96000, bitratePriority: .high, networkPriority: .low)
+        let b = AudioEncoding(maxBitrate: 96000, bitratePriority: .high, networkPriority: .low)
+        XCTAssertEqual(a, b)
+
+        let c = AudioEncoding(maxBitrate: 96000, bitratePriority: .low, networkPriority: .low)
+        XCTAssertNotEqual(a, c)
+    }
+
+    func testAudioEncodingIsNotEqualToNonAudioEncoding() {
+        let enc = AudioEncoding(maxBitrate: 48000)
+        XCTAssertFalse(enc.isEqual("not an encoding"))
+        XCTAssertFalse(enc.isEqual(nil))
+    }
+
+    // MARK: - AudioEncoding hash
+
+    func testAudioEncodingHash() {
+        let a = AudioEncoding(maxBitrate: 48000)
+        let b = AudioEncoding(maxBitrate: 48000)
+        XCTAssertEqual(a.hash, b.hash)
+    }
+
+    // MARK: - AudioEncoding presets
+
+    func testAudioEncodingPresets() {
+        XCTAssertEqual(AudioEncoding.presets.count, 6)
+        XCTAssertEqual(AudioEncoding.presetTelephone.maxBitrate, 12000)
+        XCTAssertEqual(AudioEncoding.presetSpeech.maxBitrate, 24000)
+        XCTAssertEqual(AudioEncoding.presetMusic.maxBitrate, 48000)
+        XCTAssertEqual(AudioEncoding.presetMusicStereo.maxBitrate, 64000)
+        XCTAssertEqual(AudioEncoding.presetMusicHighQuality.maxBitrate, 96000)
+        XCTAssertEqual(AudioEncoding.presetMusicHighQualityStereo.maxBitrate, 128_000)
+    }
+
+    func testAudioEncodingPresetsAreOrderedByBitrate() {
+        let bitrates = AudioEncoding.presets.map(\.maxBitrate)
+        XCTAssertEqual(bitrates, bitrates.sorted())
+    }
+
+    // MARK: - VideoEncoding Comparable
+
+    func testVideoEncodingLessThanByBitrate() {
+        let low = VideoEncoding(maxBitrate: 500_000, maxFps: 30)
+        let high = VideoEncoding(maxBitrate: 1_000_000, maxFps: 30)
+        XCTAssertTrue(low < high)
+        XCTAssertFalse(high < low)
+    }
+
+    func testVideoEncodingLessThanByFpsWhenBitrateEqual() {
+        let lowFps = VideoEncoding(maxBitrate: 1_000_000, maxFps: 15)
+        let highFps = VideoEncoding(maxBitrate: 1_000_000, maxFps: 30)
+        XCTAssertTrue(lowFps < highFps)
+    }
+
+    func testVideoEncodingNotLessThanWhenEqual() {
+        let a = VideoEncoding(maxBitrate: 1_000_000, maxFps: 30)
+        let b = VideoEncoding(maxBitrate: 1_000_000, maxFps: 30)
+        XCTAssertFalse(a < b)
+    }
+
+    // MARK: - VideoParameters Comparable
+
+    func testVideoParametersLessThanByArea() {
+        let small = VideoParameters(dimensions: .h360_169, encoding: VideoEncoding(maxBitrate: 450_000, maxFps: 20))
+        let large = VideoParameters(dimensions: .h720_169, encoding: VideoEncoding(maxBitrate: 450_000, maxFps: 20))
+        XCTAssertTrue(small < large)
+    }
+
+    func testVideoParametersLessThanByEncodingWhenAreaEqual() {
+        let lowBitrate = VideoParameters(dimensions: .h720_169, encoding: VideoEncoding(maxBitrate: 500_000, maxFps: 30))
+        let highBitrate = VideoParameters(dimensions: .h720_169, encoding: VideoEncoding(maxBitrate: 1_700_000, maxFps: 30))
+        XCTAssertTrue(lowBitrate < highBitrate)
+    }
+
+    // MARK: - VideoParameters suggestedPresetIndex (videoEncoding path)
+
+    func testSuggestedPresetIndexByVideoEncoding() {
+        let presets = VideoParameters.presets169
+        let encoding = VideoEncoding(maxBitrate: 450_000, maxFps: 20) // matches 360p
+        let index = presets.suggestedPresetIndex(videoEncoding: encoding)
+        // Counts how many presets have maxBitrate <= 450000
+        XCTAssertTrue(index > 0)
+    }
+
+    // MARK: - VideoParameters hash
+
+    func testVideoParametersHash() {
+        let a = VideoParameters(dimensions: .h720_169, encoding: VideoEncoding(maxBitrate: 1_700_000, maxFps: 30))
+        let b = VideoParameters(dimensions: .h720_169, encoding: VideoEncoding(maxBitrate: 1_700_000, maxFps: 30))
+        XCTAssertEqual(a.hash, b.hash)
+    }
+}

--- a/Tests/LiveKitCoreTests/Types/DimensionsTests.swift
+++ b/Tests/LiveKitCoreTests/Types/DimensionsTests.swift
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+class DimensionsTests: LKTestCase {
+    // MARK: - Basic Properties
+
+    func testAspectRatioLandscape() {
+        let dims = Dimensions(width: 1920, height: 1080)
+        XCTAssertEqual(dims.aspectRatio, 16.0 / 9.0, accuracy: 0.01)
+    }
+
+    func testAspectRatioPortrait() {
+        let dims = Dimensions(width: 1080, height: 1920)
+        // aspectRatio always returns larger/smaller
+        XCTAssertEqual(dims.aspectRatio, 16.0 / 9.0, accuracy: 0.01)
+    }
+
+    func testAspectRatioSquare() {
+        let dims = Dimensions(width: 100, height: 100)
+        XCTAssertEqual(dims.aspectRatio, 1.0, accuracy: 0.001)
+    }
+
+    func testAspectRatio43() {
+        let dims = Dimensions(width: 640, height: 480)
+        XCTAssertEqual(dims.aspectRatio, 4.0 / 3.0, accuracy: 0.01)
+    }
+
+    func testMax() {
+        XCTAssertEqual(Dimensions(width: 1920, height: 1080).max, 1920)
+        XCTAssertEqual(Dimensions(width: 1080, height: 1920).max, 1920)
+        XCTAssertEqual(Dimensions(width: 500, height: 500).max, 500)
+    }
+
+    func testArea() {
+        XCTAssertEqual(Dimensions(width: 1920, height: 1080).area, 1920 * 1080)
+        XCTAssertEqual(Dimensions(width: 0, height: 100).area, 0)
+    }
+
+    // MARK: - Swapped
+
+    func testSwapped() {
+        let dims = Dimensions(width: 1920, height: 1080)
+        let swapped = dims.swapped()
+        XCTAssertEqual(swapped.width, 1080)
+        XCTAssertEqual(swapped.height, 1920)
+    }
+
+    func testSwappedSquare() {
+        let dims = Dimensions(width: 100, height: 100)
+        let swapped = dims.swapped()
+        XCTAssertEqual(swapped.width, 100)
+        XCTAssertEqual(swapped.height, 100)
+    }
+
+    // MARK: - AspectFit
+
+    func testAspectFitLandscape() {
+        let dims = Dimensions(width: 1920, height: 1080)
+        let fitted = dims.aspectFit(size: 1280)
+        // Landscape: width >= height, so width becomes size, height scales proportionally
+        XCTAssertEqual(fitted.width, 1280)
+        XCTAssertEqual(fitted.height, Int32(Double(1080) / Double(1920) * 1280))
+    }
+
+    func testAspectFitPortrait() {
+        let dims = Dimensions(width: 1080, height: 1920)
+        let fitted = dims.aspectFit(size: 1280)
+        // Portrait: height > width, so height becomes size, width scales proportionally
+        XCTAssertEqual(fitted.height, 1280)
+        XCTAssertEqual(fitted.width, Int32(Double(1080) / Double(1920) * 1280))
+    }
+
+    func testAspectFitSquare() {
+        let dims = Dimensions(width: 500, height: 500)
+        let fitted = dims.aspectFit(size: 200)
+        XCTAssertEqual(fitted.width, 200)
+        XCTAssertEqual(fitted.height, 200)
+    }
+
+    // MARK: - Preset Selection
+
+    func testComputeSuggestedPresetsScreenShare() {
+        let dims = Dimensions(width: 1920, height: 1080)
+        let presets = dims.computeSuggestedPresets(isScreenShare: true)
+        XCTAssertEqual(presets, VideoParameters.presetsScreenShare)
+    }
+
+    func testComputeSuggestedPresets169() {
+        let dims = Dimensions(width: 1920, height: 1080)
+        let presets = dims.computeSuggestedPresets(isScreenShare: false)
+        XCTAssertEqual(presets, VideoParameters.presets169)
+    }
+
+    func testComputeSuggestedPresets43() {
+        let dims = Dimensions(width: 640, height: 480)
+        let presets = dims.computeSuggestedPresets(isScreenShare: false)
+        XCTAssertEqual(presets, VideoParameters.presets43)
+    }
+
+    func testComputeSuggestedPresetMatchesResolution() {
+        // 720p should select the 720p preset encoding
+        let dims = Dimensions(width: 1280, height: 720)
+        let encoding = dims.computeSuggestedPreset(in: VideoParameters.presets169)
+        XCTAssertEqual(encoding, VideoParameters.presetH720_169.encoding)
+    }
+
+    func testComputeSuggestedPresetSmallResolution() {
+        // Very small resolution should get the first (smallest) preset
+        let dims = Dimensions(width: 100, height: 56)
+        let encoding = dims.computeSuggestedPreset(in: VideoParameters.presets169)
+        XCTAssertEqual(encoding, VideoParameters.presetH90_169.encoding)
+    }
+
+    func testComputeSuggestedPresetLargeResolution() {
+        // Very large resolution should get the last (largest) preset
+        let dims = Dimensions(width: 5000, height: 2812)
+        let encoding = dims.computeSuggestedPreset(in: VideoParameters.presets169)
+        XCTAssertEqual(encoding, VideoParameters.presetH2160_169.encoding)
+    }
+
+    // MARK: - Equality and Hashing
+
+    func testEquality() {
+        let a = Dimensions(width: 1920, height: 1080)
+        let b = Dimensions(width: 1920, height: 1080)
+        let c = Dimensions(width: 1080, height: 1920)
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+
+    func testHashing() {
+        let a = Dimensions(width: 1920, height: 1080)
+        let b = Dimensions(width: 1920, height: 1080)
+        XCTAssertEqual(a.hash, b.hash)
+
+        // Different dimensions should (likely) have different hashes
+        let c = Dimensions(width: 1080, height: 1920)
+        XCTAssertNotEqual(a.hash, c.hash)
+    }
+
+    func testEqualityWithNonDimensionsObject() {
+        let dims = Dimensions(width: 1920, height: 1080)
+        XCTAssertFalse(dims.isEqual("not a Dimensions"))
+        XCTAssertFalse(dims.isEqual(nil))
+    }
+
+    // MARK: - Static Constants
+
+    func testZero() {
+        XCTAssertEqual(Dimensions.zero.width, 0)
+        XCTAssertEqual(Dimensions.zero.height, 0)
+    }
+
+    func testAspectRatioConstants() {
+        XCTAssertEqual(Dimensions.aspectRatio169, 16.0 / 9.0, accuracy: 0.0001)
+        XCTAssertEqual(Dimensions.aspectRatio43, 4.0 / 3.0, accuracy: 0.0001)
+    }
+
+    // MARK: - Presets
+
+    func testPreset169Dimensions() {
+        XCTAssertEqual(Dimensions.h90_169.width, 160)
+        XCTAssertEqual(Dimensions.h90_169.height, 90)
+        XCTAssertEqual(Dimensions.h720_169.width, 1280)
+        XCTAssertEqual(Dimensions.h720_169.height, 720)
+        XCTAssertEqual(Dimensions.h1080_169.width, 1920)
+        XCTAssertEqual(Dimensions.h1080_169.height, 1080)
+        XCTAssertEqual(Dimensions.h2160_169.width, 3840)
+        XCTAssertEqual(Dimensions.h2160_169.height, 2160)
+    }
+
+    func testPreset43Dimensions() {
+        XCTAssertEqual(Dimensions.h120_43.width, 160)
+        XCTAssertEqual(Dimensions.h120_43.height, 120)
+        XCTAssertEqual(Dimensions.h720_43.width, 960)
+        XCTAssertEqual(Dimensions.h720_43.height, 720)
+        XCTAssertEqual(Dimensions.h1440_43.width, 1920)
+        XCTAssertEqual(Dimensions.h1440_43.height, 1440)
+    }
+
+    // MARK: - Description
+
+    func testDescription() {
+        let dims = Dimensions(width: 1920, height: 1080)
+        XCTAssertEqual(dims.description, "Dimensions(1920x1080)")
+    }
+
+    // MARK: - Preset Arrays
+
+    func testPresetsAreOrderedByResolution() {
+        let presets169 = VideoParameters.presets169
+        for i in 1 ..< presets169.count {
+            XCTAssertGreaterThan(
+                presets169[i].dimensions.width,
+                presets169[i - 1].dimensions.width,
+                "16:9 presets should be ordered by ascending width"
+            )
+        }
+
+        let presets43 = VideoParameters.presets43
+        for i in 1 ..< presets43.count {
+            XCTAssertGreaterThan(
+                presets43[i].dimensions.width,
+                presets43[i - 1].dimensions.width,
+                "4:3 presets should be ordered by ascending width"
+            )
+        }
+    }
+
+    func testPresetsHaveIncreasingBitrate() {
+        let presets169 = VideoParameters.presets169
+        for i in 1 ..< presets169.count {
+            XCTAssertGreaterThan(
+                presets169[i].encoding.maxBitrate,
+                presets169[i - 1].encoding.maxBitrate,
+                "16:9 presets should have increasing bitrate"
+            )
+        }
+    }
+}

--- a/Tests/LiveKitCoreTests/Types/OptionsTests.swift
+++ b/Tests/LiveKitCoreTests/Types/OptionsTests.swift
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+class OptionsTests: LKTestCase {
+    // MARK: - Default Values
+
+    func testDefaultInitValues() {
+        let options = ConnectOptions()
+        XCTAssertTrue(options.autoSubscribe)
+        XCTAssertEqual(options.reconnectAttempts, 10)
+        XCTAssertEqual(options.reconnectAttemptDelay, TimeInterval.defaultReconnectDelay)
+        XCTAssertEqual(options.reconnectMaxDelay, TimeInterval.defaultReconnectMaxDelay)
+        XCTAssertEqual(options.socketConnectTimeoutInterval, TimeInterval.defaultSocketConnect)
+        XCTAssertEqual(options.primaryTransportConnectTimeout, TimeInterval.defaultTransportState)
+        XCTAssertEqual(options.publisherTransportConnectTimeout, TimeInterval.defaultTransportState)
+        XCTAssertTrue(options.iceServers.isEmpty)
+        XCTAssertEqual(options.iceTransportPolicy, .all)
+        XCTAssertFalse(options.isDscpEnabled)
+        XCTAssertFalse(options.enableMicrophone)
+    }
+
+    func testParameterlessInitMatchesParameterizedDefaults() {
+        let parameterless = ConnectOptions()
+        let parameterized = ConnectOptions(
+            autoSubscribe: true,
+            reconnectAttempts: 10,
+            reconnectAttemptDelay: .defaultReconnectDelay,
+            reconnectMaxDelay: .defaultReconnectMaxDelay,
+            socketConnectTimeoutInterval: .defaultSocketConnect,
+            primaryTransportConnectTimeout: .defaultTransportState,
+            publisherTransportConnectTimeout: .defaultTransportState
+        )
+        XCTAssertEqual(parameterless, parameterized)
+    }
+
+    // MARK: - Reconnect Delay Clamping
+
+    func testReconnectMaxDelayClampedToAtLeastAttemptDelay() {
+        // When maxDelay < attemptDelay, it should be clamped to attemptDelay
+        let options = ConnectOptions(
+            reconnectAttemptDelay: 5.0,
+            reconnectMaxDelay: 2.0
+        )
+        XCTAssertEqual(options.reconnectMaxDelay, 5.0,
+                       "reconnectMaxDelay should be clamped to reconnectAttemptDelay when smaller")
+    }
+
+    func testReconnectMaxDelayNotClampedWhenLarger() {
+        let options = ConnectOptions(
+            reconnectAttemptDelay: 0.5,
+            reconnectMaxDelay: 10.0
+        )
+        XCTAssertEqual(options.reconnectMaxDelay, 10.0)
+    }
+
+    func testReconnectMaxDelayEqualToAttemptDelay() {
+        let options = ConnectOptions(
+            reconnectAttemptDelay: 3.0,
+            reconnectMaxDelay: 3.0
+        )
+        XCTAssertEqual(options.reconnectMaxDelay, 3.0)
+    }
+
+    // MARK: - Default Values Sanity
+
+    func testDefaultValuesArePositive() {
+        let options = ConnectOptions()
+        XCTAssertGreaterThan(options.reconnectAttempts, 0)
+        XCTAssertGreaterThan(options.reconnectAttemptDelay, 0)
+        XCTAssertGreaterThan(options.reconnectMaxDelay, 0)
+        XCTAssertGreaterThan(options.socketConnectTimeoutInterval, 0)
+        XCTAssertGreaterThan(options.primaryTransportConnectTimeout, 0)
+        XCTAssertGreaterThan(options.publisherTransportConnectTimeout, 0)
+    }
+
+    func testMaxDelayIsGreaterThanAttemptDelay() {
+        let options = ConnectOptions()
+        XCTAssertGreaterThanOrEqual(options.reconnectMaxDelay, options.reconnectAttemptDelay)
+    }
+
+    // MARK: - Equality
+
+    func testEqualityWithSameValues() {
+        let a = ConnectOptions(reconnectAttempts: 5, reconnectAttemptDelay: 1.0)
+        let b = ConnectOptions(reconnectAttempts: 5, reconnectAttemptDelay: 1.0)
+        XCTAssertEqual(a, b)
+    }
+
+    func testInequalityWithDifferentValues() {
+        let a = ConnectOptions(reconnectAttempts: 5)
+        let b = ConnectOptions(reconnectAttempts: 10)
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testEqualityWithNonConnectOptionsObject() {
+        let options = ConnectOptions()
+        XCTAssertFalse(options.isEqual("not ConnectOptions"))
+        XCTAssertFalse(options.isEqual(nil))
+    }
+
+    // MARK: - Hashing
+
+    func testHashConsistency() {
+        let a = ConnectOptions(reconnectAttempts: 5, reconnectAttemptDelay: 1.0)
+        let b = ConnectOptions(reconnectAttempts: 5, reconnectAttemptDelay: 1.0)
+        XCTAssertEqual(a.hash, b.hash)
+    }
+
+    // MARK: - Custom Values
+
+    func testCustomIceServers() {
+        let server = IceServer(urls: ["stun:stun.example.com"], username: nil, credential: nil)
+        let options = ConnectOptions(iceServers: [server])
+        XCTAssertEqual(options.iceServers.count, 1)
+    }
+
+    func testCustomIceTransportPolicy() {
+        let options = ConnectOptions(iceTransportPolicy: .relay)
+        XCTAssertEqual(options.iceTransportPolicy, .relay)
+    }
+
+    func testDscpEnabled() {
+        let options = ConnectOptions(isDscpEnabled: true)
+        XCTAssertTrue(options.isDscpEnabled)
+    }
+
+    func testEnableMicrophone() {
+        let options = ConnectOptions(enableMicrophone: true)
+        XCTAssertTrue(options.enableMicrophone)
+    }
+}

--- a/Tests/LiveKitCoreTests/Types/ScalabilityModeTests.swift
+++ b/Tests/LiveKitCoreTests/Types/ScalabilityModeTests.swift
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+class ScalabilityModeTests: LKTestCase {
+    // MARK: - fromString Parsing
+
+    func testFromStringL3T3() {
+        let mode = ScalabilityMode.fromString("L3T3")
+        XCTAssertEqual(mode, .L3T3)
+    }
+
+    func testFromStringL3T3KEY() {
+        let mode = ScalabilityMode.fromString("L3T3_KEY")
+        XCTAssertEqual(mode, .L3T3_KEY)
+    }
+
+    func testFromStringL3T3KEYSHIFT() {
+        let mode = ScalabilityMode.fromString("L3T3_KEY_SHIFT")
+        XCTAssertEqual(mode, .L3T3_KEY_SHIFT)
+    }
+
+    func testFromStringL1T3() {
+        let mode = ScalabilityMode.fromString("L1T3")
+        XCTAssertEqual(mode, .L1T3)
+    }
+
+    func testFromStringNil() {
+        XCTAssertNil(ScalabilityMode.fromString(nil))
+    }
+
+    func testFromStringEmpty() {
+        XCTAssertNil(ScalabilityMode.fromString(""))
+    }
+
+    func testFromStringInvalid() {
+        XCTAssertNil(ScalabilityMode.fromString("L2T2"))
+        XCTAssertNil(ScalabilityMode.fromString("invalid"))
+        XCTAssertNil(ScalabilityMode.fromString("l3t3")) // case-sensitive
+    }
+
+    // MARK: - rawStringValue
+
+    func testRawStringValueRoundtrip() {
+        let modes: [ScalabilityMode] = [.L3T3, .L3T3_KEY, .L3T3_KEY_SHIFT, .L1T3]
+        for mode in modes {
+            XCTAssertEqual(ScalabilityMode.fromString(mode.rawStringValue), mode,
+                           "Round-trip failed for \(mode)")
+        }
+    }
+
+    // MARK: - Spatial and Temporal Layers
+
+    func testSpatialL1T3() {
+        XCTAssertEqual(ScalabilityMode.L1T3.spatial, 1)
+    }
+
+    func testSpatialL3T3() {
+        XCTAssertEqual(ScalabilityMode.L3T3.spatial, 3)
+    }
+
+    func testSpatialL3T3KEY() {
+        XCTAssertEqual(ScalabilityMode.L3T3_KEY.spatial, 3)
+    }
+
+    func testSpatialL3T3KEYSHIFT() {
+        XCTAssertEqual(ScalabilityMode.L3T3_KEY_SHIFT.spatial, 3)
+    }
+
+    func testTemporalIsAlways3() {
+        let modes: [ScalabilityMode] = [.L3T3, .L3T3_KEY, .L3T3_KEY_SHIFT, .L1T3]
+        for mode in modes {
+            XCTAssertEqual(mode.temporal, 3, "Temporal should be 3 for \(mode)")
+        }
+    }
+
+    // MARK: - Description
+
+    func testDescription() {
+        XCTAssertEqual(ScalabilityMode.L3T3.description, "ScalabilityMode(L3T3)")
+        XCTAssertEqual(ScalabilityMode.L1T3.description, "ScalabilityMode(L1T3)")
+    }
+}

--- a/Tests/LiveKitCoreTests/Types/StatisticsTests.swift
+++ b/Tests/LiveKitCoreTests/Types/StatisticsTests.swift
@@ -14,12 +14,30 @@
  * limitations under the License.
  */
 
+// swiftlint:disable file_length
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @testable import LiveKit
 #if canImport(LiveKitTestSupport)
 import LiveKitTestSupport
 #endif
 
-/// Tests for WebRTC Statistics types — parsing raw dictionaries into typed statistics.
+// Tests for WebRTC Statistics types — parsing raw dictionaries into typed statistics.
+// swiftlint:disable:next type_body_length
 class StatisticsTests: LKTestCase {
     // MARK: - StatisticsType raw values
 

--- a/Tests/LiveKitCoreTests/Types/StatisticsTests.swift
+++ b/Tests/LiveKitCoreTests/Types/StatisticsTests.swift
@@ -1,0 +1,515 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+/// Tests for WebRTC Statistics types — parsing raw dictionaries into typed statistics.
+class StatisticsTests: LKTestCase {
+    // MARK: - StatisticsType raw values
+
+    func testStatisticsTypeRawValues() {
+        XCTAssertEqual(StatisticsType.codec.rawValue, "codec")
+        XCTAssertEqual(StatisticsType.inboundRtp.rawValue, "inbound-rtp")
+        XCTAssertEqual(StatisticsType.outboundRtp.rawValue, "outbound-rtp")
+        XCTAssertEqual(StatisticsType.remoteInboundRtp.rawValue, "remote-inbound-rtp")
+        XCTAssertEqual(StatisticsType.remoteOutboundRtp.rawValue, "remote-outbound-rtp")
+        XCTAssertEqual(StatisticsType.mediaSource.rawValue, "media-source")
+        XCTAssertEqual(StatisticsType.mediaPlayout.rawValue, "media-playout")
+        XCTAssertEqual(StatisticsType.peerConnection.rawValue, "peer-connection")
+        XCTAssertEqual(StatisticsType.dataChannel.rawValue, "data-channel")
+        XCTAssertEqual(StatisticsType.transport.rawValue, "transport")
+        XCTAssertEqual(StatisticsType.candidatePair.rawValue, "candidate-pair")
+        XCTAssertEqual(StatisticsType.localCandidate.rawValue, "local-candidate")
+        XCTAssertEqual(StatisticsType.remoteCandidate.rawValue, "remote-candidate")
+        XCTAssertEqual(StatisticsType.certificate.rawValue, "certificate")
+    }
+
+    // MARK: - Quality / State enums
+
+    func testQualityLimitationReasonRawValues() {
+        XCTAssertEqual(QualityLimitationReason.none.rawValue, "none")
+        XCTAssertEqual(QualityLimitationReason.cpu.rawValue, "cpu")
+        XCTAssertEqual(QualityLimitationReason.bandwidth.rawValue, "bandwidth")
+        XCTAssertEqual(QualityLimitationReason.other.rawValue, "other")
+    }
+
+    func testDtlsRoleRawValues() {
+        XCTAssertEqual(DtlsRole.client.rawValue, "client")
+        XCTAssertEqual(DtlsRole.server.rawValue, "server")
+        XCTAssertEqual(DtlsRole.unknown.rawValue, "unknown")
+    }
+
+    func testIceCandidatePairStateRawValues() {
+        XCTAssertEqual(IceCandidatePairState.frozen.rawValue, "frozen")
+        XCTAssertEqual(IceCandidatePairState.waiting.rawValue, "waiting")
+        XCTAssertEqual(IceCandidatePairState.inProgress.rawValue, "in-progress")
+        XCTAssertEqual(IceCandidatePairState.failed.rawValue, "failed")
+        XCTAssertEqual(IceCandidatePairState.succeeded.rawValue, "succeeded")
+    }
+
+    func testDataChannelStateRawValues() {
+        XCTAssertEqual(DataChannelState.connecting.rawValue, "connecting")
+        XCTAssertEqual(DataChannelState.open.rawValue, "open")
+        XCTAssertEqual(DataChannelState.closing.rawValue, "closing")
+        XCTAssertEqual(DataChannelState.closed.rawValue, "closed")
+    }
+
+    func testIceRoleRawValues() {
+        XCTAssertEqual(IceRole.unknown.rawValue, "unknown")
+        XCTAssertEqual(IceRole.controlling.rawValue, "controlling")
+        XCTAssertEqual(IceRole.controlled.rawValue, "controlled")
+    }
+
+    func testDtlsTransportStateRawValues() {
+        XCTAssertEqual(DtlsTransportState.new.rawValue, "new")
+        XCTAssertEqual(DtlsTransportState.connecting.rawValue, "connecting")
+        XCTAssertEqual(DtlsTransportState.connected.rawValue, "connected")
+        XCTAssertEqual(DtlsTransportState.closed.rawValue, "closed")
+        XCTAssertEqual(DtlsTransportState.failed.rawValue, "failed")
+    }
+
+    func testIceTransportStateRawValues() {
+        XCTAssertEqual(IceTransportState.new.rawValue, "new")
+        XCTAssertEqual(IceTransportState.checking.rawValue, "checking")
+        XCTAssertEqual(IceTransportState.connected.rawValue, "connected")
+        XCTAssertEqual(IceTransportState.completed.rawValue, "completed")
+        XCTAssertEqual(IceTransportState.disconnected.rawValue, "disconnected")
+        XCTAssertEqual(IceTransportState.failed.rawValue, "failed")
+        XCTAssertEqual(IceTransportState.closed.rawValue, "closed")
+    }
+
+    func testIceCandidateTypeRawValues() {
+        XCTAssertEqual(IceCandidateType.host.rawValue, "host")
+        XCTAssertEqual(IceCandidateType.srflx.rawValue, "srflx")
+        XCTAssertEqual(IceCandidateType.prflx.rawValue, "prflx")
+        XCTAssertEqual(IceCandidateType.relay.rawValue, "relay")
+    }
+
+    func testIceServerTransportProtocolRawValues() {
+        XCTAssertEqual(IceServerTransportProtocol.udp.rawValue, "udp")
+        XCTAssertEqual(IceServerTransportProtocol.tcp.rawValue, "tcp")
+        XCTAssertEqual(IceServerTransportProtocol.tls.rawValue, "tls")
+    }
+
+    func testIceTcpCandidateTypeRawValues() {
+        XCTAssertEqual(IceTcpCandidateType.active.rawValue, "active")
+        XCTAssertEqual(IceTcpCandidateType.passive.rawValue, "passive")
+        XCTAssertEqual(IceTcpCandidateType.so.rawValue, "so")
+    }
+
+    // MARK: - CodecStatistics
+
+    func testCodecStatisticsFromRawValues() {
+        let raw: [String: NSObject] = [
+            "payloadType": NSNumber(value: 111),
+            "transportId": "T01" as NSString,
+            "mimeType": "audio/opus" as NSString,
+            "clockRate": NSNumber(value: 48000),
+            "channels": NSNumber(value: 2),
+            "sdpFmtpLine": "minptime=10;useinbandfec=1" as NSString,
+        ]
+        let codec = CodecStatistics(id: "codec-1", timestamp: 1000.0, rawValues: raw)
+        XCTAssertNotNil(codec)
+        XCTAssertEqual(codec?.id, "codec-1")
+        XCTAssertEqual(codec?.type, .codec)
+        XCTAssertEqual(codec?.payloadType, 111)
+        XCTAssertEqual(codec?.transportId, "T01")
+        XCTAssertEqual(codec?.mimeType, "audio/opus")
+        XCTAssertEqual(codec?.clockRate, 48000)
+        XCTAssertEqual(codec?.channels, 2)
+        XCTAssertEqual(codec?.sdpFmtpLine, "minptime=10;useinbandfec=1")
+    }
+
+    func testCodecStatisticsWithEmptyRawValues() {
+        let codec = CodecStatistics(id: "codec-2", timestamp: 2000.0, rawValues: [:])
+        XCTAssertNotNil(codec)
+        XCTAssertNil(codec?.payloadType)
+        XCTAssertNil(codec?.mimeType)
+    }
+
+    // MARK: - PeerConnectionStatistics
+
+    func testPeerConnectionStatistics() {
+        let raw: [String: NSObject] = [
+            "dataChannelsOpened": NSNumber(value: 3),
+            "dataChannelsClosed": NSNumber(value: 1),
+        ]
+        let pc = PeerConnectionStatistics(id: "pc-1", timestamp: 1000.0, rawValues: raw)
+        XCTAssertNotNil(pc)
+        XCTAssertEqual(pc?.type, .peerConnection)
+        XCTAssertEqual(pc?.dataChannelsOpened, 3)
+        XCTAssertEqual(pc?.dataChannelsClosed, 1)
+    }
+
+    // MARK: - DataChannelStatistics
+
+    func testDataChannelStatistics() {
+        let raw: [String: NSObject] = [
+            "label": "reliable" as NSString,
+            "protocol": "sctp" as NSString,
+            "state": "open" as NSString,
+            "messagesSent": NSNumber(value: 42),
+            "bytesSent": NSNumber(value: 1024),
+            "messagesReceived": NSNumber(value: 10),
+            "bytesReceived": NSNumber(value: 512),
+        ]
+        let dc = DataChannelStatistics(id: "dc-1", timestamp: 1000.0, rawValues: raw)
+        XCTAssertNotNil(dc)
+        XCTAssertEqual(dc?.type, .dataChannel)
+        XCTAssertEqual(dc?.label, "reliable")
+        XCTAssertEqual(dc?.state, .open)
+        XCTAssertEqual(dc?.messagesSent, 42)
+    }
+
+    // MARK: - TransportStatistics
+
+    func testTransportStatistics() {
+        let raw: [String: NSObject] = [
+            "packetsSent": NSNumber(value: 1000),
+            "packetsReceived": NSNumber(value: 900),
+            "bytesSent": NSNumber(value: 50000),
+            "bytesReceived": NSNumber(value: 45000),
+            "iceRole": "controlling" as NSString,
+            "dtlsState": "connected" as NSString,
+            "iceState": "completed" as NSString,
+            "dtlsRole": "client" as NSString,
+            "selectedCandidatePairId": "pair-1" as NSString,
+            "tlsVersion": "1.3" as NSString,
+            "dtlsCipher": "TLS_AES_128_GCM_SHA256" as NSString,
+            "srtpCipher": "AES_CM_128_HMAC_SHA1_80" as NSString,
+        ]
+        let transport = TransportStatistics(id: "transport-1", timestamp: 1000.0, rawValues: raw)
+        XCTAssertNotNil(transport)
+        XCTAssertEqual(transport?.type, .transport)
+        XCTAssertEqual(transport?.iceRole, .controlling)
+        XCTAssertEqual(transport?.dtlsState, .connected)
+        XCTAssertEqual(transport?.iceState, .completed)
+        XCTAssertEqual(transport?.dtlsRole, .client)
+        XCTAssertEqual(transport?.packetsSent, 1000)
+    }
+
+    // MARK: - IceCandidateStatistics
+
+    func testLocalIceCandidateStatistics() {
+        let raw: [String: NSObject] = [
+            "transportId": "T01" as NSString,
+            "address": "192.168.1.100" as NSString,
+            "port": NSNumber(value: 12345),
+            "protocol": "udp" as NSString,
+            "candidateType": "host" as NSString,
+            "priority": NSNumber(value: 2_130_706_431),
+            "relayProtocol": "" as NSString,
+            "tcpType": "" as NSString,
+        ]
+        let candidate = LocalIceCandidateStatistics(id: "local-1", timestamp: 1000.0, rawValues: raw)
+        XCTAssertNotNil(candidate)
+        XCTAssertEqual(candidate?.type, .localCandidate)
+        XCTAssertEqual(candidate?.address, "192.168.1.100")
+        XCTAssertEqual(candidate?.port, 12345)
+        XCTAssertEqual(candidate?.candidateType, .host)
+    }
+
+    func testRemoteIceCandidateStatistics() {
+        let raw: [String: NSObject] = [
+            "candidateType": "srflx" as NSString,
+            "address": "203.0.113.1" as NSString,
+            "relayProtocol": "" as NSString,
+            "tcpType": "" as NSString,
+        ]
+        let candidate = RemoteIceCandidateStatistics(id: "remote-1", timestamp: 1000.0, rawValues: raw)
+        XCTAssertNotNil(candidate)
+        XCTAssertEqual(candidate?.type, .remoteCandidate)
+        XCTAssertEqual(candidate?.candidateType, .srflx)
+    }
+
+    // MARK: - IceCandidatePairStatistics
+
+    func testIceCandidatePairStatistics() {
+        let raw: [String: NSObject] = [
+            "transportId": "T01" as NSString,
+            "localCandidateId": "local-1" as NSString,
+            "remoteCandidateId": "remote-1" as NSString,
+            "state": "succeeded" as NSString,
+            "nominated": NSNumber(value: true),
+            "currentRoundTripTime": NSNumber(value: 0.035),
+            "availableOutgoingBitrate": NSNumber(value: 2_500_000.0),
+        ]
+        let pair = IceCandidatePairStatistics(id: "pair-1", timestamp: 1000.0, rawValues: raw)
+        XCTAssertNotNil(pair)
+        XCTAssertEqual(pair?.type, .candidatePair)
+        XCTAssertEqual(pair?.state, .succeeded)
+        XCTAssertEqual(pair?.nominated, true)
+        XCTAssertEqual(pair?.currentRoundTripTime, 0.035)
+    }
+
+    // MARK: - CertificateStatistics
+
+    func testCertificateStatistics() {
+        let raw: [String: NSObject] = [
+            "fingerprint": "AB:CD:EF" as NSString,
+            "fingerprintAlgorithm": "sha-256" as NSString,
+            "base64Certificate": "MIIB..." as NSString,
+        ]
+        let cert = CertificateStatistics(id: "cert-1", timestamp: 1000.0, rawValues: raw)
+        XCTAssertNotNil(cert)
+        XCTAssertEqual(cert?.type, .certificate)
+        XCTAssertEqual(cert?.fingerprint, "AB:CD:EF")
+        XCTAssertEqual(cert?.fingerprintAlgorithm, "sha-256")
+    }
+
+    // MARK: - AudioPlayoutStatistics
+
+    func testAudioPlayoutStatistics() {
+        let raw: [String: NSObject] = [
+            "kind": "audio" as NSString,
+            "totalSamplesDuration": NSNumber(value: 10.5),
+            "totalPlayoutDelay": NSNumber(value: 0.02),
+        ]
+        let playout = AudioPlayoutStatistics(id: "playout-1", timestamp: 1000.0, rawValues: raw)
+        XCTAssertNotNil(playout)
+        XCTAssertEqual(playout?.type, .mediaPlayout)
+        XCTAssertEqual(playout?.kind, "audio")
+        XCTAssertEqual(playout?.totalSamplesDuration, 10.5)
+    }
+
+    // MARK: - MediaSourceStatistics
+
+    func testMediaSourceStatistics() {
+        let raw: [String: NSObject] = [
+            "trackIdentifier": "track-123" as NSString,
+            "kind": "video" as NSString,
+        ]
+        let source = MediaSourceStatistics(id: "source-1", timestamp: 1000.0, rawValues: raw)
+        XCTAssertNotNil(source)
+        XCTAssertEqual(source?.type, .mediaSource)
+        XCTAssertEqual(source?.kind, "video")
+    }
+
+    // MARK: - VideoSourceStatistics
+
+    func testVideoSourceStatistics() {
+        let raw: [String: NSObject] = [
+            "trackIdentifier": "track-123" as NSString,
+            "kind": "video" as NSString,
+            "width": NSNumber(value: 1920),
+            "height": NSNumber(value: 1080),
+            "frames": NSNumber(value: 300),
+            "framesPerSecond": NSNumber(value: 30.0),
+        ]
+        let videoSource = VideoSourceStatistics(id: "source-1", timestamp: 1000.0, rawValues: raw)
+        XCTAssertNotNil(videoSource)
+        XCTAssertEqual(videoSource?.width, 1920)
+        XCTAssertEqual(videoSource?.height, 1080)
+        XCTAssertEqual(videoSource?.framesPerSecond, 30.0)
+    }
+
+    // MARK: - AudioSourceStatistics
+
+    func testAudioSourceStatistics() {
+        let raw: [String: NSObject] = [
+            "trackIdentifier": "track-456" as NSString,
+            "kind": "audio" as NSString,
+            "audioLevel": NSNumber(value: 0.85),
+            "totalAudioEnergy": NSNumber(value: 120.5),
+        ]
+        let audioSource = AudioSourceStatistics(id: "source-2", timestamp: 1000.0, rawValues: raw)
+        XCTAssertNotNil(audioSource)
+        XCTAssertEqual(audioSource?.audioLevel, 0.85)
+        XCTAssertEqual(audioSource?.totalAudioEnergy, 120.5)
+    }
+
+    // MARK: - InboundRtpStreamStatistics
+
+    func testInboundRtpStreamStatistics() {
+        let raw: [String: NSObject] = [
+            "ssrc": NSNumber(value: 123_456),
+            "kind": "video" as NSString,
+            "trackIdentifier": "track-1" as NSString,
+            "mid": "0" as NSString,
+            "framesDecoded": NSNumber(value: 1000),
+            "framesDropped": NSNumber(value: 5),
+            "frameWidth": NSNumber(value: 1920),
+            "frameHeight": NSNumber(value: 1080),
+            "framesPerSecond": NSNumber(value: 29.97),
+            "bytesReceived": NSNumber(value: 5_000_000),
+            "jitter": NSNumber(value: 0.003),
+        ]
+        let inbound = InboundRtpStreamStatistics(id: "inbound-1", timestamp: 1000.0, rawValues: raw, previous: nil)
+        XCTAssertNotNil(inbound)
+        XCTAssertEqual(inbound?.type, .inboundRtp)
+        XCTAssertEqual(inbound?.framesDecoded, 1000)
+        XCTAssertEqual(inbound?.frameWidth, 1920)
+        XCTAssertEqual(inbound?.framesPerSecond, 29.97)
+        XCTAssertNil(inbound?.previous)
+    }
+
+    func testInboundRtpStreamWithPrevious() {
+        let prevRaw: [String: NSObject] = [
+            "ssrc": NSNumber(value: 123_456),
+            "kind": "video" as NSString,
+            "bytesReceived": NSNumber(value: 3_000_000),
+        ]
+        let prev = InboundRtpStreamStatistics(id: "inbound-1", timestamp: 500.0, rawValues: prevRaw, previous: nil)
+
+        let raw: [String: NSObject] = [
+            "ssrc": NSNumber(value: 123_456),
+            "kind": "video" as NSString,
+            "bytesReceived": NSNumber(value: 5_000_000),
+        ]
+        let current = InboundRtpStreamStatistics(id: "inbound-1", timestamp: 1000.0, rawValues: raw, previous: prev)
+        XCTAssertNotNil(current)
+        XCTAssertNotNil(current?.previous)
+        XCTAssertEqual(current?.previous?.bytesReceived, 3_000_000)
+    }
+
+    // MARK: - OutboundRtpStreamStatistics
+
+    func testOutboundRtpStreamStatistics() {
+        let raw: [String: NSObject] = [
+            "ssrc": NSNumber(value: 654_321),
+            "kind": "video" as NSString,
+            "mid": "1" as NSString,
+            "rid": "f" as NSString,
+            "packetsSent": NSNumber(value: 500),
+            "bytesSent": NSNumber(value: 2_000_000),
+            "targetBitrate": NSNumber(value: 1_700_000.0),
+            "frameWidth": NSNumber(value: 1280),
+            "frameHeight": NSNumber(value: 720),
+            "framesPerSecond": NSNumber(value: 30.0),
+            "framesEncoded": NSNumber(value: 900),
+            "qualityLimitationReason": "none" as NSString,
+            "qualityLimitationDurations": [:] as NSDictionary,
+            "active": NSNumber(value: true),
+            "scalabilityMode": "L1T3" as NSString,
+        ]
+        let outbound = OutboundRtpStreamStatistics(id: "outbound-1", timestamp: 1000.0, rawValues: raw, previous: nil)
+        XCTAssertNotNil(outbound)
+        XCTAssertEqual(outbound?.type, .outboundRtp)
+        XCTAssertEqual(outbound?.rid, "f")
+        XCTAssertEqual(outbound?.targetBitrate, 1_700_000.0)
+        XCTAssertEqual(outbound?.qualityLimitationReason, QualityLimitationReason.none)
+        XCTAssertEqual(outbound?.active, true)
+        XCTAssertEqual(outbound?.scalabilityMode, "L1T3")
+    }
+
+    func testOutboundRtpRidIndex() {
+        let makeRaw: (String?) -> [String: NSObject] = { rid in
+            var raw: [String: NSObject] = ["kind": "video" as NSString]
+            if let rid { raw["rid"] = rid as NSString }
+            return raw
+        }
+
+        let full = OutboundRtpStreamStatistics(id: "o1", timestamp: 0, rawValues: makeRaw("f"), previous: nil)
+        XCTAssertEqual(full?.ridIndex, 2) // "f" is index 2 in ["q", "h", "f"]
+
+        let half = OutboundRtpStreamStatistics(id: "o2", timestamp: 0, rawValues: makeRaw("h"), previous: nil)
+        XCTAssertEqual(half?.ridIndex, 1)
+
+        let quarter = OutboundRtpStreamStatistics(id: "o3", timestamp: 0, rawValues: makeRaw("q"), previous: nil)
+        XCTAssertEqual(quarter?.ridIndex, 0)
+
+        let noRid = OutboundRtpStreamStatistics(id: "o4", timestamp: 0, rawValues: makeRaw(nil), previous: nil)
+        XCTAssertEqual(noRid?.ridIndex, -1)
+    }
+
+    func testSortedByRidIndex() {
+        let makeStats: (String, String?) -> OutboundRtpStreamStatistics? = { id, rid in
+            var raw: [String: NSObject] = ["kind": "video" as NSString]
+            if let rid { raw["rid"] = rid as NSString }
+            return OutboundRtpStreamStatistics(id: id, timestamp: 0, rawValues: raw, previous: nil)
+        }
+
+        let stats = [makeStats("q", "q")!, makeStats("h", "h")!, makeStats("f", "f")!]
+        let sorted = stats.sortedByRidIndex()
+
+        // sortedByRidIndex sorts descending by ridIndex
+        XCTAssertEqual(sorted[0].rid, "f")
+        XCTAssertEqual(sorted[1].rid, "h")
+        XCTAssertEqual(sorted[2].rid, "q")
+    }
+
+    // MARK: - RemoteInboundRtpStreamStatistics
+
+    func testRemoteInboundRtpStreamStatistics() {
+        let raw: [String: NSObject] = [
+            "ssrc": NSNumber(value: 111),
+            "kind": "audio" as NSString,
+            "localId": "outbound-1" as NSString,
+            "roundTripTime": NSNumber(value: 0.045),
+            "totalRoundTripTime": NSNumber(value: 1.35),
+            "fractionLost": NSNumber(value: 0.01),
+        ]
+        let remote = RemoteInboundRtpStreamStatistics(id: "remote-in-1", timestamp: 1000.0, rawValues: raw)
+        XCTAssertNotNil(remote)
+        XCTAssertEqual(remote?.type, .remoteInboundRtp)
+        XCTAssertEqual(remote?.roundTripTime, 0.045)
+        XCTAssertEqual(remote?.fractionLost, 0.01)
+    }
+
+    // MARK: - RemoteOutboundRtpStreamStatistics
+
+    func testRemoteOutboundRtpStreamStatistics() {
+        let raw: [String: NSObject] = [
+            "ssrc": NSNumber(value: 222),
+            "kind": "video" as NSString,
+            "localId": "inbound-1" as NSString,
+            "remoteTimestamp": NSNumber(value: 999.5),
+            "reportsSent": NSNumber(value: 50),
+            "roundTripTime": NSNumber(value: 0.03),
+        ]
+        let remote = RemoteOutboundRtpStreamStatistics(id: "remote-out-1", timestamp: 1000.0, rawValues: raw)
+        XCTAssertNotNil(remote)
+        XCTAssertEqual(remote?.type, .remoteOutboundRtp)
+        XCTAssertEqual(remote?.remoteTimestamp, 999.5)
+    }
+
+    // MARK: - TrackStatistics description
+
+    func testTrackStatisticsDescription() {
+        // TrackStatistics requires LKRTCStatistics which is from WebRTC, so we test description format
+        // which is public. The description is defined as a computed property.
+        // We can at least verify the StatisticsType enum and the Statistics base class.
+        let base = Statistics(id: "base-1", type: .codec, timestamp: 1000.0)
+        XCTAssertNotNil(base)
+        XCTAssertEqual(base?.id, "base-1")
+        XCTAssertEqual(base?.type, .codec)
+        XCTAssertEqual(base?.timestamp, 1000.0)
+    }
+
+    // MARK: - Dictionary readOptional / readNonOptional helpers
+
+    func testReadOptionalReturnsNilForMissingKey() {
+        let dict: [String: NSObject] = [:]
+        let intVal: Int? = dict.readOptional("missing")
+        let strVal: String? = dict.readOptional("missing")
+        let dblVal: Double? = dict.readOptional("missing")
+        XCTAssertNil(intVal)
+        XCTAssertNil(strVal)
+        XCTAssertNil(dblVal)
+    }
+
+    func testReadNonOptionalReturnsDefaultForMissingKey() {
+        let dict: [String: NSObject] = [:]
+        let str: String = dict.readNonOptional("missing")
+        XCTAssertEqual(str, "")
+
+        let dictVal: [String: NSObject] = dict.readNonOptional("missing")
+        XCTAssertTrue(dictVal.isEmpty)
+    }
+}

--- a/Tests/LiveKitTestSupport/MockWebSocket.swift
+++ b/Tests/LiveKitTestSupport/MockWebSocket.swift
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+@testable import LiveKit
+
+/// Mock WebSocket that captures sent data and tracks close state.
+/// Used to test SignalClient's send methods without a real network connection.
+///
+/// Usage:
+/// ```swift
+/// let mock = MockWebSocket()
+/// await signalClient.setWebSocket(mock)
+/// await signalClient.setConnectionState(.connected)
+/// try await signalClient.sendMuteTrack(trackSid: Track.Sid(from: "TR_1"), muted: true)
+/// XCTAssertEqual(mock.sentRequests.count, 1)
+/// XCTAssertTrue(mock.sentRequests[0].hasMute)
+/// ```
+public final class MockWebSocket: WebSocketType, @unchecked Sendable {
+    private let _state = StateSync(State())
+
+    private struct State {
+        var sentData: [Data] = []
+        var isClosed: Bool = false
+        var sendError: LiveKitError?
+    }
+
+    public init() {}
+
+    // MARK: - WebSocketType
+
+    public func send(data: Data) async throws {
+        let error = _state.read { $0.sendError }
+        if let error { throw error }
+        _state.mutate { $0.sentData.append(data) }
+    }
+
+    public func close() {
+        _state.mutate { $0.isClosed = true }
+    }
+
+    // MARK: - Test Inspection
+
+    /// All raw Data payloads sent through this socket.
+    public var sentData: [Data] {
+        _state.read { $0.sentData }
+    }
+
+    /// All sent payloads decoded as Livekit_SignalRequest.
+    public var sentRequests: [Livekit_SignalRequest] {
+        sentData.compactMap { try? Livekit_SignalRequest(serializedBytes: $0) }
+    }
+
+    /// Whether `close()` has been called.
+    public var isClosed: Bool {
+        _state.read { $0.isClosed }
+    }
+
+    /// The most recently sent request (convenience).
+    public var lastRequest: Livekit_SignalRequest? {
+        sentRequests.last
+    }
+
+    // MARK: - Test Configuration
+
+    /// Set an error to throw on the next `send` call.
+    public func setSendError(_ error: LiveKitError?) {
+        _state.mutate { $0.sendError = error }
+    }
+
+    /// Clear all recorded sent data.
+    public func reset() {
+        _state.mutate {
+            $0.sentData.removeAll()
+            $0.isClosed = false
+            $0.sendError = nil
+        }
+    }
+}

--- a/Tests/LiveKitTestSupport/RoomTestHelper.swift
+++ b/Tests/LiveKitTestSupport/RoomTestHelper.swift
@@ -31,6 +31,8 @@
 /// ```
 public final class RoomTestHelper: @unchecked Sendable {
     public let room: Room
+    /// Mock WebSocket injected into the SignalClient for capturing sent messages.
+    public let mockWebSocket: MockWebSocket
 
     public init(
         roomOptions: RoomOptions = RoomOptions(),
@@ -38,10 +40,20 @@ public final class RoomTestHelper: @unchecked Sendable {
         localSid: String = "PA_local",
         localIdentity: String = "local-user"
     ) {
+        let mock = MockWebSocket()
+        mockWebSocket = mock
         room = Room(connectOptions: connectOptions, roomOptions: roomOptions)
         room._state.mutate { $0.connectionState = .connected }
         let localInfo = TestData.participantInfo(sid: localSid, identity: localIdentity)
         room.localParticipant.set(info: localInfo, connectionState: .connected)
+    }
+
+    /// Injects the mock WebSocket and sets the SignalClient to connected state.
+    /// Call this before testing send operations.
+    public func connectSignalClient() async {
+        await room.signalClient.setWebSocket(mockWebSocket)
+        await room.signalClient.setConnectionState(.connected)
+        await room.signalClient.resumeQueues()
     }
 
     // MARK: - Participant Management

--- a/Tests/LiveKitTestSupport/RoomTestHelper.swift
+++ b/Tests/LiveKitTestSupport/RoomTestHelper.swift
@@ -107,10 +107,10 @@ public final class RoomTestHelper: @unchecked Sendable {
 
     /// Simulate a leave message from the server.
     public func simulateLeave(
-        action: Livekit_LeaveRequest.Action = .disconnect,
-        reason: Livekit_DisconnectReason = .clientInitiated
+        action: Livekit_LeaveRequest.Action? = nil,
+        reason: Livekit_DisconnectReason? = nil
     ) async {
-        await room.signalClient(room.signalClient, didReceiveLeave: action, reason: reason, regions: nil)
+        await room.signalClient(room.signalClient, didReceiveLeave: action ?? .disconnect, reason: reason ?? .clientInitiated, regions: nil)
     }
 
     /// Simulate remote mute update for a local track.

--- a/Tests/LiveKitTestSupport/RoomTestHelper.swift
+++ b/Tests/LiveKitTestSupport/RoomTestHelper.swift
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+
+/// Test helper equivalent to Android SDK's MockE2ETest infrastructure.
+/// Creates a Room in a simulated connected state and provides methods to
+/// simulate server events by calling Room's delegate methods directly,
+/// bypassing the WebSocket layer.
+///
+/// Usage:
+/// ```swift
+/// let helper = RoomTestHelper()
+/// let tracker = MyDelegateTracker()
+/// helper.room.delegates.add(delegate: tracker)
+/// await helper.simulateParticipantUpdate([...])
+/// XCTAssertEqual(helper.room.remoteParticipants.count, 1)
+/// ```
+public final class RoomTestHelper: @unchecked Sendable {
+    public let room: Room
+
+    public init(
+        roomOptions: RoomOptions = RoomOptions(),
+        connectOptions: ConnectOptions = ConnectOptions(),
+        localSid: String = "PA_local",
+        localIdentity: String = "local-user"
+    ) {
+        room = Room(connectOptions: connectOptions, roomOptions: roomOptions)
+        room._state.mutate { $0.connectionState = .connected }
+        let localInfo = TestData.participantInfo(sid: localSid, identity: localIdentity)
+        room.localParticipant.set(info: localInfo, connectionState: .connected)
+    }
+
+    // MARK: - Participant Management
+
+    @discardableResult
+    public func addRemoteParticipant(
+        sid: String = "PA_r1",
+        identity: String = "remote-1",
+        name: String = "Remote User",
+        tracks: [Livekit_TrackInfo] = []
+    ) -> RemoteParticipant {
+        let info = TestData.participantInfo(sid: sid, identity: identity, name: name, tracks: tracks)
+        let participant = RemoteParticipant(info: info, room: room, connectionState: .connected)
+        room._state.mutate {
+            $0.remoteParticipants[Participant.Identity(from: identity)] = participant
+        }
+        return participant
+    }
+
+    // MARK: - SignalClient Delegate Simulation
+
+    /// Simulate a join response from the server (via SignalClient delegate).
+    public func simulateJoinResponse(_ response: Livekit_JoinResponse = TestData.joinResponse()) async {
+        await room.signalClient(room.signalClient, didReceiveConnectResponse: .join(response))
+    }
+
+    /// Simulate room update (metadata, recording state, etc.)
+    public func simulateRoomUpdate(_ roomInfo: Livekit_Room) async {
+        await room.signalClient(room.signalClient, didUpdateRoom: roomInfo)
+    }
+
+    /// Simulate participant updates from the server.
+    public func simulateParticipantUpdate(_ participants: [Livekit_ParticipantInfo]) async {
+        await room.signalClient(room.signalClient, didUpdateParticipants: participants)
+    }
+
+    /// Simulate speaker updates (via SignalClient delegate path).
+    public func simulateSignalSpeakerUpdate(_ speakers: [Livekit_SpeakerInfo]) async {
+        await room.signalClient(room.signalClient, didUpdateSpeakers: speakers)
+    }
+
+    /// Simulate connection quality updates.
+    public func simulateConnectionQuality(_ updates: [Livekit_ConnectionQualityInfo]) async {
+        await room.signalClient(room.signalClient, didUpdateConnectionQuality: updates)
+    }
+
+    /// Simulate token refresh.
+    public func simulateTokenRefresh(_ token: String) async {
+        await room.signalClient(room.signalClient, didUpdateToken: token)
+    }
+
+    /// Simulate a leave message from the server.
+    public func simulateLeave(
+        action: Livekit_LeaveRequest.Action = .disconnect,
+        reason: Livekit_DisconnectReason = .clientInitiated
+    ) async {
+        await room.signalClient(room.signalClient, didReceiveLeave: action, reason: reason, regions: nil)
+    }
+
+    /// Simulate remote mute update for a local track.
+    public func simulateRemoteMute(trackSid: String, muted: Bool) async {
+        await room.signalClient(room.signalClient, didUpdateRemoteMute: Track.Sid(from: trackSid), muted: muted)
+    }
+
+    /// Simulate subscription permission update.
+    public func simulateSubscriptionPermission(_ update: Livekit_SubscriptionPermissionUpdate) async {
+        await room.signalClient(room.signalClient, didUpdateSubscriptionPermission: update)
+    }
+
+    /// Simulate track stream state updates.
+    public func simulateTrackStreamStates(_ states: [Livekit_StreamStateInfo]) async {
+        await room.signalClient(room.signalClient, didUpdateTrackStreamStates: states)
+    }
+
+    /// Simulate subscribed quality/codec updates.
+    public func simulateSubscribedCodecs(
+        _ codecs: [Livekit_SubscribedCodec],
+        qualities: [Livekit_SubscribedQuality],
+        trackSid: String
+    ) async {
+        await room.signalClient(room.signalClient, didUpdateSubscribedCodecs: codecs, qualities: qualities, forTrackSid: trackSid)
+    }
+
+    /// Simulate room moved response.
+    public func simulateRoomMoved(_ response: Livekit_RoomMovedResponse) async {
+        await room.signalClient(room.signalClient, didReceiveRoomMoved: response)
+    }
+
+    /// Simulate track subscribed notification.
+    public func simulateTrackSubscribed(trackSid: String) async {
+        await room.signalClient(room.signalClient, didSubscribeTrack: Track.Sid(from: trackSid))
+    }
+
+    // MARK: - Engine Delegate Simulation (data channel path)
+
+    /// Simulate a state transition via the engine delegate.
+    public func simulateStateTransition(from oldState: Room.State, to newState: Room.State) {
+        room.engine(room, didMutateState: newState, oldState: oldState)
+    }
+
+    /// Simulate speaker updates (via data channel / engine delegate path).
+    public func simulateEngineSpeakerUpdate(_ speakers: [Livekit_SpeakerInfo]) {
+        room.engine(room, didUpdateSpeakers: speakers)
+    }
+
+    /// Simulate receiving a data packet.
+    public func simulateUserPacket(_ packet: Livekit_UserPacket, encryption: EncryptionType = .none) {
+        room.engine(room, didReceiveUserPacket: packet, encryptionType: encryption)
+    }
+
+    /// Simulate receiving a transcription.
+    public func simulateTranscription(_ transcription: Livekit_Transcription) {
+        room.room(didReceiveTranscriptionPacket: transcription)
+    }
+
+    /// Simulate RPC response.
+    public func simulateRpcResponse(_ response: Livekit_RpcResponse) {
+        room.room(didReceiveRpcResponse: response)
+    }
+
+    /// Simulate RPC ack.
+    public func simulateRpcAck(_ ack: Livekit_RpcAck) {
+        room.room(didReceiveRpcAck: ack)
+    }
+
+    /// Simulate RPC request.
+    public func simulateRpcRequest(_ request: Livekit_RpcRequest, from identity: String) {
+        room.room(didReceiveRpcRequest: request, from: identity)
+    }
+
+    // MARK: - SignalClient._process Pipeline
+
+    /// Inject a signal response through SignalClient's _process pipeline.
+    /// This tests the full dispatch chain: signalResponse -> SignalClient._process -> Room delegate.
+    /// Requires SignalClient to be in connected state.
+    public func processSignalResponse(_ response: Livekit_SignalResponse) async {
+        // Ensure SignalClient is in connected state (required by _process guard)
+        await room.signalClient.setConnectionState(.connected)
+        await room.signalClient._process(signalResponse: response)
+    }
+}

--- a/Tests/LiveKitTestSupport/TestData.swift
+++ b/Tests/LiveKitTestSupport/TestData.swift
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+
+/// Pre-built protobuf fixtures for unit testing SignalClient and Room delegate handling.
+public enum TestData {
+    // MARK: - Participant Info
+
+    public static func participantInfo(
+        sid: String = "PA_test123",
+        identity: String = "test-user",
+        name: String = "Test User",
+        state: Livekit_ParticipantInfo.State = .active,
+        metadata: String = "",
+        attributes: [String: String] = [:],
+        kind: Livekit_ParticipantInfo.Kind = .standard,
+        joinedAt: Int64 = 1_700_000_000,
+        tracks: [Livekit_TrackInfo] = [],
+        canPublish: Bool = true,
+        canSubscribe: Bool = true,
+        canPublishData: Bool = true
+    ) -> Livekit_ParticipantInfo {
+        Livekit_ParticipantInfo.with {
+            $0.sid = sid
+            $0.identity = identity
+            $0.name = name
+            $0.state = state
+            $0.metadata = metadata
+            $0.attributes = attributes
+            $0.kind = kind
+            $0.joinedAt = joinedAt
+            $0.tracks = tracks
+            $0.permission = Livekit_ParticipantPermission.with {
+                $0.canPublish = canPublish
+                $0.canSubscribe = canSubscribe
+                $0.canPublishData = canPublishData
+            }
+        }
+    }
+
+    // MARK: - Room Info
+
+    public static func roomInfo(
+        sid: String = "RM_test456",
+        name: String = "test-room",
+        metadata: String = "",
+        activeRecording: Bool = false,
+        maxParticipants: UInt32 = 100,
+        numParticipants: UInt32 = 2,
+        numPublishers: UInt32 = 1,
+        creationTime: Int64 = 1_700_000_000
+    ) -> Livekit_Room {
+        Livekit_Room.with {
+            $0.sid = sid
+            $0.name = name
+            $0.metadata = metadata
+            $0.activeRecording = activeRecording
+            $0.maxParticipants = maxParticipants
+            $0.numParticipants = numParticipants
+            $0.numPublishers = numPublishers
+            $0.creationTime = creationTime
+        }
+    }
+
+    // MARK: - Server Info
+
+    public static func serverInfo(
+        version: String = "1.7.0",
+        region: String = "us-east-1",
+        nodeID: String = "node-abc123"
+    ) -> Livekit_ServerInfo {
+        Livekit_ServerInfo.with {
+            $0.version = version
+            $0.region = region
+            $0.nodeID = nodeID
+        }
+    }
+
+    // MARK: - Join Response
+
+    public static func joinResponse(
+        room: Livekit_Room? = nil,
+        participant: Livekit_ParticipantInfo? = nil,
+        otherParticipants: [Livekit_ParticipantInfo] = [],
+        serverInfo: Livekit_ServerInfo? = nil,
+        pingInterval: Int32 = 10,
+        pingTimeout: Int32 = 20
+    ) -> Livekit_JoinResponse {
+        Livekit_JoinResponse.with {
+            $0.room = room ?? roomInfo()
+            $0.participant = participant ?? participantInfo(sid: "PA_local", identity: "local-user", name: "Local User")
+            $0.otherParticipants = otherParticipants
+            $0.serverInfo = serverInfo ?? self.serverInfo()
+            $0.pingInterval = pingInterval
+            $0.pingTimeout = pingTimeout
+        }
+    }
+
+    // MARK: - Connect Response
+
+    public static func connectResponseJoin(
+        room: Livekit_Room? = nil,
+        participant: Livekit_ParticipantInfo? = nil,
+        otherParticipants: [Livekit_ParticipantInfo] = [],
+        serverInfo: Livekit_ServerInfo? = nil
+    ) -> SignalClient.ConnectResponse {
+        .join(joinResponse(
+            room: room,
+            participant: participant,
+            otherParticipants: otherParticipants,
+            serverInfo: serverInfo
+        ))
+    }
+
+    // MARK: - Speaker Info
+
+    public static func speakerInfo(
+        sid: String,
+        level: Float = 0.8,
+        active: Bool = true
+    ) -> Livekit_SpeakerInfo {
+        Livekit_SpeakerInfo.with {
+            $0.sid = sid
+            $0.level = level
+            $0.active = active
+        }
+    }
+
+    // MARK: - Connection Quality
+
+    public static func connectionQualityInfo(
+        participantSid: String,
+        quality: Livekit_ConnectionQuality = .good
+    ) -> Livekit_ConnectionQualityInfo {
+        Livekit_ConnectionQualityInfo.with {
+            $0.participantSid = participantSid
+            $0.quality = quality
+        }
+    }
+
+    // MARK: - Track Info
+
+    public static func trackInfo(
+        sid: String = "TR_test789",
+        name: String = "microphone",
+        type: Livekit_TrackType = .audio,
+        source: Livekit_TrackSource = .microphone,
+        muted: Bool = false
+    ) -> Livekit_TrackInfo {
+        Livekit_TrackInfo.with {
+            $0.sid = sid
+            $0.name = name
+            $0.type = type
+            $0.source = source
+            $0.muted = muted
+        }
+    }
+}

--- a/Tests/LiveKitTestSupport/TestData.swift
+++ b/Tests/LiveKitTestSupport/TestData.swift
@@ -230,4 +230,159 @@ public enum TestData {
         state.disconnectError = disconnectError
         return state
     }
+
+    // MARK: - Subscription Permission Update
+
+    public static func subscriptionPermissionUpdate(
+        participantSid: String = "PA_r1",
+        trackSid: String = "TR_v1",
+        allowed: Bool = true
+    ) -> Livekit_SubscriptionPermissionUpdate {
+        Livekit_SubscriptionPermissionUpdate.with {
+            $0.participantSid = participantSid
+            $0.trackSid = trackSid
+            $0.allowed = allowed
+        }
+    }
+
+    // MARK: - Stream State Info
+
+    public static func streamStateInfo(
+        participantSid: String = "PA_r1",
+        trackSid: String = "TR_v1",
+        state: Livekit_StreamState = .active
+    ) -> Livekit_StreamStateInfo {
+        Livekit_StreamStateInfo.with {
+            $0.participantSid = participantSid
+            $0.trackSid = trackSid
+            $0.state = state
+        }
+    }
+
+    // MARK: - Room Moved Response
+
+    public static func roomMovedResponse(
+        room: Livekit_Room? = nil,
+        token: String = "new-token",
+        participant: Livekit_ParticipantInfo? = nil,
+        otherParticipants: [Livekit_ParticipantInfo] = []
+    ) -> Livekit_RoomMovedResponse {
+        Livekit_RoomMovedResponse.with {
+            if let room { $0.room = room }
+            $0.token = token
+            if let participant { $0.participant = participant }
+            $0.otherParticipants = otherParticipants
+        }
+    }
+
+    // MARK: - Signal Response Builders
+
+    /// Build a Livekit_SignalResponse wrapping a join response.
+    public static func signalResponse(join: Livekit_JoinResponse) -> Livekit_SignalResponse {
+        Livekit_SignalResponse.with { $0.join = join }
+    }
+
+    /// Build a Livekit_SignalResponse wrapping a room update.
+    public static func signalResponse(roomUpdate: Livekit_Room) -> Livekit_SignalResponse {
+        Livekit_SignalResponse.with {
+            $0.roomUpdate = Livekit_RoomUpdate.with { $0.room = roomUpdate }
+        }
+    }
+
+    /// Build a Livekit_SignalResponse wrapping participant updates.
+    public static func signalResponse(participantUpdate participants: [Livekit_ParticipantInfo]) -> Livekit_SignalResponse {
+        Livekit_SignalResponse.with {
+            $0.update = Livekit_ParticipantUpdate.with { $0.participants = participants }
+        }
+    }
+
+    /// Build a Livekit_SignalResponse wrapping speaker updates.
+    public static func signalResponse(speakersChanged speakers: [Livekit_SpeakerInfo]) -> Livekit_SignalResponse {
+        Livekit_SignalResponse.with {
+            $0.speakersChanged = Livekit_SpeakersChanged.with { $0.speakers = speakers }
+        }
+    }
+
+    /// Build a Livekit_SignalResponse wrapping connection quality updates.
+    public static func signalResponse(connectionQuality updates: [Livekit_ConnectionQualityInfo]) -> Livekit_SignalResponse {
+        Livekit_SignalResponse.with {
+            $0.connectionQuality = Livekit_ConnectionQualityUpdate.with { $0.updates = updates }
+        }
+    }
+
+    /// Build a Livekit_SignalResponse wrapping a leave request.
+    public static func signalResponse(
+        leave action: Livekit_LeaveRequest.Action,
+        reason: Livekit_DisconnectReason = .clientInitiated
+    ) -> Livekit_SignalResponse {
+        Livekit_SignalResponse.with {
+            $0.leave = Livekit_LeaveRequest.with {
+                $0.action = action
+                $0.reason = reason
+            }
+        }
+    }
+
+    /// Build a Livekit_SignalResponse wrapping a token refresh.
+    public static func signalResponse(refreshToken token: String) -> Livekit_SignalResponse {
+        Livekit_SignalResponse.with { $0.refreshToken = token }
+    }
+
+    /// Build a Livekit_SignalResponse wrapping a mute update.
+    public static func signalResponse(mute trackSid: String, muted: Bool) -> Livekit_SignalResponse {
+        Livekit_SignalResponse.with {
+            $0.mute = Livekit_MuteTrackRequest.with {
+                $0.sid = trackSid
+                $0.muted = muted
+            }
+        }
+    }
+
+    /// Build a Livekit_SignalResponse wrapping stream state updates.
+    public static func signalResponse(streamStates: [Livekit_StreamStateInfo]) -> Livekit_SignalResponse {
+        Livekit_SignalResponse.with {
+            $0.streamStateUpdate = Livekit_StreamStateUpdate.with { $0.streamStates = streamStates }
+        }
+    }
+
+    /// Build a Livekit_SignalResponse wrapping a subscription permission update.
+    public static func signalResponse(subscriptionPermission: Livekit_SubscriptionPermissionUpdate) -> Livekit_SignalResponse {
+        Livekit_SignalResponse.with { $0.subscriptionPermissionUpdate = subscriptionPermission }
+    }
+
+    /// Build a Livekit_SignalResponse wrapping a track published response.
+    public static func signalResponse(trackPublished cid: String, track: Livekit_TrackInfo) -> Livekit_SignalResponse {
+        Livekit_SignalResponse.with {
+            $0.trackPublished = Livekit_TrackPublishedResponse.with {
+                $0.cid = cid
+                $0.track = track
+            }
+        }
+    }
+
+    /// Build a Livekit_SignalResponse wrapping a track unpublished response.
+    public static func signalResponse(trackUnpublished trackSid: String) -> Livekit_SignalResponse {
+        Livekit_SignalResponse.with {
+            $0.trackUnpublished = Livekit_TrackUnpublishedResponse.with {
+                $0.trackSid = trackSid
+            }
+        }
+    }
+
+    /// Build a Livekit_SignalResponse wrapping a room moved response.
+    public static func signalResponse(roomMoved: Livekit_RoomMovedResponse) -> Livekit_SignalResponse {
+        Livekit_SignalResponse.with { $0.roomMoved = roomMoved }
+    }
+
+    /// Build a Livekit_SignalResponse wrapping a pong.
+    public static func signalResponse(pong timestamp: Int64) -> Livekit_SignalResponse {
+        Livekit_SignalResponse.with { $0.pong = timestamp }
+    }
+
+    /// Build a Livekit_SignalResponse wrapping a track subscribed event.
+    public static func signalResponse(trackSubscribed trackSid: String) -> Livekit_SignalResponse {
+        Livekit_SignalResponse.with {
+            $0.trackSubscribed = Livekit_TrackSubscribed.with { $0.trackSid = trackSid }
+        }
+    }
 }

--- a/Tests/LiveKitTestSupport/TestData.swift
+++ b/Tests/LiveKitTestSupport/TestData.swift
@@ -16,7 +16,8 @@
 
 @testable import LiveKit
 
-/// Pre-built protobuf fixtures for unit testing SignalClient and Room delegate handling.
+// Pre-built protobuf fixtures for unit testing SignalClient and Room delegate handling.
+// swiftlint:disable:next type_body_length
 public enum TestData {
     // MARK: - Participant Info
 
@@ -24,10 +25,10 @@ public enum TestData {
         sid: String = "PA_test123",
         identity: String = "test-user",
         name: String = "Test User",
-        state: Livekit_ParticipantInfo.State = .active,
+        state: Livekit_ParticipantInfo.State? = nil,
         metadata: String = "",
         attributes: [String: String] = [:],
-        kind: Livekit_ParticipantInfo.Kind = .standard,
+        kind: Livekit_ParticipantInfo.Kind? = nil,
         joinedAt: Int64 = 1_700_000_000,
         tracks: [Livekit_TrackInfo] = [],
         canPublish: Bool = true,
@@ -38,10 +39,10 @@ public enum TestData {
             $0.sid = sid
             $0.identity = identity
             $0.name = name
-            $0.state = state
+            $0.state = state ?? .active
             $0.metadata = metadata
             $0.attributes = attributes
-            $0.kind = kind
+            $0.kind = kind ?? .standard
             $0.joinedAt = joinedAt
             $0.tracks = tracks
             $0.permission = Livekit_ParticipantPermission.with {
@@ -144,11 +145,11 @@ public enum TestData {
 
     public static func connectionQualityInfo(
         participantSid: String,
-        quality: Livekit_ConnectionQuality = .good
+        quality: Livekit_ConnectionQuality? = nil
     ) -> Livekit_ConnectionQualityInfo {
         Livekit_ConnectionQualityInfo.with {
             $0.participantSid = participantSid
-            $0.quality = quality
+            $0.quality = quality ?? .good
         }
     }
 
@@ -157,15 +158,15 @@ public enum TestData {
     public static func trackInfo(
         sid: String = "TR_test789",
         name: String = "microphone",
-        type: Livekit_TrackType = .audio,
-        source: Livekit_TrackSource = .microphone,
+        type: Livekit_TrackType? = nil,
+        source: Livekit_TrackSource? = nil,
         muted: Bool = false
     ) -> Livekit_TrackInfo {
         Livekit_TrackInfo.with {
             $0.sid = sid
             $0.name = name
-            $0.type = type
-            $0.source = source
+            $0.type = type ?? .audio
+            $0.source = source ?? .microphone
             $0.muted = muted
         }
     }
@@ -250,12 +251,12 @@ public enum TestData {
     public static func streamStateInfo(
         participantSid: String = "PA_r1",
         trackSid: String = "TR_v1",
-        state: Livekit_StreamState = .active
+        state: Livekit_StreamState? = nil
     ) -> Livekit_StreamStateInfo {
         Livekit_StreamStateInfo.with {
             $0.participantSid = participantSid
             $0.trackSid = trackSid
-            $0.state = state
+            $0.state = state ?? .active
         }
     }
 
@@ -313,12 +314,12 @@ public enum TestData {
     /// Build a Livekit_SignalResponse wrapping a leave request.
     public static func signalResponse(
         leave action: Livekit_LeaveRequest.Action,
-        reason: Livekit_DisconnectReason = .clientInitiated
+        reason: Livekit_DisconnectReason? = nil
     ) -> Livekit_SignalResponse {
         Livekit_SignalResponse.with {
             $0.leave = Livekit_LeaveRequest.with {
                 $0.action = action
-                $0.reason = reason
+                $0.reason = reason ?? .clientInitiated
             }
         }
     }

--- a/Tests/LiveKitTestSupport/TestData.swift
+++ b/Tests/LiveKitTestSupport/TestData.swift
@@ -169,4 +169,65 @@ public enum TestData {
             $0.muted = muted
         }
     }
+
+    // MARK: - User Packet
+
+    public static func userPacket(
+        participantIdentity: String = "remote-user",
+        payload: Data = Data("hello".utf8),
+        topic: String = "chat"
+    ) -> Livekit_UserPacket {
+        Livekit_UserPacket.with {
+            $0.participantIdentity = participantIdentity
+            $0.payload = payload
+            $0.topic = topic
+        }
+    }
+
+    // MARK: - Transcription
+
+    public static func transcriptionSegment(
+        id: String = "seg-1",
+        text: String = "Hello world",
+        language: String = "en",
+        startTime: UInt64 = 0,
+        endTime: UInt64 = 1000,
+        isFinal: Bool = false
+    ) -> Livekit_TranscriptionSegment {
+        Livekit_TranscriptionSegment.with {
+            $0.id = id
+            $0.text = text
+            $0.language = language
+            $0.startTime = startTime
+            $0.endTime = endTime
+            $0.final = isFinal
+        }
+    }
+
+    public static func transcription(
+        participantIdentity: String = "remote-user",
+        trackID: String = "TR_audio1",
+        segments: [Livekit_TranscriptionSegment] = []
+    ) -> Livekit_Transcription {
+        Livekit_Transcription.with {
+            $0.transcribedParticipantIdentity = participantIdentity
+            $0.trackID = trackID
+            $0.segments = segments
+        }
+    }
+
+    // MARK: - Room State Helpers
+
+    /// Creates a Room.State for state machine testing.
+    public static func roomState(
+        connectionState: ConnectionState = .disconnected,
+        isReconnectingWithMode: ReconnectMode? = nil,
+        disconnectError: LiveKitError? = nil
+    ) -> Room.State {
+        var state = Room.State(connectOptions: ConnectOptions(), roomOptions: RoomOptions())
+        state.connectionState = connectionState
+        state.isReconnectingWithMode = isReconnectingWithMode
+        state.disconnectError = disconnectError
+        return state
+    }
 }


### PR DESCRIPTION
Mostly to capture current `Room`/`SignalClient` behavior and make regression tracking easier.