### PR TITLE
Fix statistics crash

### DIFF
--- a/.changes/stats-crash
+++ b/.changes/stats-crash
@@ -1,0 +1,1 @@
+patch type="fixed" "Crash during PeerConnection teardown caused by stats timer race"

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -499,6 +499,9 @@ extension Room {
         publisherTransportConnectedCompleter.reset()
 
         await signalClient.cleanUp(withError: disconnectError)
+        // Cancel all track stats timers before closing transports to prevent
+        // stats collection from accessing destroyed WebRTC channels.
+        cancelTimers()
         await cleanUpRTC()
         await cleanUpParticipants(isFullReconnect: isFullReconnect)
 
@@ -527,6 +530,14 @@ extension Room {
                 reconnectTask: $0.reconnectTask,
                 disconnectError: LiveKitError.from(error: disconnectError)
             )
+        }
+    }
+
+    private func cancelTimers() {
+        for (_, participant) in allParticipants {
+            for (_, publication) in participant._state.trackPublications {
+                publication.track?.cancelStatisticsTimer()
+            }
         }
     }
 }

--- a/Sources/LiveKit/Track/Track.swift
+++ b/Sources/LiveKit/Track/Track.swift
@@ -203,6 +203,12 @@ public class Track: NSObject, @unchecked Sendable, Loggable {
         await _resumeOrSuspendStatisticsTimer()
     }
 
+    /// Cancel the statistics timer without changing any state.
+    /// The timer will restart when the track is re-attached to a transport.
+    func cancelStatisticsTimer() {
+        _statisticsTimer.cancel()
+    }
+
     func set(trackState: TrackState) {
         _state.mutate { $0.trackState = trackState }
     }


### PR DESCRIPTION
Resolves #929

Trying to re-symbolicate this crash, hypothesis:

```
 Room.cleanUp() (Room.swift:488) calls:
 1. signalClient.cleanUp()
 2. cleanUpRTC() → transport.close() → PeerConnection::Close() → channels destroyed
 3. cleanUpParticipants() → participant/track cleanup → _statisticsTimer.cancel() ← TOO LATE
```

Symbols:

```
 ┌───────┬─────────────────────────────────┬─────────────────────────────────────────────┐
 │ Frame │           Source file           │                  Function                   │
 ├───────┼─────────────────────────────────┼─────────────────────────────────────────────┤
 │ 0     │ struct_parameters_parser.cc:115 │ logging/assertion — CRASH                   │
 ├───────┼─────────────────────────────────┼─────────────────────────────────────────────┤
 │ 1     │ field_trial_parser.cc           │ __tree_node_destructor (map cleanup)        │
 ├───────┼─────────────────────────────────┼─────────────────────────────────────────────┤
 │ 2     │ field_trial_parser.cc           │ ParseOptionalParameter<double>              │
 ├───────┼─────────────────────────────────┼─────────────────────────────────────────────┤
 │ 3     │ field_trial_parser.cc           │ AbstractFieldTrialEnum constructor          │
 ├───────┼─────────────────────────────────┼─────────────────────────────────────────────┤
 │ 4     │ trendline_estimator.cc          │ split_buffer<PacketTiming*>::clear()        │
 ├───────┼─────────────────────────────────┼─────────────────────────────────────────────┤
 │ 5     │ webrtc_video_engine.cc          │ GetPerLayerVideoSenderInfos(bool)           │
 ├───────┼─────────────────────────────────┼─────────────────────────────────────────────┤
 │ 6-9   │ legacy_stats_types.cc           │ StatsReport list/map iteration              │
 ├───────┼─────────────────────────────────┼─────────────────────────────────────────────┤
 │ 10-12 │ thread.cc                       │ Thread::Dispatch → ProcessMessages → PreRun │
 └───────┴─────────────────────────────────┴─────────────────────────────────────────────┘
```

May be fixed by m144 as well (smaller race window)