### PR TITLE
Sound API 2

### DIFF
--- a/.changes/sound-api-2
+++ b/.changes/sound-api-2
@@ -1,1 +1,1 @@
-minor type="added" "SoundPlayer API for local playback and best-effort remote injection"
+minor type="added" "SoundPlayer API for prepared audio clips with local playback and best-effort remote playback"

--- a/.changes/sound-api-2
+++ b/.changes/sound-api-2
@@ -1,0 +1,1 @@
+minor type="added" "SoundPlayer API for local playback and best-effort remote injection"

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -116,8 +116,18 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
     /// Use this to keep the audio session active from external components
     /// (e.g., ``SoundPlayer``) that need playout or recording independently
     /// of the WebRTC engine lifecycle.
-    public func set(requirement: SessionRequirement, for id: UUID) {
-        _state.mutate { $0.sessionRequirements[id] = requirement }
+    ///
+    /// - Throws: ``LiveKitError`` if the audio session fails to configure or activate.
+    public func set(requirement: SessionRequirement, for id: UUID) throws {
+        try _state.mutate {
+            let oldState = $0
+            $0.sessionRequirements[id] = requirement
+            let result = configureIfNeeded(oldState: oldState, newState: $0)
+            if result != 0 {
+                $0 = oldState
+                throw LiveKitError(.audioSession, message: "Failed to configure audio session")
+            }
+        }
     }
 
     // MARK: - Audio Session Configuration

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -210,16 +210,11 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
 
     public func engineWillEnable(_ engine: AVAudioEngine, isPlayoutEnabled: Bool, isRecordingEnabled: Bool) -> Int {
         let requirement = SessionRequirement(isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled)
-        let result: Int = _state.mutate {
-            let oldState = $0
-            $0.sessionRequirements[sessionRequirementId] = requirement
-            let result = configureIfNeeded(oldState: oldState, newState: $0)
-            if result != 0 {
-                $0 = oldState
-            }
-            return result
+        do {
+            try set(requirement: requirement, for: sessionRequirementId)
+        } catch {
+            return kAudioEngineErrorFailedToConfigureAudioSession
         }
-        guard result == 0 else { return result }
         return _state.next?.engineWillEnable(engine, isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled) ?? 0
     }
 
@@ -227,16 +222,11 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         let nextResult = _state.next?.engineDidDisable(engine, isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled) ?? 0
 
         let requirement = SessionRequirement(isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled)
-        let result: Int = _state.mutate {
-            let oldState = $0
-            $0.sessionRequirements[sessionRequirementId] = requirement
-            let result = configureIfNeeded(oldState: oldState, newState: $0)
-            if result != 0 {
-                $0 = oldState
-            }
-            return result
+        do {
+            try set(requirement: requirement, for: sessionRequirementId)
+        } catch {
+            return kAudioEngineErrorFailedToConfigureAudioSession
         }
-        guard result == 0 else { return result }
         return nextResult
     }
 }

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -87,7 +87,11 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         _state.onDidMutate = { [weak self] new, old in
             guard let self,
                   new.isSpeakerOutputPreferred != old.isSpeakerOutputPreferred else { return }
-            _ = configureIfNeeded(oldState: old, newState: new)
+            do {
+                try configureIfNeeded(oldState: old, newState: new)
+            } catch {
+                log("Failed to configure audio session after speaker preference change: \(error)", .error)
+            }
         }
     }
 
@@ -128,8 +132,9 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
             let oldState = $0
             block(&$0.sessionRequirements)
             guard $0.sessionRequirements != oldState.sessionRequirements else { return }
-            let result = configureIfNeeded(oldState: oldState, newState: $0)
-            if result != 0 {
+            do {
+                try configureIfNeeded(oldState: oldState, newState: $0)
+            } catch {
                 $0 = oldState
                 throw LiveKitError(.audioSession, message: "Failed to configure audio session")
             }
@@ -138,8 +143,8 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
 
     // MARK: - Audio Session Configuration
 
-    private func configureIfNeeded(oldState: State, newState: State) -> Int {
-        guard newState.isAutomaticConfigurationEnabled else { return 0 }
+    private func configureIfNeeded(oldState: State, newState: State) throws {
+        guard newState.isAutomaticConfigurationEnabled else { return }
 
         // Deprecated: `customConfigureAudioSessionFunc` overrides the default configuration.
         // This path does not support error propagation since the legacy func returns Void.
@@ -148,15 +153,10 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
             let oldLegacy = AudioManager.State(localTracksCount: oldState.isRecordingEnabled ? 1 : 0, remoteTracksCount: oldState.isPlayoutEnabled ? 1 : 0)
             let newLegacy = AudioManager.State(localTracksCount: newState.isRecordingEnabled ? 1 : 0, remoteTracksCount: newState.isPlayoutEnabled ? 1 : 0)
             legacyConfigFunc(newLegacy, oldLegacy)
-            return 0
+            return
         }
 
-        do {
-            try configureAudioSession(oldState: oldState, newState: newState)
-            return 0
-        } catch {
-            return kAudioEngineErrorFailedToConfigureAudioSession
-        }
+        try configureAudioSession(oldState: oldState, newState: newState)
     }
 
     @Sendable private func configureAudioSession(oldState: State, newState: State) throws {

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -69,7 +69,7 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
     /// Multiple components (e.g., WebRTC engine, SoundPlayer) can independently
     /// register their requirements. The audio session stays active as long as
     /// any component requires playout or recording.
-    public struct SessionRequirement: Sendable {
+    public struct SessionRequirement: Sendable, Equatable {
         public static let none = Self(isPlayoutEnabled: false, isRecordingEnabled: false)
         public static let playbackOnly = Self(isPlayoutEnabled: true, isRecordingEnabled: false)
         public static let recordingOnly = Self(isPlayoutEnabled: false, isRecordingEnabled: true)
@@ -117,11 +117,33 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
     /// (e.g., ``SoundPlayer``) that need playout or recording independently
     /// of the WebRTC engine lifecycle.
     ///
+    /// Setting ``SessionRequirement/none`` removes the requirement.
+    ///
     /// - Throws: ``LiveKitError`` if the audio session fails to configure or activate.
     public func set(requirement: SessionRequirement, for id: UUID) throws {
+        try updateRequirements {
+            if requirement == .none {
+                $0.removeValue(forKey: id)
+            } else {
+                $0[id] = requirement
+            }
+        }
+    }
+
+    /// Removes a previously registered audio session requirement.
+    ///
+    /// - Throws: ``LiveKitError`` if removing the requirement fails to reconfigure the audio session.
+    public func removeRequirement(for id: UUID) throws {
+        try updateRequirements {
+            $0.removeValue(forKey: id)
+        }
+    }
+
+    private func updateRequirements(_ block: (inout [UUID: SessionRequirement]) -> Void) throws {
         try _state.mutate {
             let oldState = $0
-            $0.sessionRequirements[id] = requirement
+            block(&$0.sessionRequirements)
+            guard $0.sessionRequirements != oldState.sessionRequirements else { return }
             let result = configureIfNeeded(oldState: oldState, newState: $0)
             if result != 0 {
                 $0 = oldState

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -64,17 +64,39 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         set { _state.mutate { $0.isSpeakerOutputPreferred = newValue } }
     }
 
-    struct State: Sendable {
+    /// Represents an audio session requirement from a specific component.
+    ///
+    /// Multiple components (e.g., WebRTC engine, SoundPlayer) can independently
+    /// register their requirements. The audio session stays active as long as
+    /// any component requires playout or recording.
+    public struct SessionRequirement: Sendable {
+        public static let none = Self(isPlayoutEnabled: false, isRecordingEnabled: false)
+        public static let playbackOnly = Self(isPlayoutEnabled: true, isRecordingEnabled: false)
+        public static let recordingOnly = Self(isPlayoutEnabled: false, isRecordingEnabled: true)
+        public static let playbackAndRecording = Self(isPlayoutEnabled: true, isRecordingEnabled: true)
+
+        public let isPlayoutEnabled: Bool
+        public let isRecordingEnabled: Bool
+
+        public init(isPlayoutEnabled: Bool = false, isRecordingEnabled: Bool = false) {
+            self.isPlayoutEnabled = isPlayoutEnabled
+            self.isRecordingEnabled = isRecordingEnabled
+        }
+    }
+
+    struct State {
         var next: (any AudioEngineObserver)?
 
         var isAutomaticConfigurationEnabled: Bool = true
         var isAutomaticDeactivationEnabled: Bool = true
-        var isPlayoutEnabled: Bool = false
-        var isRecordingEnabled: Bool = false
         var isSpeakerOutputPreferred: Bool = true
+
+        var sessionRequirements: [UUID: SessionRequirement] = [:]
     }
 
     let _state = StateSync(State())
+
+    private let sessionRequirementId = UUID()
 
     public var next: (any AudioEngineObserver)? {
         get { _state.next }
@@ -100,8 +122,19 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         }
     }
 
+    /// Register or update an audio session requirement for the given identifier.
+    ///
+    /// Use this to keep the audio session active from external components
+    /// (e.g., ``SoundPlayer``) that need playout or recording independently
+    /// of the WebRTC engine lifecycle.
+    public func set(requirement: SessionRequirement, for id: UUID) {
+        _state.mutate { $0.sessionRequirements[id] = requirement }
+    }
+
     @Sendable func configure(oldState: State, newState: State) {
         let session = AVAudioSession.sharedInstance()
+
+        log("configure isRecordingEnabled: \(newState.isRecordingEnabled), isPlayoutEnabled: \(newState.isPlayoutEnabled)")
 
         if (!newState.isPlayoutEnabled && !newState.isRecordingEnabled) && (oldState.isPlayoutEnabled || oldState.isRecordingEnabled) {
             if newState.isAutomaticDeactivationEnabled {
@@ -149,10 +182,8 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
     }
 
     public func engineWillEnable(_ engine: AVAudioEngine, isPlayoutEnabled: Bool, isRecordingEnabled: Bool) -> Int {
-        _state.mutate {
-            $0.isPlayoutEnabled = isPlayoutEnabled
-            $0.isRecordingEnabled = isRecordingEnabled
-        }
+        let requirement = SessionRequirement(isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled)
+        set(requirement: requirement, for: sessionRequirementId)
 
         // Call next last
         return _state.next?.engineWillEnable(engine, isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled) ?? 0
@@ -162,13 +193,16 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         // Call next first
         let nextResult = _state.next?.engineDidDisable(engine, isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled)
 
-        _state.mutate {
-            $0.isPlayoutEnabled = isPlayoutEnabled
-            $0.isRecordingEnabled = isRecordingEnabled
-        }
+        let requirement = SessionRequirement(isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled)
+        set(requirement: requirement, for: sessionRequirementId)
 
         return nextResult ?? 0
     }
+}
+
+extension AudioSessionEngineObserver.State {
+    var isPlayoutEnabled: Bool { sessionRequirements.values.contains(where: \.isPlayoutEnabled) }
+    var isRecordingEnabled: Bool { sessionRequirements.values.contains(where: \.isRecordingEnabled) }
 }
 
 #endif

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -84,6 +84,27 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         }
     }
 
+    /// Opaque handle for an externally acquired audio session requirement.
+    ///
+    /// Call ``release()`` when the requirement is no longer needed.
+    public final class SessionRequirementHandle: @unchecked Sendable {
+        fileprivate let id: UUID
+        private weak var observer: AudioSessionEngineObserver?
+
+        fileprivate init(id: UUID, observer: AudioSessionEngineObserver) {
+            self.id = id
+            self.observer = observer
+        }
+
+        /// Releases the associated audio session requirement.
+        ///
+        /// Releasing the same handle multiple times is a no-op.
+        public func release() throws {
+            guard let observer else { return }
+            try observer.removeRequirement(for: id)
+        }
+    }
+
     struct State {
         var next: (any AudioEngineObserver)?
 
@@ -111,16 +132,20 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         }
     }
 
-    /// Register or update an audio session requirement for the given identifier.
+    /// Acquires an audio session requirement handle for external ownership.
     ///
     /// Use this to keep the audio session active from external components
     /// (e.g., ``SoundPlayer``) that need playout or recording independently
     /// of the WebRTC engine lifecycle.
     ///
-    /// Setting ``SessionRequirement/none`` removes the requirement.
-    ///
     /// - Throws: ``LiveKitError`` if the audio session fails to configure or activate.
-    public func set(requirement: SessionRequirement, for id: UUID) throws {
+    public func acquire(requirement: SessionRequirement) throws -> SessionRequirementHandle {
+        let id = UUID()
+        try set(requirement: requirement, for: id)
+        return SessionRequirementHandle(id: id, observer: self)
+    }
+
+    private func set(requirement: SessionRequirement, for id: UUID) throws {
         try updateRequirements {
             if requirement == .none {
                 $0.removeValue(forKey: id)
@@ -130,10 +155,7 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         }
     }
 
-    /// Removes a previously registered audio session requirement.
-    ///
-    /// - Throws: ``LiveKitError`` if removing the requirement fails to reconfigure the audio session.
-    public func removeRequirement(for id: UUID) throws {
+    fileprivate func removeRequirement(for id: UUID) throws {
         try updateRequirements {
             $0.removeValue(forKey: id)
         }

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -64,47 +64,6 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         set { _state.mutate { $0.isSpeakerOutputPreferred = newValue } }
     }
 
-    /// Represents an audio session requirement from a specific component.
-    ///
-    /// Multiple components (e.g., WebRTC engine, SoundPlayer) can independently
-    /// register their requirements. The audio session stays active as long as
-    /// any component requires playout or recording.
-    public struct SessionRequirement: Sendable, Equatable {
-        public static let none = Self(isPlayoutEnabled: false, isRecordingEnabled: false)
-        public static let playbackOnly = Self(isPlayoutEnabled: true, isRecordingEnabled: false)
-        public static let recordingOnly = Self(isPlayoutEnabled: false, isRecordingEnabled: true)
-        public static let playbackAndRecording = Self(isPlayoutEnabled: true, isRecordingEnabled: true)
-
-        public let isPlayoutEnabled: Bool
-        public let isRecordingEnabled: Bool
-
-        public init(isPlayoutEnabled: Bool = false, isRecordingEnabled: Bool = false) {
-            self.isPlayoutEnabled = isPlayoutEnabled
-            self.isRecordingEnabled = isRecordingEnabled
-        }
-    }
-
-    /// Opaque handle for an externally acquired audio session requirement.
-    ///
-    /// Call ``release()`` when the requirement is no longer needed.
-    public final class SessionRequirementHandle: @unchecked Sendable {
-        fileprivate let id: UUID
-        private weak var observer: AudioSessionEngineObserver?
-
-        fileprivate init(id: UUID, observer: AudioSessionEngineObserver) {
-            self.id = id
-            self.observer = observer
-        }
-
-        /// Releases the associated audio session requirement.
-        ///
-        /// Releasing the same handle multiple times is a no-op.
-        public func release() throws {
-            guard let observer else { return }
-            try observer.removeRequirement(for: id)
-        }
-    }
-
     struct State {
         var next: (any AudioEngineObserver)?
 
@@ -142,7 +101,10 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
     public func acquire(requirement: SessionRequirement) throws -> SessionRequirementHandle {
         let id = UUID()
         try set(requirement: requirement, for: id)
-        return SessionRequirementHandle(id: id, observer: self)
+        return SessionRequirementHandle(releaseImpl: { [weak self] in
+            guard let self else { return }
+            try removeRequirement(for: id)
+        })
     }
 
     private func set(requirement: SessionRequirement, for id: UUID) throws {

--- a/Sources/LiveKit/Audio/Manager/AudioManager.swift
+++ b/Sources/LiveKit/Audio/Manager/AudioManager.swift
@@ -26,18 +26,38 @@ internal import LiveKitWebRTC
 ///
 /// Multiple components can independently register their requirements. On platforms that use
 /// `AVAudioSession`, the session stays active as long as any component requires playout or recording.
-public struct SessionRequirement: Sendable, Equatable {
-    public static let none = Self(isPlayoutEnabled: false, isRecordingEnabled: false)
-    public static let playbackOnly = Self(isPlayoutEnabled: true, isRecordingEnabled: false)
-    public static let recordingOnly = Self(isPlayoutEnabled: false, isRecordingEnabled: true)
-    public static let playbackAndRecording = Self(isPlayoutEnabled: true, isRecordingEnabled: true)
+public struct SessionRequirement: OptionSet, Sendable {
+    public let rawValue: UInt8
 
-    public let isPlayoutEnabled: Bool
-    public let isRecordingEnabled: Bool
+    public static let playout = Self(rawValue: 1 << 0)
+    public static let recording = Self(rawValue: 1 << 1)
+
+    public static let none: Self = []
+    public static let playbackOnly: Self = [.playout]
+    public static let recordingOnly: Self = [.recording]
+    public static let playbackAndRecording: Self = [.playout, .recording]
+
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
 
     public init(isPlayoutEnabled: Bool = false, isRecordingEnabled: Bool = false) {
-        self.isPlayoutEnabled = isPlayoutEnabled
-        self.isRecordingEnabled = isRecordingEnabled
+        var rawValue: UInt8 = 0
+        if isPlayoutEnabled {
+            rawValue |= Self.playout.rawValue
+        }
+        if isRecordingEnabled {
+            rawValue |= Self.recording.rawValue
+        }
+        self.init(rawValue: rawValue)
+    }
+
+    public var isPlayoutEnabled: Bool {
+        contains(.playout)
+    }
+
+    public var isRecordingEnabled: Bool {
+        contains(.recording)
     }
 }
 

--- a/Sources/LiveKit/Audio/Manager/AudioManager.swift
+++ b/Sources/LiveKit/Audio/Manager/AudioManager.swift
@@ -64,18 +64,36 @@ public struct SessionRequirement: OptionSet, Sendable {
 /// Opaque handle for an acquired audio session requirement.
 ///
 /// Call ``release()`` when the requirement is no longer needed.
+/// If not released explicitly, the requirement is released automatically on deinit.
 public final class SessionRequirementHandle: @unchecked Sendable {
-    private let releaseImpl: @Sendable () throws -> Void
+    private struct State {
+        var releaseImpl: (@Sendable () throws -> Void)?
+    }
+
+    private let _state: StateSync<State>
 
     init(releaseImpl: @escaping @Sendable () throws -> Void) {
-        self.releaseImpl = releaseImpl
+        _state = StateSync(State(releaseImpl: releaseImpl))
+    }
+
+    deinit {
+        try? releaseIfNeeded()
     }
 
     /// Releases the associated audio session requirement.
     ///
     /// Releasing the same handle multiple times is a no-op.
     public func release() throws {
-        try releaseImpl()
+        try releaseIfNeeded()
+    }
+
+    private func releaseIfNeeded() throws {
+        let releaseImpl = _state.mutate { state -> (@Sendable () throws -> Void)? in
+            let releaseImpl = state.releaseImpl
+            state.releaseImpl = nil
+            return releaseImpl
+        }
+        try releaseImpl?()
     }
 }
 

--- a/Sources/LiveKit/Audio/Manager/AudioManager.swift
+++ b/Sources/LiveKit/Audio/Manager/AudioManager.swift
@@ -22,6 +22,43 @@ import Combine
 
 internal import LiveKitWebRTC
 
+/// Represents an audio session requirement from a specific component.
+///
+/// Multiple components can independently register their requirements. On platforms that use
+/// `AVAudioSession`, the session stays active as long as any component requires playout or recording.
+public struct SessionRequirement: Sendable, Equatable {
+    public static let none = Self(isPlayoutEnabled: false, isRecordingEnabled: false)
+    public static let playbackOnly = Self(isPlayoutEnabled: true, isRecordingEnabled: false)
+    public static let recordingOnly = Self(isPlayoutEnabled: false, isRecordingEnabled: true)
+    public static let playbackAndRecording = Self(isPlayoutEnabled: true, isRecordingEnabled: true)
+
+    public let isPlayoutEnabled: Bool
+    public let isRecordingEnabled: Bool
+
+    public init(isPlayoutEnabled: Bool = false, isRecordingEnabled: Bool = false) {
+        self.isPlayoutEnabled = isPlayoutEnabled
+        self.isRecordingEnabled = isRecordingEnabled
+    }
+}
+
+/// Opaque handle for an acquired audio session requirement.
+///
+/// Call ``release()`` when the requirement is no longer needed.
+public final class SessionRequirementHandle: @unchecked Sendable {
+    private let releaseImpl: @Sendable () throws -> Void
+
+    init(releaseImpl: @escaping @Sendable () throws -> Void) {
+        self.releaseImpl = releaseImpl
+    }
+
+    /// Releases the associated audio session requirement.
+    ///
+    /// Releasing the same handle multiple times is a no-op.
+    public func release() throws {
+        try releaseImpl()
+    }
+}
+
 // Audio Session Configuration related
 public class AudioManager: Loggable {
     // MARK: - Public
@@ -373,6 +410,17 @@ public class AudioManager: Loggable {
 
     public var isEngineRunning: Bool {
         RTC.audioDeviceModule.isEngineRunning
+    }
+
+    /// Acquires an audio session requirement for external ownership.
+    ///
+    /// On platforms without `AVAudioSession`, this returns a no-op handle.
+    public func acquireSessionRequirement(_ requirement: SessionRequirement) throws -> SessionRequirementHandle {
+        #if os(iOS) || os(visionOS) || os(tvOS)
+        try audioSession.acquire(requirement: requirement)
+        #else
+        SessionRequirementHandle(releaseImpl: {})
+        #endif
     }
 
     /// The mute state of internal audio engine which uses Voice Processing I/O mute API ``AVAudioInputNode.isVoiceProcessingInputMuted``.

--- a/Sources/LiveKit/Audio/MixerEngineObserver.swift
+++ b/Sources/LiveKit/Audio/MixerEngineObserver.swift
@@ -286,23 +286,39 @@ extension MixerEngineObserver {
     /// Play a sound buffer through the input path for remote participants via WebRTC.
     @discardableResult
     func playSound(_ inputBuffer: AVAudioPCMBuffer, loop: Bool = false) -> SoundPlayback? {
-        guard let converter = converter(for: inputBuffer.format) else {
-            log("Failed to get converter for sound buffer format: \(inputBuffer.format)", .warning)
+        let (isConnected, soundPlayerNodes, playerNodeFormat) = _state.read {
+            ($0.isInputConnected, $0.soundPlayerNodes, $0.playerNodeFormat)
+        }
+
+        guard isConnected, let playerNodeFormat, let engine = soundPlayerNodes.engine, engine.isRunning else {
+            log("Engine is not running or input not connected, cannot play sound remotely", .warning)
             return nil
         }
 
-        let buffer = converter.convert(from: inputBuffer)
-
-        let (isConnected, soundPlayerNodes) = _state.read {
-            ($0.isInputConnected, $0.soundPlayerNodes)
+        // Convert buffer to engine format with a properly-sized converter.
+        let bufferToSchedule: AVAudioPCMBuffer
+        if inputBuffer.format != playerNodeFormat {
+            let outputBufferCapacity = AudioConverter.frameCapacity(from: inputBuffer.format,
+                                                                    to: playerNodeFormat,
+                                                                    inputFrameCount: inputBuffer.frameLength)
+            guard let converter = AudioConverter(from: inputBuffer.format,
+                                                 to: playerNodeFormat,
+                                                 outputBufferCapacity: outputBufferCapacity)
+            else {
+                log("Failed to create converter for sound buffer", .warning)
+                return nil
+            }
+            bufferToSchedule = converter.convert(from: inputBuffer)
+        } else {
+            bufferToSchedule = inputBuffer
         }
 
-        guard isConnected, let engine = soundPlayerNodes.engine, engine.isRunning else {
-            log("Engine is not running, cannot play sound remotely", .warning)
+        do {
+            return try soundPlayerNodes.play(bufferToSchedule, loop: loop)
+        } catch {
+            log("Failed to play sound remotely: \(error)", .warning)
             return nil
         }
-
-        return try? soundPlayerNodes.play(buffer, loop: loop)
     }
 
     // Capture appAudio and apply conversion automatically suitable for internal audio engine.

--- a/Sources/LiveKit/Audio/MixerEngineObserver.swift
+++ b/Sources/LiveKit/Audio/MixerEngineObserver.swift
@@ -123,18 +123,21 @@ public final class MixerEngineObserver: AudioEngineObserver, Loggable {
             "appNode=\(appNode.auAudioUnit.maximumFramesToRender), " +
             "appMixerNode=\(appMixerNode.auAudioUnit.maximumFramesToRender), " +
             "micNode=\(micNode.auAudioUnit.maximumFramesToRender), " +
-            "micMixerNode=\(micMixerNode.auAudioUnit.maximumFramesToRender)", .debug)
+            "micMixerNode=\(micMixerNode.auAudioUnit.maximumFramesToRender), " +
+            "soundPlayerMixerNode=\(soundPlayerNodes.mixerNode.auAudioUnit.maximumFramesToRender)", .debug)
 
         appNode.auAudioUnit.maximumFramesToRender = maxFrames
         appMixerNode.auAudioUnit.maximumFramesToRender = maxFrames
         micNode.auAudioUnit.maximumFramesToRender = maxFrames
         micMixerNode.auAudioUnit.maximumFramesToRender = maxFrames
+        soundPlayerNodes.setMaximumFramesToRender(maxFrames)
 
         log("maximumFramesToRender setting to \(maxFrames): " +
             "appNode=\(appNode.auAudioUnit.maximumFramesToRender), " +
             "appMixerNode=\(appMixerNode.auAudioUnit.maximumFramesToRender), " +
             "micNode=\(micNode.auAudioUnit.maximumFramesToRender), " +
-            "micMixerNode=\(micMixerNode.auAudioUnit.maximumFramesToRender)", .debug)
+            "micMixerNode=\(micMixerNode.auAudioUnit.maximumFramesToRender), " +
+            "soundPlayerMixerNode=\(soundPlayerNodes.mixerNode.auAudioUnit.maximumFramesToRender)", .debug)
 
         #if os(iOS) || os(visionOS) || os(tvOS)
         let config = LKRTCAudioSessionConfiguration.webRTC()

--- a/Sources/LiveKit/Audio/MixerEngineObserver.swift
+++ b/Sources/LiveKit/Audio/MixerEngineObserver.swift
@@ -47,6 +47,12 @@ public final class MixerEngineObserver: AudioEngineObserver, Loggable {
         set { _state.mutate { $0.micMixerNode.outputVolume = newValue } }
     }
 
+    /// Adjust the volume of sound player audio sent to remote participants. Range is 0.0 ~ 1.0.
+    public var soundPlayerVolume: Float {
+        get { _state.read { $0.soundPlayerNodes.mixerNode.outputVolume } }
+        set { _state.mutate { $0.soundPlayerNodes.mixerNode.outputVolume = newValue } }
+    }
+
     // MARK: - Internal
 
     var appAudioNode: AVAudioPlayerNode {
@@ -60,13 +66,16 @@ public final class MixerEngineObserver: AudioEngineObserver, Loggable {
     struct State {
         var next: (any AudioEngineObserver)?
 
-        // AppAudio
+        // App audio (Input)
         let appNode = AVAudioPlayerNode()
         let appMixerNode = AVAudioMixerNode()
 
-        // Not connected for device rendering mode.
+        // Mic audio (Input), not connected for device rendering mode.
         let micNode = AVAudioPlayerNode()
         let micMixerNode = AVAudioMixerNode()
+
+        // Sound player audio (Input) — for sending sounds to remote participants via WebRTC
+        let soundPlayerNodes = AVAudioPlayerNodePool()
 
         // Reference to mainMixerNode
         weak var mainMixerNode: AVAudioMixerNode?
@@ -92,14 +101,15 @@ public final class MixerEngineObserver: AudioEngineObserver, Loggable {
 
     public func engineDidCreate(_ engine: AVAudioEngine) -> Int {
         log("isManualRenderingMode: \(engine.isInManualRenderingMode)")
-        let (appNode, appMixerNode, micNode, micMixerNode) = _state.read {
-            ($0.appNode, $0.appMixerNode, $0.micNode, $0.micMixerNode)
+        let (appNode, appMixerNode, micNode, micMixerNode, soundPlayerNodes) = _state.read {
+            ($0.appNode, $0.appMixerNode, $0.micNode, $0.micMixerNode, $0.soundPlayerNodes)
         }
 
         engine.attach(appNode)
         engine.attach(appMixerNode)
         engine.attach(micNode)
         engine.attach(micMixerNode)
+        engine.attach(soundPlayerNodes)
 
         // Invoke next
         return next?.engineDidCreate(engine) ?? 0
@@ -110,14 +120,15 @@ public final class MixerEngineObserver: AudioEngineObserver, Loggable {
         // Invoke next
         let nextResult = next?.engineWillRelease(engine)
 
-        let (appNode, appMixerNode, micNode, micMixerNode) = _state.read {
-            ($0.appNode, $0.appMixerNode, $0.micNode, $0.micMixerNode)
+        let (appNode, appMixerNode, micNode, micMixerNode, soundPlayerNodes) = _state.read {
+            ($0.appNode, $0.appMixerNode, $0.micNode, $0.micMixerNode, $0.soundPlayerNodes)
         }
 
         engine.detach(appNode)
         engine.detach(appMixerNode)
         engine.detach(micNode)
         engine.detach(micMixerNode)
+        engine.detach(soundPlayerNodes)
 
         return nextResult ?? 0
     }
@@ -133,8 +144,8 @@ public final class MixerEngineObserver: AudioEngineObserver, Loggable {
         }
 
         // Read nodes from state lock.
-        let (appNode, appMixerNode, micNode, micMixerNode) = _state.read {
-            ($0.appNode, $0.appMixerNode, $0.micNode, $0.micMixerNode)
+        let (appNode, appMixerNode, micNode, micMixerNode, soundPlayerNodes) = _state.read {
+            ($0.appNode, $0.appMixerNode, $0.micNode, $0.micMixerNode, $0.soundPlayerNodes)
         }
 
         // AVAudioPlayerNode doesn't support Int16 so we ensure to use Float32
@@ -160,6 +171,10 @@ public final class MixerEngineObserver: AudioEngineObserver, Loggable {
         engine.connect(micNode, to: micMixerNode, format: playerNodeFormat)
         // Always connect micMixer to mainMixer
         engine.connect(micMixerNode, to: mainMixerNode, format: format)
+
+        log("Connecting soundPlayerNodes -> mainMixer")
+        // soundPlayerNodes -> mainMixer -> WebRTC (remote)
+        engine.connect(soundPlayerNodes, to: mainMixerNode, format: format, playerNodeFormat: playerNodeFormat)
 
         _state.mutate {
             if let previousEngineFormat = $0.playerNodeFormat, previousEngineFormat != format {
@@ -189,12 +204,13 @@ public final class MixerEngineObserver: AudioEngineObserver, Loggable {
 
     public func engineWillStart(_ engine: AVAudioEngine, isPlayoutEnabled: Bool, isRecordingEnabled: Bool) -> Int {
         log("isPlayoutEnabled: \(isPlayoutEnabled), isRecordingEnabled: \(isRecordingEnabled)")
-        let (micNode, appNode) = _state.read {
-            ($0.micNode, $0.appNode)
+        let (micNode, appNode, soundPlayerNodes) = _state.read {
+            ($0.micNode, $0.appNode, $0.soundPlayerNodes)
         }
 
         micNode.reset()
         appNode.reset()
+        soundPlayerNodes.reset()
 
         return next?.engineWillStart(engine, isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled) ?? 0
     }
@@ -229,6 +245,28 @@ extension MixerEngineObserver {
             $0.converters[format] = newConverter
             return newConverter
         }
+    }
+
+    /// Play a sound buffer through the input path for remote participants via WebRTC.
+    @discardableResult
+    func playSound(_ inputBuffer: AVAudioPCMBuffer, loop: Bool = false) -> SoundPlayback? {
+        guard let converter = converter(for: inputBuffer.format) else {
+            log("Failed to get converter for sound buffer format: \(inputBuffer.format)", .warning)
+            return nil
+        }
+
+        let buffer = converter.convert(from: inputBuffer)
+
+        let (isConnected, soundPlayerNodes) = _state.read {
+            ($0.isInputConnected, $0.soundPlayerNodes)
+        }
+
+        guard isConnected, let engine = soundPlayerNodes.engine, engine.isRunning else {
+            log("Engine is not running, cannot play sound remotely", .warning)
+            return nil
+        }
+
+        return try? soundPlayerNodes.play(buffer, loop: loop)
     }
 
     // Capture appAudio and apply conversion automatically suitable for internal audio engine.

--- a/Sources/LiveKit/Audio/MixerEngineObserver.swift
+++ b/Sources/LiveKit/Audio/MixerEngineObserver.swift
@@ -289,11 +289,11 @@ extension MixerEngineObserver {
     /// Play a sound buffer through the input path for remote participants via WebRTC.
     @discardableResult
     func playSound(_ inputBuffer: AVAudioPCMBuffer, loop: Bool = false) -> SoundPlayback? {
-        let (isConnected, soundPlayerNodes, playerNodeFormat) = _state.read {
+        let (isInputConnected, soundPlayerNodes, playerNodeFormat) = _state.read {
             ($0.isInputConnected, $0.soundPlayerNodes, $0.playerNodeFormat)
         }
 
-        guard isConnected else {
+        guard isInputConnected else {
             log("Remote sound playback skipped because the microphone is not published. Publish the microphone to send SoundPlayer audio to remote participants.", .warning)
             return nil
         }
@@ -338,11 +338,11 @@ extension MixerEngineObserver {
 
         let buffer = converter.convert(from: inputBuffer)
 
-        let (isConnected, appNode) = _state.read {
+        let (isInputConnected, appNode) = _state.read {
             ($0.isInputConnected, $0.appNode)
         }
 
-        guard isConnected, let engine = appNode.engine, engine.isRunning else {
+        guard isInputConnected, let engine = appNode.engine, engine.isRunning else {
             log("Engine is not running", .warning)
             return
         }

--- a/Sources/LiveKit/Audio/MixerEngineObserver.swift
+++ b/Sources/LiveKit/Audio/MixerEngineObserver.swift
@@ -294,6 +294,7 @@ extension MixerEngineObserver {
         }
 
         guard isConnected, let playerNodeFormat, let engine = soundPlayerNodes.engine, engine.isRunning else {
+            log("Remote sound playback skipped because the microphone is not published. Publish the microphone to send SoundPlayer audio to remote participants.", .warning)
             return nil
         }
 

--- a/Sources/LiveKit/Audio/MixerEngineObserver.swift
+++ b/Sources/LiveKit/Audio/MixerEngineObserver.swift
@@ -189,9 +189,9 @@ public final class MixerEngineObserver: AudioEngineObserver, Loggable {
 
         // AVAudioPlayerNode doesn't support Int16 so we ensure to use Float32
         guard let playerNodeFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
-                                                    sampleRate: format.sampleRate,
-                                                    channels: format.channelCount,
-                                                    interleaved: format.isInterleaved)
+                                                   sampleRate: format.sampleRate,
+                                                   channels: format.channelCount,
+                                                   interleaved: format.isInterleaved)
         else {
             log("Failed to create player node format", .error)
             return next?.engineWillConnectInput(engine, src: src, dst: dst, format: format, context: context) ?? 0

--- a/Sources/LiveKit/Audio/MixerEngineObserver.swift
+++ b/Sources/LiveKit/Audio/MixerEngineObserver.swift
@@ -291,7 +291,7 @@ extension MixerEngineObserver {
         }
 
         guard isConnected, let playerNodeFormat, let engine = soundPlayerNodes.engine, engine.isRunning else {
-            log("Engine is not running or input not connected, cannot play sound remotely", .warning)
+            log("Engine is not running or input not connected, skipping remote sound playback", .debug)
             return nil
         }
 
@@ -305,7 +305,7 @@ extension MixerEngineObserver {
                                                  to: playerNodeFormat,
                                                  outputBufferCapacity: outputBufferCapacity)
             else {
-                log("Failed to create converter for sound buffer", .warning)
+                log("Failed to create converter for sound buffer, skipping remote sound playback", .debug)
                 return nil
             }
             bufferToSchedule = converter.convert(from: inputBuffer)
@@ -316,7 +316,7 @@ extension MixerEngineObserver {
         do {
             return try soundPlayerNodes.play(bufferToSchedule, loop: loop)
         } catch {
-            log("Failed to play sound remotely: \(error)", .warning)
+            log("Failed to play sound remotely: \(error)", .debug)
             return nil
         }
     }

--- a/Sources/LiveKit/Audio/MixerEngineObserver.swift
+++ b/Sources/LiveKit/Audio/MixerEngineObserver.swift
@@ -293,8 +293,13 @@ extension MixerEngineObserver {
             ($0.isInputConnected, $0.soundPlayerNodes, $0.playerNodeFormat)
         }
 
-        guard isConnected, let playerNodeFormat, let engine = soundPlayerNodes.engine, engine.isRunning else {
+        guard isConnected else {
             log("Remote sound playback skipped because the microphone is not published. Publish the microphone to send SoundPlayer audio to remote participants.", .warning)
+            return nil
+        }
+
+        guard let playerNodeFormat, let engine = soundPlayerNodes.engine, engine.isRunning else {
+            log("Remote sound playback skipped because the remote sound path is temporarily unavailable.", .warning)
             return nil
         }
 

--- a/Sources/LiveKit/Audio/MixerEngineObserver.swift
+++ b/Sources/LiveKit/Audio/MixerEngineObserver.swift
@@ -188,10 +188,14 @@ public final class MixerEngineObserver: AudioEngineObserver, Loggable {
         }
 
         // AVAudioPlayerNode doesn't support Int16 so we ensure to use Float32
-        let playerNodeFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
-                                             sampleRate: format.sampleRate,
-                                             channels: format.channelCount,
-                                             interleaved: format.isInterleaved)!
+        guard let playerNodeFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                                    sampleRate: format.sampleRate,
+                                                    channels: format.channelCount,
+                                                    interleaved: format.isInterleaved)
+        else {
+            log("Failed to create player node format", .error)
+            return next?.engineWillConnectInput(engine, src: src, dst: dst, format: format, context: context) ?? 0
+        }
 
         log("Connecting app -> appMixer -> mainMixer")
         // appAudio -> appAudioMixer -> mainMixer

--- a/Sources/LiveKit/Audio/MixerEngineObserver.swift
+++ b/Sources/LiveKit/Audio/MixerEngineObserver.swift
@@ -291,7 +291,6 @@ extension MixerEngineObserver {
         }
 
         guard isConnected, let playerNodeFormat, let engine = soundPlayerNodes.engine, engine.isRunning else {
-            log("Engine is not running or input not connected, skipping remote sound playback", .debug)
             return nil
         }
 

--- a/Sources/LiveKit/Audio/PlayerNodePool.swift
+++ b/Sources/LiveKit/Audio/PlayerNodePool.swift
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@preconcurrency import AVFAudio
+
+/// Represents an active sound playback that can be stopped.
+protocol SoundPlayback: AnyObject, Sendable {
+    var isPlaying: Bool { get }
+    func stop()
+}
+
+/// Manages a pool of AVAudioPlayerNodes for concurrent audio playback.
+class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
+    let poolSize: Int
+    let mixerNode = AVAudioMixerNode()
+
+    var playerNodes: [AVAudioPlayerNode] {
+        _state.read { $0.map(\.node) }
+    }
+
+    var engine: AVAudioEngine? {
+        mixerNode.engine
+    }
+
+    private struct NodeItem {
+        let node: AVAudioPlayerNode
+        var isInUse: Bool = false
+        var generation: UInt64 = 0
+    }
+
+    private let audioCallbackQueue = DispatchQueue(label: "audio.playerNodePool.queue")
+    private let _state: StateSync<[NodeItem]>
+
+    init(poolSize: Int = 10) {
+        self.poolSize = poolSize
+        let items = (0 ..< poolSize).map { _ in NodeItem(node: AVAudioPlayerNode()) }
+        _state = StateSync(items)
+    }
+
+    @discardableResult
+    func play(_ buffer: AVAudioPCMBuffer) throws -> SoundPlayback {
+        guard let (index, node, generation) = _state.mutate({ items -> (Int, AVAudioPlayerNode, UInt64)? in
+            guard let index = items.firstIndex(where: { !$0.isInUse }) else {
+                return nil
+            }
+            items[index].isInUse = true
+            items[index].generation &+= 1
+            let node = items[index].node
+            node.volume = 1.0
+            node.pan = 0.0
+            return (index, node, items[index].generation)
+        }) else {
+            throw LiveKitError(.audioEngine, message: "No available player nodes")
+        }
+
+        node.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [weak self] _ in
+            self?.audioCallbackQueue.async { [weak self] in
+                self?.freeSlot(index: index, generation: generation)
+            }
+        }
+        node.play()
+
+        return NodePlayback(node: node) { [weak self] in
+            self?.freeSlot(index: index, generation: generation)
+        }
+    }
+
+    func stop() {
+        let nodes = _state.mutate { items in
+            for index in items.indices {
+                items[index].isInUse = false
+                items[index].generation &+= 1
+            }
+            return items.map(\.node)
+        }
+        for node in nodes {
+            node.stop()
+        }
+    }
+
+    func reset() {
+        let nodes = _state.mutate { items in
+            for index in items.indices {
+                items[index].isInUse = false
+                items[index].generation &+= 1
+            }
+            return items.map(\.node)
+        }
+        for node in nodes {
+            node.reset()
+        }
+    }
+
+    private func freeSlot(index: Int, generation: UInt64) {
+        _state.mutate { items in
+            guard items[index].generation == generation else { return }
+            items[index].isInUse = false
+            items[index].node.stop()
+        }
+    }
+}
+
+// MARK: - NodePlayback
+
+class NodePlayback: SoundPlayback, @unchecked Sendable {
+    private weak var node: AVAudioPlayerNode?
+    private let onStop: @Sendable () -> Void
+
+    var isPlaying: Bool { node?.isPlaying ?? false }
+
+    init(node: AVAudioPlayerNode, onStop: @escaping @Sendable () -> Void) {
+        self.node = node
+        self.onStop = onStop
+    }
+
+    func stop() {
+        node?.stop()
+        onStop()
+    }
+}
+
+// MARK: - AVAudioEngine extensions
+
+extension AVAudioEngine {
+    func attach(_ playerNodePool: AVAudioPlayerNodePool) {
+        for playerNode in playerNodePool.playerNodes {
+            attach(playerNode)
+        }
+        attach(playerNodePool.mixerNode)
+    }
+
+    func detach(_ playerNodePool: AVAudioPlayerNodePool) {
+        for playerNode in playerNodePool.playerNodes {
+            playerNode.stop()
+            detach(playerNode)
+        }
+        detach(playerNodePool.mixerNode)
+    }
+
+    func connect(_ playerNodePool: AVAudioPlayerNodePool, to node2: AVAudioNode, format: AVAudioFormat?, playerNodeFormat: AVAudioFormat?) {
+        for playerNode in playerNodePool.playerNodes {
+            connect(playerNode, to: playerNodePool.mixerNode, format: playerNodeFormat ?? format)
+        }
+        connect(playerNodePool.mixerNode, to: node2, format: format)
+    }
+}

--- a/Sources/LiveKit/Audio/PlayerNodePool.swift
+++ b/Sources/LiveKit/Audio/PlayerNodePool.swift
@@ -94,9 +94,7 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
 
         return NodePlayback(node: acquired.node) { [weak self] in
             guard let self else { return }
-            await withCheckedContinuation { continuation in
-                self.beginStoppingSlot(index: acquired.index, generation: acquired.generation, continuation: continuation)
-            }
+            await beginStoppingSlot(index: acquired.index, generation: acquired.generation)
         }
     }
 
@@ -136,24 +134,23 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
         items[index].state = .idle
     }
 
-    private func beginStoppingSlot(index: Int,
-                                   generation: UInt64,
-                                   continuation: CheckedContinuation<Void, Never>)
-    {
-        executionQueue.async { [weak self] in
-            guard let self else {
-                continuation.resume()
-                return
-            }
-            guard items[index].generation == generation else {
-                continuation.resume()
-                return
-            }
+    private func beginStoppingSlot(index: Int, generation: UInt64) async {
+        let node: AVAudioPlayerNode? = await withCheckedContinuation { (continuation: CheckedContinuation<AVAudioPlayerNode?, Never>) in
+            executionQueue.async { [self] in
+                guard items[index].generation == generation else {
+                    continuation.resume(returning: nil)
+                    return
+                }
 
-            items[index].state = .stopping
-            items[index].generation &+= 1
-            let node = items[index].node
+                items[index].state = .stopping
+                items[index].generation &+= 1
+                continuation.resume(returning: items[index].node)
+            }
+        }
 
+        guard let node else { return }
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             stopQueue.async { [weak self] in
                 node.stop()
                 guard let self else {

--- a/Sources/LiveKit/Audio/PlayerNodePool.swift
+++ b/Sources/LiveKit/Audio/PlayerNodePool.swift
@@ -50,9 +50,15 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
         _state = StateSync(items)
     }
 
+    private struct AcquiredNode {
+        let index: Int
+        let node: AVAudioPlayerNode
+        let generation: UInt64
+    }
+
     @discardableResult
     func play(_ buffer: AVAudioPCMBuffer, loop: Bool = false) throws -> SoundPlayback {
-        guard let (index, node, generation) = _state.mutate({ items -> (Int, AVAudioPlayerNode, UInt64)? in
+        guard let acquired = _state.mutate({ items -> AcquiredNode? in
             guard let index = items.firstIndex(where: { !$0.isInUse }) else {
                 return nil
             }
@@ -61,24 +67,24 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
             let node = items[index].node
             node.volume = 1.0
             node.pan = 0.0
-            return (index, node, items[index].generation)
+            return AcquiredNode(index: index, node: node, generation: items[index].generation)
         }) else {
             throw LiveKitError(.audioEngine, message: "No available player nodes")
         }
 
         if loop {
-            node.scheduleBuffer(buffer, at: nil, options: .loops)
+            acquired.node.scheduleBuffer(buffer, at: nil, options: .loops)
         } else {
-            node.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [weak self] _ in
+            acquired.node.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [weak self] _ in
                 self?.audioCallbackQueue.async { [weak self] in
-                    self?.freeSlot(index: index, generation: generation)
+                    self?.freeSlot(index: acquired.index, generation: acquired.generation)
                 }
             }
         }
-        node.play()
+        acquired.node.play()
 
-        return NodePlayback(node: node) { [weak self] in
-            self?.freeSlot(index: index, generation: generation)
+        return NodePlayback(node: acquired.node) { [weak self] in
+            self?.freeSlot(index: acquired.index, generation: acquired.generation)
         }
     }
 

--- a/Sources/LiveKit/Audio/PlayerNodePool.swift
+++ b/Sources/LiveKit/Audio/PlayerNodePool.swift
@@ -97,7 +97,7 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
             return items.map(\.node)
         }
         for node in nodes {
-            node.stop()
+            queueNodeStop(node)
         }
     }
 
@@ -115,10 +115,18 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
     }
 
     private func freeSlot(index: Int, generation: UInt64) {
-        _state.mutate { items in
-            guard items[index].generation == generation else { return }
+        let node = _state.mutate { items -> AVAudioPlayerNode? in
+            guard items[index].generation == generation else { return nil }
             items[index].isInUse = false
-            items[index].node.stop()
+            return items[index].node
+        }
+        queueNodeStop(node)
+    }
+
+    private func queueNodeStop(_ node: AVAudioPlayerNode?) {
+        guard let node else { return }
+        audioCallbackQueue.async(qos: .default, flags: .enforceQoS) {
+            node.stop()
         }
     }
 }
@@ -137,7 +145,6 @@ class NodePlayback: SoundPlayback, @unchecked Sendable {
     }
 
     func stop() {
-        node?.stop()
         onStop()
     }
 }

--- a/Sources/LiveKit/Audio/PlayerNodePool.swift
+++ b/Sources/LiveKit/Audio/PlayerNodePool.swift
@@ -203,6 +203,13 @@ extension AVAudioEngine {
         attach(playerNodePool.mixerNode)
     }
 
+    func disconnect(_ playerNodePool: AVAudioPlayerNodePool) {
+        for playerNode in playerNodePool.playerNodes {
+            disconnectNodeOutput(playerNode)
+        }
+        disconnectNodeOutput(playerNodePool.mixerNode)
+    }
+
     func detach(_ playerNodePool: AVAudioPlayerNodePool) {
         for playerNode in playerNodePool.playerNodes {
             playerNode.stop()

--- a/Sources/LiveKit/Audio/PlayerNodePool.swift
+++ b/Sources/LiveKit/Audio/PlayerNodePool.swift
@@ -19,7 +19,7 @@
 /// Represents an active sound playback that can be stopped.
 protocol SoundPlayback: AnyObject, Sendable {
     var isPlaying: Bool { get }
-    func stop()
+    func stop() async
 }
 
 /// Manages a pool of AVAudioPlayerNodes for concurrent audio playback.
@@ -35,13 +35,20 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
         mixerNode.engine
     }
 
+    private enum NodeState {
+        case idle
+        case inUse
+        case stopping
+    }
+
     private struct NodeItem {
         let node: AVAudioPlayerNode
-        var isInUse: Bool = false
+        var state: NodeState = .idle
         var generation: UInt64 = 0
     }
 
     private let executionQueue = DispatchQueue(label: "audio.playerNodePool.queue")
+    private let stopQueue = DispatchQueue(label: "audio.playerNodePool.stop", qos: .default)
     private var items: [NodeItem]
 
     init(poolSize: Int = 10) {
@@ -58,11 +65,11 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
     @discardableResult
     func play(_ buffer: AVAudioPCMBuffer, loop: Bool = false) throws -> SoundPlayback {
         let acquired = try executionQueue.sync { () throws -> AcquiredNode in
-            guard let index = items.firstIndex(where: { !$0.isInUse }) else {
+            guard let index = items.firstIndex(where: { $0.state == .idle }) else {
                 throw LiveKitError(.audioEngine, message: "No available player nodes")
             }
 
-            items[index].isInUse = true
+            items[index].state = .inUse
             items[index].generation &+= 1
 
             let node = items[index].node
@@ -75,7 +82,7 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
             } else {
                 node.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [weak self] _ in
                     self?.executionQueue.async { [weak self] in
-                        self?.releaseSlot(index: index, generation: generation, shouldStopNode: false)
+                        self?.releaseCompletedSlot(index: index, generation: generation)
                     }
                 }
             }
@@ -86,8 +93,9 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
         }
 
         return NodePlayback(node: acquired.node) { [weak self] in
-            self?.executionQueue.sync {
-                self?.releaseSlot(index: acquired.index, generation: acquired.generation, shouldStopNode: true)
+            guard let self else { return }
+            await withCheckedContinuation { continuation in
+                self.beginStoppingSlot(index: acquired.index, generation: acquired.generation, continuation: continuation)
             }
         }
     }
@@ -97,7 +105,7 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
             for index in items.indices {
                 let node = items[index].node
                 node.stop()
-                items[index].isInUse = false
+                items[index].state = .idle
                 items[index].generation &+= 1
             }
         }
@@ -108,7 +116,7 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
             for index in items.indices {
                 let node = items[index].node
                 node.reset()
-                items[index].isInUse = false
+                items[index].state = .idle
                 items[index].generation &+= 1
             }
         }
@@ -123,14 +131,46 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
         }
     }
 
-    private func releaseSlot(index: Int, generation: UInt64, shouldStopNode: Bool) {
+    private func releaseCompletedSlot(index: Int, generation: UInt64) {
         guard items[index].generation == generation else { return }
+        items[index].state = .idle
+    }
 
-        if shouldStopNode {
-            items[index].node.stop()
+    private func beginStoppingSlot(index: Int,
+                                   generation: UInt64,
+                                   continuation: CheckedContinuation<Void, Never>)
+    {
+        executionQueue.async { [weak self] in
+            guard let self else {
+                continuation.resume()
+                return
+            }
+            guard items[index].generation == generation else {
+                continuation.resume()
+                return
+            }
+
+            items[index].state = .stopping
+            items[index].generation &+= 1
+            let node = items[index].node
+
+            stopQueue.async { [weak self] in
+                node.stop()
+                guard let self else {
+                    continuation.resume()
+                    return
+                }
+                executionQueue.async { [self] in
+                    finishStoppingSlot(index: index)
+                    continuation.resume()
+                }
+            }
         }
+    }
 
-        items[index].isInUse = false
+    private func finishStoppingSlot(index: Int) {
+        guard items.indices.contains(index) else { return }
+        items[index].state = .idle
     }
 }
 
@@ -138,17 +178,17 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
 
 class NodePlayback: SoundPlayback, @unchecked Sendable {
     private weak var node: AVAudioPlayerNode?
-    private let onStop: @Sendable () -> Void
+    private let onStop: @Sendable () async -> Void
 
     var isPlaying: Bool { node?.isPlaying ?? false }
 
-    init(node: AVAudioPlayerNode, onStop: @escaping @Sendable () -> Void) {
+    init(node: AVAudioPlayerNode, onStop: @escaping @Sendable () async -> Void) {
         self.node = node
         self.onStop = onStop
     }
 
-    func stop() {
-        onStop()
+    func stop() async {
+        await onStop()
     }
 }
 

--- a/Sources/LiveKit/Audio/PlayerNodePool.swift
+++ b/Sources/LiveKit/Audio/PlayerNodePool.swift
@@ -157,8 +157,12 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
                     continuation.resume()
                     return
                 }
-                executionQueue.async { [self] in
-                    finishStoppingSlot(index: index)
+                executionQueue.async { [weak self] in
+                    guard let pool = self else {
+                        continuation.resume()
+                        return
+                    }
+                    pool.finishStoppingSlot(index: index)
                     continuation.resume()
                 }
             }

--- a/Sources/LiveKit/Audio/PlayerNodePool.swift
+++ b/Sources/LiveKit/Audio/PlayerNodePool.swift
@@ -28,7 +28,7 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
     let mixerNode = AVAudioMixerNode()
 
     var playerNodes: [AVAudioPlayerNode] {
-        _state.read { $0.map(\.node) }
+        executionQueue.sync { items.map(\.node) }
     }
 
     var engine: AVAudioEngine? {
@@ -41,13 +41,12 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
         var generation: UInt64 = 0
     }
 
-    private let audioCallbackQueue = DispatchQueue(label: "audio.playerNodePool.queue")
-    private let _state: StateSync<[NodeItem]>
+    private let executionQueue = DispatchQueue(label: "audio.playerNodePool.queue")
+    private var items: [NodeItem]
 
     init(poolSize: Int = 10) {
         self.poolSize = poolSize
-        let items = (0 ..< poolSize).map { _ in NodeItem(node: AVAudioPlayerNode()) }
-        _state = StateSync(items)
+        items = (0 ..< poolSize).map { _ in NodeItem(node: AVAudioPlayerNode()) }
     }
 
     private struct AcquiredNode {
@@ -58,76 +57,71 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
 
     @discardableResult
     func play(_ buffer: AVAudioPCMBuffer, loop: Bool = false) throws -> SoundPlayback {
-        guard let acquired = _state.mutate({ items -> AcquiredNode? in
+        let acquired = try executionQueue.sync { () throws -> AcquiredNode in
             guard let index = items.firstIndex(where: { !$0.isInUse }) else {
-                return nil
+                throw LiveKitError(.audioEngine, message: "No available player nodes")
             }
+
             items[index].isInUse = true
             items[index].generation &+= 1
+
             let node = items[index].node
+            let generation = items[index].generation
             node.volume = 1.0
             node.pan = 0.0
-            return AcquiredNode(index: index, node: node, generation: items[index].generation)
-        }) else {
-            throw LiveKitError(.audioEngine, message: "No available player nodes")
-        }
 
-        if loop {
-            acquired.node.scheduleBuffer(buffer, at: nil, options: .loops)
-        } else {
-            acquired.node.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [weak self] _ in
-                self?.audioCallbackQueue.async { [weak self] in
-                    self?.freeSlot(index: acquired.index, generation: acquired.generation)
+            if loop {
+                node.scheduleBuffer(buffer, at: nil, options: .loops)
+            } else {
+                node.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [weak self] _ in
+                    self?.executionQueue.async { [weak self] in
+                        self?.releaseSlot(index: index, generation: generation, shouldStopNode: false)
+                    }
                 }
             }
+
+            node.play()
+
+            return AcquiredNode(index: index, node: node, generation: generation)
         }
-        acquired.node.play()
 
         return NodePlayback(node: acquired.node) { [weak self] in
-            self?.freeSlot(index: acquired.index, generation: acquired.generation)
+            self?.executionQueue.sync {
+                self?.releaseSlot(index: acquired.index, generation: acquired.generation, shouldStopNode: true)
+            }
         }
     }
 
     func stop() {
-        let nodes = _state.mutate { items in
+        executionQueue.sync {
             for index in items.indices {
+                let node = items[index].node
+                node.stop()
                 items[index].isInUse = false
                 items[index].generation &+= 1
             }
-            return items.map(\.node)
-        }
-        for node in nodes {
-            queueNodeStop(node)
         }
     }
 
     func reset() {
-        let nodes = _state.mutate { items in
+        executionQueue.sync {
             for index in items.indices {
+                let node = items[index].node
+                node.reset()
                 items[index].isInUse = false
                 items[index].generation &+= 1
             }
-            return items.map(\.node)
-        }
-        for node in nodes {
-            node.reset()
         }
     }
 
-    private func freeSlot(index: Int, generation: UInt64) {
-        let node = _state.mutate { items -> AVAudioPlayerNode? in
-            guard items[index].generation == generation else { return nil }
-            items[index].isInUse = false
-            return items[index].node
-        }
-        queueNodeStop(node)
-    }
+    private func releaseSlot(index: Int, generation: UInt64, shouldStopNode: Bool) {
+        guard items[index].generation == generation else { return }
 
-    private func queueNodeStop(_ node: AVAudioPlayerNode?) {
-        guard let node else { return }
-        audioCallbackQueue.async(qos: .default, flags: .enforceQoS) {
-            node.stop()
+        if shouldStopNode {
+            items[index].node.stop()
         }
+
+        items[index].isInUse = false
     }
 }
 

--- a/Sources/LiveKit/Audio/PlayerNodePool.swift
+++ b/Sources/LiveKit/Audio/PlayerNodePool.swift
@@ -51,7 +51,7 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
     }
 
     @discardableResult
-    func play(_ buffer: AVAudioPCMBuffer) throws -> SoundPlayback {
+    func play(_ buffer: AVAudioPCMBuffer, loop: Bool = false) throws -> SoundPlayback {
         guard let (index, node, generation) = _state.mutate({ items -> (Int, AVAudioPlayerNode, UInt64)? in
             guard let index = items.firstIndex(where: { !$0.isInUse }) else {
                 return nil
@@ -66,9 +66,13 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
             throw LiveKitError(.audioEngine, message: "No available player nodes")
         }
 
-        node.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [weak self] _ in
-            self?.audioCallbackQueue.async { [weak self] in
-                self?.freeSlot(index: index, generation: generation)
+        if loop {
+            node.scheduleBuffer(buffer, at: nil, options: .loops)
+        } else {
+            node.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [weak self] _ in
+                self?.audioCallbackQueue.async { [weak self] in
+                    self?.freeSlot(index: index, generation: generation)
+                }
             }
         }
         node.play()

--- a/Sources/LiveKit/Audio/PlayerNodePool.swift
+++ b/Sources/LiveKit/Audio/PlayerNodePool.swift
@@ -114,6 +114,15 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
         }
     }
 
+    func setMaximumFramesToRender(_ maxFrames: AUAudioFrameCount) {
+        executionQueue.sync {
+            mixerNode.auAudioUnit.maximumFramesToRender = maxFrames
+            for item in items {
+                item.node.auAudioUnit.maximumFramesToRender = maxFrames
+            }
+        }
+    }
+
     private func releaseSlot(index: Int, generation: UInt64, shouldStopNode: Bool) {
         guard items[index].generation == generation else { return }
 

--- a/Sources/LiveKit/Audio/SoundPlayer+Types.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer+Types.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import Foundation
+
 @globalActor
 public actor SoundPlayerActor {
     public static let shared = SoundPlayerActor()
@@ -67,5 +69,35 @@ public struct PlaybackOptions: Sendable {
         self.mode = mode
         self.loop = loop
         self.destination = destination
+    }
+}
+
+/// Typed reference to a prepared sound managed by ``SoundPlayer``.
+///
+/// Handles are value types and do not own the underlying sound resource. They act as
+/// lightweight tokens that forward operations to ``SoundPlayer.shared``.
+public struct SoundHandle: Hashable, Sendable {
+    let id: UUID
+
+    public func play(options: PlaybackOptions = PlaybackOptions()) async throws {
+        try await SoundPlayer.shared.play(self, options: options)
+    }
+
+    public func stop(destination: PlaybackOptions.Destination = .localAndRemote) async {
+        await SoundPlayer.shared.stop(self, destination: destination)
+    }
+
+    public func release() async {
+        await SoundPlayer.shared.release(self)
+    }
+
+    public var isPrepared: Bool {
+        get async {
+            await SoundPlayer.shared.isPrepared(self)
+        }
+    }
+
+    public func isPlaying(destination: PlaybackOptions.Destination = .localAndRemote) async -> Bool {
+        await SoundPlayer.shared.isPlaying(self, destination: destination)
     }
 }

--- a/Sources/LiveKit/Audio/SoundPlayer+Types.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer+Types.swift
@@ -25,7 +25,7 @@ public actor SoundPlayerActor {
 }
 
 /// Options for controlling sound playback behavior.
-public struct PlaybackOptions: Sendable {
+public struct SoundPlaybackOptions: Sendable {
     /// How to handle existing playback of the same sound.
     public enum Mode: Sendable {
         /// Play concurrently with any existing playback of the same sound.
@@ -85,12 +85,12 @@ public struct SoundHandle: Hashable, Sendable {
     let id: UUID
 
     /// Plays this prepared sound with the provided options.
-    public func play(options: PlaybackOptions = PlaybackOptions()) async throws {
+    public func play(options: SoundPlaybackOptions = SoundPlaybackOptions()) async throws {
         try await SoundPlayer.shared.play(self, options: options)
     }
 
     /// Stops active local and/or remote playback for this prepared sound.
-    public func stop(destination: PlaybackOptions.Destination = .localAndRemote) async {
+    public func stop(destination: SoundPlaybackOptions.Destination = .localAndRemote) async {
         await SoundPlayer.shared.stop(self, destination: destination)
     }
 
@@ -109,7 +109,7 @@ public struct SoundHandle: Hashable, Sendable {
     }
 
     /// Returns `true` if this prepared sound has active playback for the selected destination.
-    public func isPlaying(destination: PlaybackOptions.Destination = .localAndRemote) async -> Bool {
+    public func isPlaying(destination: SoundPlaybackOptions.Destination = .localAndRemote) async -> Bool {
         await SoundPlayer.shared.isPlaying(self, destination: destination)
     }
 }
@@ -135,7 +135,7 @@ struct PreparedSound {
         remote.removeAll { !$0.isPlaying }
     }
 
-    mutating func stop(destination: PlaybackOptions.Destination) async {
+    mutating func stop(destination: SoundPlaybackOptions.Destination) async {
         switch destination {
         case .local:
             await Self.stop(&local)

--- a/Sources/LiveKit/Audio/SoundPlayer+Types.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer+Types.swift
@@ -31,9 +31,9 @@ public struct PlaybackOptions: Sendable {
         case concurrent
         /// Stop any existing playback of the same sound before playing.
         ///
-        /// Replacement is scoped by sound identifier, not by destination.
-        /// Existing local and remote playback for the same `id` are both stopped
-        /// before the new playback starts.
+        /// Replacement is scoped by prepared sound, not by destination. Existing
+        /// local and remote playback for the same handle are both stopped before
+        /// the new playback starts.
         case replace
     }
 

--- a/Sources/LiveKit/Audio/SoundPlayer+Types.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer+Types.swift
@@ -114,7 +114,8 @@ public struct SoundHandle: Hashable, Sendable {
     }
 }
 
-struct PreparedSound {
+@SoundPlayerActor
+class PreparedSound {
     let name: String?
     let sourceBuffer: AVAudioPCMBuffer
     let sessionRequirementHandle: SessionRequirementHandle
@@ -123,31 +124,28 @@ struct PreparedSound {
     var local: [SoundPlayback] = []
     var remote: [SoundPlayback] = []
 
-    private static func stop(_ playbacks: inout [SoundPlayback]) async {
-        for playback in playbacks {
-            await playback.stop()
-        }
-        playbacks.removeAll()
+    init(name: String?, sourceBuffer: AVAudioPCMBuffer, sessionRequirementHandle: SessionRequirementHandle) {
+        self.name = name
+        self.sourceBuffer = sourceBuffer
+        self.sessionRequirementHandle = sessionRequirementHandle
     }
 
-    mutating func cleanUp() {
+    func cleanUp() {
         local.removeAll { !$0.isPlaying }
         remote.removeAll { !$0.isPlaying }
     }
 
-    mutating func stop(destination: SoundPlaybackOptions.Destination) async {
-        switch destination {
-        case .local:
-            await Self.stop(&local)
-        case .remote:
-            await Self.stop(&remote)
-        case .localAndRemote:
-            await Self.stop(&local)
-            await Self.stop(&remote)
+    func stop(destination: SoundPlaybackOptions.Destination) async {
+        if destination.includesLocal {
+            for playback in local { await playback.stop() }
         }
+        if destination.includesRemote {
+            for playback in remote { await playback.stop() }
+        }
+        cleanUp()
     }
 
-    mutating func localBuffer(for playerNodeFormat: AVAudioFormat) throws -> AVAudioPCMBuffer {
+    func localBuffer(for playerNodeFormat: AVAudioFormat) throws -> AVAudioPCMBuffer {
         if let cachedLocalBuffer, let cachedLocalBufferFormat, cachedLocalBufferFormat == playerNodeFormat {
             return cachedLocalBuffer
         }

--- a/Sources/LiveKit/Audio/SoundPlayer+Types.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer+Types.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@preconcurrency import AVFAudio
 import Foundation
 
 @globalActor
@@ -74,30 +75,116 @@ public struct PlaybackOptions: Sendable {
 
 /// Typed reference to a prepared sound managed by ``SoundPlayer``.
 ///
-/// Handles are value types and do not own the underlying sound resource. They act as
-/// lightweight tokens that forward operations to ``SoundPlayer.shared``.
+/// `SoundHandle` is a value type, so it is safe to store in SwiftUI state, pass through
+/// view models, and copy. It does not own the underlying sound resource; call ``release()``
+/// when the prepared sound is no longer needed.
+///
+/// Use ``SoundPlayer/prepare(fileURL:named:)`` to create a handle. If a sound was prepared
+/// with a name, use ``SoundPlayer/sound(named:)`` to look up the current handle for that name.
 public struct SoundHandle: Hashable, Sendable {
     let id: UUID
 
+    /// Plays this prepared sound with the provided options.
     public func play(options: PlaybackOptions = PlaybackOptions()) async throws {
         try await SoundPlayer.shared.play(self, options: options)
     }
 
+    /// Stops active local and/or remote playback for this prepared sound.
     public func stop(destination: PlaybackOptions.Destination = .localAndRemote) async {
         await SoundPlayer.shared.stop(self, destination: destination)
     }
 
+    /// Releases this prepared sound and its audio session requirement.
+    ///
+    /// Other copies of the same handle become invalid after release.
     public func release() async {
         await SoundPlayer.shared.release(self)
     }
 
+    /// Returns `true` if this handle still refers to a prepared sound.
     public var isPrepared: Bool {
         get async {
             await SoundPlayer.shared.isPrepared(self)
         }
     }
 
+    /// Returns `true` if this prepared sound has active playback for the selected destination.
     public func isPlaying(destination: PlaybackOptions.Destination = .localAndRemote) async -> Bool {
         await SoundPlayer.shared.isPlaying(self, destination: destination)
+    }
+}
+
+struct PreparedSound {
+    let name: String?
+    let sourceBuffer: AVAudioPCMBuffer
+    let sessionRequirementHandle: SessionRequirementHandle
+    var cachedLocalBuffer: AVAudioPCMBuffer?
+    var cachedLocalBufferFormat: AVAudioFormat?
+    var local: [SoundPlayback] = []
+    var remote: [SoundPlayback] = []
+
+    private static func stop(_ playbacks: inout [SoundPlayback]) async {
+        for playback in playbacks {
+            await playback.stop()
+        }
+        playbacks.removeAll()
+    }
+
+    mutating func cleanUp() {
+        local.removeAll { !$0.isPlaying }
+        remote.removeAll { !$0.isPlaying }
+    }
+
+    mutating func stop(destination: PlaybackOptions.Destination) async {
+        switch destination {
+        case .local:
+            await Self.stop(&local)
+        case .remote:
+            await Self.stop(&remote)
+        case .localAndRemote:
+            await Self.stop(&local)
+            await Self.stop(&remote)
+        }
+    }
+
+    mutating func localBuffer(for playerNodeFormat: AVAudioFormat) throws -> AVAudioPCMBuffer {
+        if let cachedLocalBuffer, let cachedLocalBufferFormat, cachedLocalBufferFormat == playerNodeFormat {
+            return cachedLocalBuffer
+        }
+
+        let localBuffer: AVAudioPCMBuffer
+        if sourceBuffer.format == playerNodeFormat {
+            localBuffer = sourceBuffer
+        } else {
+            let outputBufferCapacity = AudioConverter.frameCapacity(from: sourceBuffer.format,
+                                                                    to: playerNodeFormat,
+                                                                    inputFrameCount: sourceBuffer.frameLength)
+            guard let converter = AudioConverter(from: sourceBuffer.format,
+                                                 to: playerNodeFormat,
+                                                 outputBufferCapacity: outputBufferCapacity)
+            else {
+                throw LiveKitError(.soundPlayer, message: "Failed to create audio converter")
+            }
+            localBuffer = converter.convert(from: sourceBuffer)
+        }
+
+        cachedLocalBuffer = localBuffer
+        cachedLocalBufferFormat = playerNodeFormat
+        return localBuffer
+    }
+}
+
+struct LocalEngineState {
+    var connectedOutputFormat: AVAudioFormat?
+    var playerNodeFormat: AVAudioFormat?
+    var needsReconnect = false
+
+    init(connectedOutputFormat: AVAudioFormat? = nil,
+         playerNodeFormat: AVAudioFormat? = nil,
+         needsReconnect: Bool = false)
+    {
+        self.connectedOutputFormat = connectedOutputFormat
+        self.playerNodeFormat = playerNodeFormat
+        self.needsReconnect = needsReconnect
     }
 }

--- a/Sources/LiveKit/Audio/SoundPlayer+Types.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer+Types.swift
@@ -137,10 +137,14 @@ class PreparedSound {
 
     func stop(destination: SoundPlaybackOptions.Destination) async {
         if destination.includesLocal {
-            for playback in local { await playback.stop() }
+            for playback in local {
+                await playback.stop()
+            }
         }
         if destination.includesRemote {
-            for playback in remote { await playback.stop() }
+            for playback in remote {
+                await playback.stop()
+            }
         }
         cleanUp()
     }

--- a/Sources/LiveKit/Audio/SoundPlayer+Types.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer+Types.swift
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@globalActor
+public actor SoundPlayerActor {
+    public static let shared = SoundPlayerActor()
+
+    private init() {}
+}
+
+/// Options for controlling sound playback behavior.
+public struct PlaybackOptions: Sendable {
+    /// How to handle existing playback of the same sound.
+    public enum Mode: Sendable {
+        /// Play concurrently with any existing playback of the same sound.
+        case concurrent
+        /// Stop any existing playback of the same sound before playing.
+        ///
+        /// Replacement is scoped by sound identifier, not by destination.
+        /// Existing local and remote playback for the same `id` are both stopped
+        /// before the new playback starts.
+        case replace
+    }
+
+    /// Where the sound should be played.
+    public enum Destination: Sendable {
+        /// Play locally only (through device speakers).
+        case local
+        /// Play for remote participants only (through WebRTC).
+        ///
+        /// Remote playback is best-effort. If the WebRTC mixer input path is unavailable
+        /// (for example, no active remote-routing path is connected), playback is skipped.
+        case remote
+        /// Play both locally and for remote participants.
+        ///
+        /// Remote playback is best-effort and may be skipped when the WebRTC mixer input path
+        /// is unavailable.
+        case localAndRemote
+
+        var includesLocal: Bool {
+            self == .local || self == .localAndRemote
+        }
+
+        var includesRemote: Bool {
+            self == .remote || self == .localAndRemote
+        }
+    }
+
+    public var mode: Mode
+    public var loop: Bool
+    public var destination: Destination
+
+    public init(mode: Mode = .concurrent, loop: Bool = false, destination: Destination = .localAndRemote) {
+        self.mode = mode
+        self.loop = loop
+        self.destination = destination
+    }
+}

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -16,62 +16,6 @@
 
 @preconcurrency import AVFAudio
 
-@globalActor
-public actor SoundPlayerActor {
-    public static let shared = SoundPlayerActor()
-
-    private init() {}
-}
-
-/// Options for controlling sound playback behavior.
-public struct PlaybackOptions: Sendable {
-    /// How to handle existing playback of the same sound.
-    public enum Mode: Sendable {
-        /// Play concurrently with any existing playback of the same sound.
-        case concurrent
-        /// Stop any existing playback of the same sound before playing.
-        ///
-        /// Replacement is scoped by sound identifier, not by destination.
-        /// Existing local and remote playback for the same `id` are both stopped
-        /// before the new playback starts.
-        case replace
-    }
-
-    /// Where the sound should be played.
-    public enum Destination: Sendable {
-        /// Play locally only (through device speakers).
-        case local
-        /// Play for remote participants only (through WebRTC).
-        ///
-        /// Remote playback is best-effort. If the WebRTC mixer input path is unavailable
-        /// (for example, no active remote-routing path is connected), playback is skipped.
-        case remote
-        /// Play both locally and for remote participants.
-        ///
-        /// Remote playback is best-effort and may be skipped when the WebRTC mixer input path
-        /// is unavailable.
-        case localAndRemote
-
-        var includesLocal: Bool {
-            self == .local || self == .localAndRemote
-        }
-
-        var includesRemote: Bool {
-            self == .remote || self == .localAndRemote
-        }
-    }
-
-    public var mode: Mode
-    public var loop: Bool
-    public var destination: Destination
-
-    public init(mode: Mode = .concurrent, loop: Bool = false, destination: Destination = .localAndRemote) {
-        self.mode = mode
-        self.loop = loop
-        self.destination = destination
-    }
-}
-
 /// High-level API for preparing and playing short sounds locally and over the room mixer.
 ///
 /// ```swift

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -16,6 +16,25 @@
 
 @preconcurrency import AVFAudio
 
+/// Options for controlling sound playback behavior.
+public struct PlaybackOptions: Sendable {
+    /// How to handle existing playback of the same sound.
+    public enum Mode: Sendable {
+        /// Play concurrently with any existing playback of the same sound.
+        case concurrent
+        /// Stop any existing playback of the same sound before playing.
+        case replace
+    }
+
+    public var mode: Mode
+    public var loop: Bool
+
+    public init(mode: Mode = .concurrent, loop: Bool = false) {
+        self.mode = mode
+        self.loop = loop
+    }
+}
+
 public class SoundPlayer: Loggable, @unchecked Sendable {
     // MARK: - Public
 
@@ -125,8 +144,12 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
         }
     }
 
-    public func play(id: String) throws {
+    public func play(id: String, options: PlaybackOptions = PlaybackOptions()) throws {
         try startIfNeeded()
+
+        if options.mode == .replace {
+            stop(id: id)
+        }
 
         guard let audioBuffer = _state.read(\.sounds[id]) else {
             throw LiveKitError(.audioEngine, message: "Sound not prepared")
@@ -154,7 +177,7 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
             bufferToSchedule = audioBuffer
         }
 
-        let playback = try playerNodePool.play(bufferToSchedule)
+        let playback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
         _state.mutate {
             // Clean up finished playbacks
             $0.activePlaybacks[id] = ($0.activePlaybacks[id] ?? []).filter { $0.isPlaying }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -207,7 +207,12 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
 
         // Play remotely through MixerEngineObserver's input path (WebRTC)
         if playRemote {
-            AudioManager.shared.mixer.playSound(audioBuffer, loop: options.loop)
+            if let playback = AudioManager.shared.mixer.playSound(audioBuffer, loop: options.loop) {
+                _state.mutate {
+                    $0.activePlaybacks[id] = ($0.activePlaybacks[id] ?? []).filter(\.isPlaying)
+                    $0.activePlaybacks[id, default: []].append(playback)
+                }
+            }
         }
     }
 }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -23,6 +23,10 @@ public struct PlaybackOptions: Sendable {
         /// Play concurrently with any existing playback of the same sound.
         case concurrent
         /// Stop any existing playback of the same sound before playing.
+        ///
+        /// Replacement is scoped by sound identifier, not by destination.
+        /// Existing local and remote playback for the same `id` are both stopped
+        /// before the new playback starts.
         case replace
     }
 
@@ -32,11 +36,13 @@ public struct PlaybackOptions: Sendable {
         case local
         /// Play for remote participants only (through WebRTC).
         ///
-        /// If remote routing is unavailable, playback is skipped.
+        /// Remote playback is best-effort. If the WebRTC mixer input path is unavailable
+        /// (for example, no active remote-routing path is connected), playback is skipped.
         case remote
         /// Play both locally and for remote participants.
         ///
-        /// Remote playback is best-effort and may be skipped if remote routing is unavailable.
+        /// Remote playback is best-effort and may be skipped when the WebRTC mixer input path
+        /// is unavailable.
         case localAndRemote
 
         var includesLocal: Bool {
@@ -62,15 +68,28 @@ public struct PlaybackOptions: Sendable {
 /// High-level API for preparing and playing short sounds locally and over the room mixer.
 ///
 /// ```swift
-/// try await SoundPlayer.shared.prepare(url: clickURL, withId: "click")
+/// try await SoundPlayer.shared.prepare(fileURL: clickFileURL, withId: "click")
 /// try await SoundPlayer.shared.play(id: "click")
+/// await SoundPlayer.shared.release(id: "click")
 /// ```
 ///
-/// Prepared sounds must come from local file URLs and use a format supported by `AVAudioFile`
+/// Prepared sounds must come from local file URLs and use a format readable by `AVAudioFile`
 /// on the current platform.
 ///
-/// Local playback uses a fixed internal player-node pool. If that pool is exhausted, `play(id:)`
-/// throws instead of silently dropping local playback.
+/// The recommended lifecycle for reusable clips is:
+/// 1. Prepare once with ``prepare(fileURL:withId:)``
+/// 2. Play one or more times with ``play(id:options:)``
+/// 3. Release with ``release(id:)`` when no longer needed
+///
+/// Preparing a sound acquires a playback session requirement and may start the local engine
+/// early to reduce first-play latency.
+///
+/// Local playback uses a fixed internal player-node pool. If that pool is exhausted,
+/// ``play(id:options:)`` throws instead of silently dropping local playback.
+///
+/// Remote playback is best-effort. It depends on the WebRTC mixer input path being available,
+/// which typically requires the microphone to be published. Local playback can still succeed
+/// even when remote playback is skipped.
 public actor SoundPlayer: Loggable {
     // MARK: - Public
 
@@ -173,13 +192,13 @@ public actor SoundPlayer: Loggable {
         return converter.convert(from: buffer)
     }
 
-    private nonisolated static func decodeBuffer(from url: URL) async throws -> AVAudioPCMBuffer {
-        guard url.isFileURL else {
+    private nonisolated static func decodeBuffer(from fileURL: URL) async throws -> AVAudioPCMBuffer {
+        guard fileURL.isFileURL else {
             throw LiveKitError(.invalidParameter, message: "Only file URLs are supported")
         }
 
         return try await Task.detached(priority: .userInitiated) {
-            let audioFile = try AVAudioFile(forReading: url)
+            let audioFile = try AVAudioFile(forReading: fileURL)
             guard let readBuffer = AVAudioPCMBuffer(pcmFormat: audioFile.processingFormat,
                                                     frameCapacity: AVAudioFrameCount(audioFile.length))
             else {
@@ -199,10 +218,12 @@ public actor SoundPlayer: Loggable {
     ///
     /// - Note: Only local file URLs are supported.
     /// - Note: The file format must be readable by `AVAudioFile` on the current platform.
-    public func prepare(url: URL, withId id: String) async throws {
+    /// - Note: Repeated playback of the same short clip should generally reuse a prepared sound
+    ///   instead of decoding from disk each time.
+    public func prepare(fileURL: URL, withId id: String) async throws {
         guard sounds[id] == nil else { return }
 
-        let readBuffer = try await Self.decodeBuffer(from: url)
+        let readBuffer = try await Self.decodeBuffer(from: fileURL)
         let sessionRequirementHandle = try AudioManager.shared.acquireSessionRequirement(.playbackOnly)
 
         do {
@@ -220,6 +241,8 @@ public actor SoundPlayer: Loggable {
     }
 
     /// Releases a prepared sound, stops any active playback, and relinquishes its session requirement.
+    ///
+    /// Releasing the last prepared sound also stops the local playback engine owned by `SoundPlayer`.
     public func release(id: String) async {
         guard var sound = sounds.removeValue(forKey: id) else { return }
         await sound.stop(destination: .localAndRemote)
@@ -267,7 +290,14 @@ public actor SoundPlayer: Loggable {
 
     /// Plays a prepared sound.
     ///
-    /// Remote playback is best-effort and is skipped if remote routing is unavailable.
+    /// Remote playback is best-effort and is skipped when the WebRTC mixer input path
+    /// is unavailable.
+    ///
+    /// When `options.mode` is `.replace`, any existing playback for the same `id`
+    /// is stopped for both local and remote destinations before the new playback starts.
+    ///
+    /// When `options.destination` includes `.localAndRemote`, local playback may still succeed
+    /// even if remote playback is skipped.
     ///
     /// - Throws: ``LiveKitError`` if the sound is not prepared, local playback setup fails,
     ///   or the local player-node pool is exhausted.

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -193,8 +193,8 @@ public final class SoundPlayer: Loggable {
         playerNodePool = AVAudioPlayerNodePool(poolSize: poolSize)
         engine.attach(playerNodePool)
         engineConfigurationObserver = notificationCenter.addObserver(forName: .AVAudioEngineConfigurationChange,
-                                                                    object: engine,
-                                                                    queue: nil)
+                                                                     object: engine,
+                                                                     queue: nil)
         { [weak self] _ in
             guard let self else { return }
             Task {

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -68,11 +68,20 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
             remote.removeAll { !$0.isPlaying }
         }
 
-        mutating func stopAll() {
-            for p in local { p.stop() }
-            for p in remote { p.stop() }
-            local.removeAll()
-            remote.removeAll()
+        mutating func stop(destination: PlaybackOptions.Destination) {
+            switch destination {
+            case .local:
+                for p in local { p.stop() }
+                local.removeAll()
+            case .remote:
+                for p in remote { p.stop() }
+                remote.removeAll()
+            case .localAndRemote:
+                for p in local { p.stop() }
+                for p in remote { p.stop() }
+                local.removeAll()
+                remote.removeAll()
+            }
         }
     }
 
@@ -159,7 +168,7 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
 
     public func release(id: String) {
         let (sound, shouldStop) = _state.mutate {
-            $0.sounds[id]?.stopAll()
+            $0.sounds[id]?.stop(destination: .localAndRemote)
             let sound = $0.sounds.removeValue(forKey: id)
             return (sound, $0.sounds.isEmpty)
         }
@@ -176,18 +185,18 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
     }
 
     /// Stops all playing or queued sounds without releasing prepared audio buffers.
-    public func stopAll() {
+    public func stopAll(destination: PlaybackOptions.Destination = .localAndRemote) {
         _state.mutate {
             for id in $0.sounds.keys {
-                $0.sounds[id]?.stopAll()
+                $0.sounds[id]?.stop(destination: destination)
             }
         }
     }
 
     /// Stops all playing or queued sounds for the specified id without releasing prepared audio buffers.
-    public func stop(id: String) {
+    public func stop(id: String, destination: PlaybackOptions.Destination = .localAndRemote) {
         _state.mutate {
-            $0.sounds[id]?.stopAll()
+            $0.sounds[id]?.stop(destination: destination)
         }
     }
 

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -131,6 +131,7 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
         guard let outputFormat else {
             throw LiveKitError(.audioEngine, message: "Invalid output format")
         }
+        playerNodePool.setMaximumFramesToRender(engine.outputNode.auAudioUnit.maximumFramesToRender)
         let playerNodeFormat = makePlayerNodeFormat(for: outputFormat)
         engine.connect(playerNodePool, to: engine.mainMixerNode,
                        format: outputFormat, playerNodeFormat: playerNodeFormat)

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -16,31 +16,94 @@
 
 @preconcurrency import AVFAudio
 
+private struct PreparedSound {
+    let name: String?
+    let sourceBuffer: AVAudioPCMBuffer
+    let sessionRequirementHandle: SessionRequirementHandle
+    var cachedLocalBuffer: AVAudioPCMBuffer?
+    var cachedLocalBufferFormat: AVAudioFormat?
+    var local: [SoundPlayback] = []
+    var remote: [SoundPlayback] = []
+
+    private static func stop(_ playbacks: inout [SoundPlayback]) async {
+        for playback in playbacks {
+            await playback.stop()
+        }
+        playbacks.removeAll()
+    }
+
+    mutating func cleanUp() {
+        local.removeAll { !$0.isPlaying }
+        remote.removeAll { !$0.isPlaying }
+    }
+
+    mutating func stop(destination: PlaybackOptions.Destination) async {
+        switch destination {
+        case .local:
+            await Self.stop(&local)
+        case .remote:
+            await Self.stop(&remote)
+        case .localAndRemote:
+            await Self.stop(&local)
+            await Self.stop(&remote)
+        }
+    }
+
+    mutating func localBuffer(for playerNodeFormat: AVAudioFormat) throws -> AVAudioPCMBuffer {
+        if let cachedLocalBuffer, let cachedLocalBufferFormat, cachedLocalBufferFormat == playerNodeFormat {
+            return cachedLocalBuffer
+        }
+
+        let localBuffer: AVAudioPCMBuffer
+        if sourceBuffer.format == playerNodeFormat {
+            localBuffer = sourceBuffer
+        } else {
+            let outputBufferCapacity = AudioConverter.frameCapacity(from: sourceBuffer.format,
+                                                                    to: playerNodeFormat,
+                                                                    inputFrameCount: sourceBuffer.frameLength)
+            guard let converter = AudioConverter(from: sourceBuffer.format,
+                                                 to: playerNodeFormat,
+                                                 outputBufferCapacity: outputBufferCapacity)
+            else {
+                throw LiveKitError(.audioEngine, message: "Failed to create audio converter")
+            }
+            localBuffer = converter.convert(from: sourceBuffer)
+        }
+
+        cachedLocalBuffer = localBuffer
+        cachedLocalBufferFormat = playerNodeFormat
+        return localBuffer
+    }
+}
+
+private struct LocalEngineState {
+    var connectedOutputFormat: AVAudioFormat?
+    var playerNodeFormat: AVAudioFormat?
+    var needsReconnect = false
+
+    init(connectedOutputFormat: AVAudioFormat? = nil,
+         playerNodeFormat: AVAudioFormat? = nil,
+         needsReconnect: Bool = false)
+    {
+        self.connectedOutputFormat = connectedOutputFormat
+        self.playerNodeFormat = playerNodeFormat
+        self.needsReconnect = needsReconnect
+    }
+}
+
 /// High-level API for preparing and playing short sounds locally and over the room mixer.
 ///
 /// ```swift
-/// try await SoundPlayer.shared.prepare(fileURL: clickFileURL, withId: "click")
-/// try await SoundPlayer.shared.play(id: "click")
-/// await SoundPlayer.shared.release(id: "click")
+/// let click = try await SoundPlayer.shared.prepare(fileURL: clickFileURL, named: "click")
+/// try await click.play()
+/// await click.release()
 /// ```
 ///
-/// Prepared sounds must come from local file URLs and use a format readable by `AVAudioFile`
-/// on the current platform.
-///
-/// The recommended lifecycle for reusable clips is:
-/// 1. Prepare once with ``prepare(fileURL:withId:)``
-/// 2. Play one or more times with ``play(id:options:)``
-/// 3. Release with ``release(id:)`` when no longer needed
-///
-/// Preparing a sound acquires a playback session requirement and may start the local engine
-/// early to reduce first-play latency.
-///
-/// Local playback uses a fixed internal player-node pool. If that pool is exhausted,
-/// ``play(id:options:)`` throws instead of silently dropping local playback.
-///
-/// Remote playback is best-effort. It depends on the WebRTC mixer input path being available,
-/// which typically requires the microphone to be published. Local playback can still succeed
-/// even when remote playback is skipped.
+/// Prepared sounds must come from local file URLs and use a format readable by `AVAudioFile`.
+/// Recommended lifecycle: prepare once, play as needed, then release.
+/// Preparing a sound acquires a playback session requirement and may start the local engine early.
+/// Local playback uses a fixed internal player-node pool and throws if the pool is exhausted.
+/// Remote playback is best-effort and typically requires the microphone to be published.
 @SoundPlayerActor
 public final class SoundPlayer: Loggable {
     // MARK: - Public
@@ -55,81 +118,8 @@ public final class SoundPlayer: Loggable {
     private let notificationCenter: NotificationCenter
     private var engineConfigurationObserver: NSObjectProtocol?
 
-    private struct Sound {
-        let sourceBuffer: AVAudioPCMBuffer
-        let sessionRequirementHandle: SessionRequirementHandle
-        var cachedLocalBuffer: AVAudioPCMBuffer?
-        var cachedLocalBufferFormat: AVAudioFormat?
-        var local: [SoundPlayback] = []
-        var remote: [SoundPlayback] = []
-
-        private static func stop(_ playbacks: inout [SoundPlayback]) async {
-            for playback in playbacks {
-                await playback.stop()
-            }
-            playbacks.removeAll()
-        }
-
-        mutating func cleanUp() {
-            local.removeAll { !$0.isPlaying }
-            remote.removeAll { !$0.isPlaying }
-        }
-
-        mutating func stop(destination: PlaybackOptions.Destination) async {
-            switch destination {
-            case .local:
-                await Self.stop(&local)
-            case .remote:
-                await Self.stop(&remote)
-            case .localAndRemote:
-                await Self.stop(&local)
-                await Self.stop(&remote)
-            }
-        }
-
-        mutating func localBuffer(for playerNodeFormat: AVAudioFormat) throws -> AVAudioPCMBuffer {
-            if let cachedLocalBuffer, let cachedLocalBufferFormat, cachedLocalBufferFormat == playerNodeFormat {
-                return cachedLocalBuffer
-            }
-
-            let localBuffer: AVAudioPCMBuffer
-            if sourceBuffer.format == playerNodeFormat {
-                localBuffer = sourceBuffer
-            } else {
-                let outputBufferCapacity = AudioConverter.frameCapacity(from: sourceBuffer.format,
-                                                                        to: playerNodeFormat,
-                                                                        inputFrameCount: sourceBuffer.frameLength)
-                guard let converter = AudioConverter(from: sourceBuffer.format,
-                                                     to: playerNodeFormat,
-                                                     outputBufferCapacity: outputBufferCapacity)
-                else {
-                    throw LiveKitError(.audioEngine, message: "Failed to create audio converter")
-                }
-                localBuffer = converter.convert(from: sourceBuffer)
-            }
-
-            cachedLocalBuffer = localBuffer
-            cachedLocalBufferFormat = playerNodeFormat
-            return localBuffer
-        }
-    }
-
-    private struct LocalEngineState {
-        var connectedOutputFormat: AVAudioFormat?
-        var playerNodeFormat: AVAudioFormat?
-        var needsReconnect = false
-
-        init(connectedOutputFormat: AVAudioFormat? = nil,
-             playerNodeFormat: AVAudioFormat? = nil,
-             needsReconnect: Bool = false)
-        {
-            self.connectedOutputFormat = connectedOutputFormat
-            self.playerNodeFormat = playerNodeFormat
-            self.needsReconnect = needsReconnect
-        }
-    }
-
-    private var sounds: [String: Sound] = [:]
+    private var sounds: [UUID: PreparedSound] = [:]
+    private var soundIDsByName: [String: UUID] = [:]
     private var localEngineState = LocalEngineState()
 
     init(poolSize: Int = 10, notificationCenter: NotificationCenter = .default) {
@@ -153,46 +143,189 @@ public final class SoundPlayer: Loggable {
         }
     }
 
-    // MARK: - Engine lifecycle
+    // MARK: - Public API
 
-    private var outputFormat: AVAudioFormat? {
+    /// Decodes and caches audio, optionally associating it with a unique name.
+    ///
+    /// Preparing a sound also acquires a playback session requirement and starts the
+    /// local engine early to reduce first-play latency.
+    ///
+    /// If `name` is provided and another prepared sound already uses the same name,
+    /// the previous sound is stopped, released, and replaced.
+    ///
+    /// - Note: Only local file URLs are supported.
+    /// - Note: The file format must be readable by `AVAudioFile` on the current platform.
+    /// - Note: Repeated playback of the same short clip should generally reuse a prepared sound
+    ///   instead of decoding from disk each time.
+    @discardableResult
+    public func prepare(fileURL: URL, named name: String? = nil) async throws -> SoundHandle {
+        let readBuffer = try await Self.decodeBuffer(from: fileURL)
+        let sessionRequirementHandle = try AudioManager.shared.acquireSessionRequirement(.playbackOnly)
+        let soundID = UUID()
+        let replacedSoundID = name.flatMap { soundIDsByName[$0] }
+
+        do {
+            _ = try startIfNeeded()
+            sounds[soundID] = PreparedSound(name: name,
+                                            sourceBuffer: readBuffer,
+                                            sessionRequirementHandle: sessionRequirementHandle)
+            if let name {
+                soundIDsByName[name] = soundID
+            }
+
+            if let replacedSoundID {
+                await releaseSound(id: replacedSoundID)
+            }
+
+            return SoundHandle(id: soundID)
+        } catch {
+            try? sessionRequirementHandle.release()
+            throw error
+        }
+    }
+
+    /// Returns the prepared sound currently associated with `name`, if any.
+    public func sound(named name: String) -> SoundHandle? {
+        guard let soundID = soundIDsByName[name], sounds[soundID] != nil else { return nil }
+        return SoundHandle(id: soundID)
+    }
+
+    /// Releases a prepared sound, stops any active playback, and relinquishes its session requirement.
+    ///
+    /// Releasing the last prepared sound also stops the local playback engine owned by `SoundPlayer`.
+    public func release(_ sound: SoundHandle) async {
+        await releaseSound(id: sound.id)
+    }
+
+    /// Returns `true` if the handle still refers to a prepared sound.
+    public func isPrepared(_ sound: SoundHandle) -> Bool {
+        sounds[sound.id] != nil
+    }
+
+    /// Returns `true` if the sound currently has active playback for the selected destination.
+    public func isPlaying(_ sound: SoundHandle, destination: PlaybackOptions.Destination = .localAndRemote) -> Bool {
+        guard let sound = sounds[sound.id] else { return false }
+        switch destination {
+        case .local:
+            return sound.local.contains(where: \.isPlaying)
+        case .remote:
+            return sound.remote.contains(where: \.isPlaying)
+        case .localAndRemote:
+            return sound.local.contains(where: \.isPlaying) || sound.remote.contains(where: \.isPlaying)
+        }
+    }
+
+    /// Stops all playing or queued sounds without releasing prepared audio buffers.
+    public func stopAll(destination: PlaybackOptions.Destination = .localAndRemote) async {
+        for soundID in sounds.keys {
+            if var sound = sounds[soundID] {
+                await sound.stop(destination: destination)
+                sounds[soundID] = sound
+            }
+        }
+    }
+
+    /// Stops all playing or queued instances of a prepared sound without releasing its buffer.
+    public func stop(_ sound: SoundHandle, destination: PlaybackOptions.Destination = .localAndRemote) async {
+        guard var soundState = sounds[sound.id] else { return }
+        await soundState.stop(destination: destination)
+        sounds[sound.id] = soundState
+    }
+
+    /// Stops all playing or queued sounds associated with the given name without releasing the prepared buffer.
+    public func stop(named name: String, destination: PlaybackOptions.Destination = .localAndRemote) async {
+        guard let sound = sound(named: name) else { return }
+        await sound.stop(destination: destination)
+    }
+
+    /// Plays a prepared sound.
+    ///
+    /// Remote playback is best-effort and is skipped when the WebRTC mixer input path
+    /// is unavailable.
+    ///
+    /// When `options.mode` is `.replace`, any existing playback for the same prepared sound
+    /// is stopped for both local and remote destinations before the new playback starts.
+    ///
+    /// When `options.destination` includes `.localAndRemote`, local playback may still succeed
+    /// even if remote playback is skipped.
+    ///
+    /// - Throws: ``LiveKitError`` if the sound is not prepared, local playback setup fails,
+    ///   or the local player-node pool is exhausted.
+    public func play(_ sound: SoundHandle, options: PlaybackOptions = PlaybackOptions()) async throws {
+        guard var soundState = sounds[sound.id] else {
+            throw LiveKitError(.audioEngine, message: "Sound not prepared")
+        }
+
+        if options.mode == .replace {
+            await soundState.stop(destination: .localAndRemote)
+        }
+
+        soundState.cleanUp()
+
+        var localPlayback: SoundPlayback?
+        var remotePlayback: SoundPlayback?
+
+        if options.destination.includesLocal {
+            let playerNodeFormat = try startIfNeeded()
+            let bufferToSchedule = try soundState.localBuffer(for: playerNodeFormat)
+            localPlayback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
+        }
+
+        if options.destination.includesRemote {
+            remotePlayback = AudioManager.shared.mixer.playSound(soundState.sourceBuffer, loop: options.loop)
+        }
+
+        if let localPlayback {
+            soundState.local.append(localPlayback)
+        }
+
+        if let remotePlayback {
+            soundState.remote.append(remotePlayback)
+        }
+
+        sounds[sound.id] = soundState
+    }
+}
+
+private extension SoundPlayer {
+    var outputFormat: AVAudioFormat? {
         let format = engine.outputNode.outputFormat(forBus: 0)
         guard format.channelCount > 0 else { return nil }
         return format
     }
 
-    private func makePlayerNodeFormat(for outputFormat: AVAudioFormat) -> AVAudioFormat {
+    func makePlayerNodeFormat(for outputFormat: AVAudioFormat) -> AVAudioFormat {
         AVAudioFormat(commonFormat: .pcmFormatFloat32,
                       sampleRate: outputFormat.sampleRate,
                       channels: outputFormat.channelCount,
                       interleaved: outputFormat.isInterleaved)!
     }
 
-    private func resetLocalEngineState(needsReconnect: Bool) {
+    func resetLocalEngineState(needsReconnect: Bool) {
         localEngineState = LocalEngineState(needsReconnect: needsReconnect)
     }
 
-    private func invalidateCachedLocalBuffers() {
-        for id in Array(sounds.keys) {
-            guard var sound = sounds[id] else { continue }
+    func invalidateCachedLocalBuffers() {
+        for soundID in Array(sounds.keys) {
+            guard var sound = sounds[soundID] else { continue }
             sound.cachedLocalBuffer = nil
             sound.cachedLocalBufferFormat = nil
             sound.local.removeAll()
-            sounds[id] = sound
+            sounds[soundID] = sound
         }
     }
 
-    private func invalidateLocalState() {
+    func invalidateLocalState() {
         resetLocalEngineState(needsReconnect: true)
         playerNodePool.reset()
         invalidateCachedLocalBuffers()
     }
 
-    private func handleEngineConfigurationChange() {
+    func handleEngineConfigurationChange() {
         invalidateLocalState()
     }
 
-    private func reconnectEngine(outputFormat: AVAudioFormat, playerNodeFormat: AVAudioFormat) throws {
+    func reconnectEngine(outputFormat: AVAudioFormat, playerNodeFormat: AVAudioFormat) throws {
         playerNodePool.stop()
         engine.stop()
         engine.disconnect(playerNodePool)
@@ -205,7 +338,7 @@ public final class SoundPlayer: Loggable {
         localEngineState.needsReconnect = false
     }
 
-    private func startIfNeeded() throws -> AVAudioFormat {
+    func startIfNeeded() throws -> AVAudioFormat {
         guard let outputFormat else {
             throw LiveKitError(.audioEngine, message: "Invalid output format")
         }
@@ -222,13 +355,28 @@ public final class SoundPlayer: Loggable {
         return playerNodeFormat
     }
 
-    private func stopEngine() {
+    func stopEngine() {
         resetLocalEngineState(needsReconnect: false)
         playerNodePool.stop()
         engine.stop()
     }
 
-    private nonisolated static func decodeBuffer(from fileURL: URL) async throws -> AVAudioPCMBuffer {
+    func releaseSound(id soundID: UUID) async {
+        guard var sound = sounds.removeValue(forKey: soundID) else { return }
+
+        if let name = sound.name, soundIDsByName[name] == soundID {
+            soundIDsByName.removeValue(forKey: name)
+        }
+
+        await sound.stop(destination: .localAndRemote)
+        if sounds.isEmpty {
+            stopEngine()
+        }
+
+        try? sound.sessionRequirementHandle.release()
+    }
+
+    static func decodeBuffer(from fileURL: URL) async throws -> AVAudioPCMBuffer {
         guard fileURL.isFileURL else {
             throw LiveKitError(.invalidParameter, message: "Only file URLs are supported")
         }
@@ -243,132 +391,5 @@ public final class SoundPlayer: Loggable {
             try audioFile.read(into: readBuffer, frameCount: AVAudioFrameCount(audioFile.length))
             return readBuffer
         }.value
-    }
-
-    // MARK: - Public API
-
-    /// Decodes and caches audio for the given identifier.
-    ///
-    /// Preparing a sound also acquires a playback session requirement and starts the
-    /// local engine early to reduce first-play latency.
-    ///
-    /// - Note: Only local file URLs are supported.
-    /// - Note: The file format must be readable by `AVAudioFile` on the current platform.
-    /// - Note: Repeated playback of the same short clip should generally reuse a prepared sound
-    ///   instead of decoding from disk each time.
-    public func prepare(fileURL: URL, withId id: String) async throws {
-        guard sounds[id] == nil else { return }
-
-        let readBuffer = try await Self.decodeBuffer(from: fileURL)
-        let sessionRequirementHandle = try AudioManager.shared.acquireSessionRequirement(.playbackOnly)
-
-        do {
-            guard sounds[id] == nil else {
-                try? sessionRequirementHandle.release()
-                return
-            }
-
-            _ = try startIfNeeded()
-            sounds[id] = Sound(sourceBuffer: readBuffer, sessionRequirementHandle: sessionRequirementHandle)
-        } catch {
-            try? sessionRequirementHandle.release()
-            throw error
-        }
-    }
-
-    /// Releases a prepared sound, stops any active playback, and relinquishes its session requirement.
-    ///
-    /// Releasing the last prepared sound also stops the local playback engine owned by `SoundPlayer`.
-    public func release(id: String) async {
-        guard var sound = sounds.removeValue(forKey: id) else { return }
-        await sound.stop(destination: .localAndRemote)
-        if sounds.isEmpty {
-            stopEngine()
-        }
-
-        try? sound.sessionRequirementHandle.release()
-    }
-
-    /// Returns `true` if a sound has been prepared for the given identifier.
-    public func isPrepared(id: String) -> Bool {
-        sounds[id] != nil
-    }
-
-    /// Returns `true` if the sound currently has active playback for the selected destination.
-    public func isPlaying(id: String, destination: PlaybackOptions.Destination = .localAndRemote) -> Bool {
-        guard let sound = sounds[id] else { return false }
-        switch destination {
-        case .local:
-            return sound.local.contains(where: \.isPlaying)
-        case .remote:
-            return sound.remote.contains(where: \.isPlaying)
-        case .localAndRemote:
-            return sound.local.contains(where: \.isPlaying) || sound.remote.contains(where: \.isPlaying)
-        }
-    }
-
-    /// Stops all playing or queued sounds without releasing prepared audio buffers.
-    public func stopAll(destination: PlaybackOptions.Destination = .localAndRemote) async {
-        for id in sounds.keys {
-            if var sound = sounds[id] {
-                await sound.stop(destination: destination)
-                sounds[id] = sound
-            }
-        }
-    }
-
-    /// Stops all playing or queued sounds for the specified id without releasing prepared audio buffers.
-    public func stop(id: String, destination: PlaybackOptions.Destination = .localAndRemote) async {
-        guard var sound = sounds[id] else { return }
-        await sound.stop(destination: destination)
-        sounds[id] = sound
-    }
-
-    /// Plays a prepared sound.
-    ///
-    /// Remote playback is best-effort and is skipped when the WebRTC mixer input path
-    /// is unavailable.
-    ///
-    /// When `options.mode` is `.replace`, any existing playback for the same `id`
-    /// is stopped for both local and remote destinations before the new playback starts.
-    ///
-    /// When `options.destination` includes `.localAndRemote`, local playback may still succeed
-    /// even if remote playback is skipped.
-    ///
-    /// - Throws: ``LiveKitError`` if the sound is not prepared, local playback setup fails,
-    ///   or the local player-node pool is exhausted.
-    public func play(id: String, options: PlaybackOptions = PlaybackOptions()) async throws {
-        guard var sound = sounds[id] else {
-            throw LiveKitError(.audioEngine, message: "Sound not prepared")
-        }
-
-        if options.mode == .replace {
-            await sound.stop(destination: .localAndRemote)
-        }
-
-        sound.cleanUp()
-
-        var localPlayback: SoundPlayback?
-        var remotePlayback: SoundPlayback?
-
-        if options.destination.includesLocal {
-            let playerNodeFormat = try startIfNeeded()
-            let bufferToSchedule = try sound.localBuffer(for: playerNodeFormat)
-            localPlayback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
-        }
-
-        if options.destination.includesRemote {
-            remotePlayback = AudioManager.shared.mixer.playSound(sound.sourceBuffer, loop: options.loop)
-        }
-
-        if let localPlayback {
-            sound.local.append(localPlayback)
-        }
-
-        if let remotePlayback {
-            sound.remote.append(remotePlayback)
-        }
-
-        sounds[id] = sound
     }
 }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -51,7 +51,7 @@ public struct PlaybackOptions: Sendable {
     }
 }
 
-public class SoundPlayer: Loggable, @unchecked Sendable {
+public actor SoundPlayer: Loggable {
     // MARK: - Public
 
     public static let shared = SoundPlayer()
@@ -97,12 +97,8 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
         }
     }
 
-    private struct State {
-        var sounds: [String: Sound] = [:]
-        var playerNodeFormat: AVAudioFormat?
-    }
-
-    private let _state = StateSync(State())
+    private var sounds: [String: Sound] = [:]
+    private var playerNodeFormat: AVAudioFormat?
 
     init(poolSize: Int = 10) {
         playerNodePool = AVAudioPlayerNodePool(poolSize: poolSize)
@@ -124,8 +120,8 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
                       interleaved: outputFormat.isInterleaved)!
     }
 
-    private func startIfNeeded(state: inout State) throws -> AVAudioFormat {
-        if engine.isRunning, let playerNodeFormat = state.playerNodeFormat {
+    private func startIfNeeded() throws -> AVAudioFormat {
+        if engine.isRunning, let playerNodeFormat {
             return playerNodeFormat
         }
         guard let outputFormat else {
@@ -136,12 +132,12 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
         engine.connect(playerNodePool, to: engine.mainMixerNode,
                        format: outputFormat, playerNodeFormat: playerNodeFormat)
         try engine.start()
-        state.playerNodeFormat = playerNodeFormat
+        self.playerNodeFormat = playerNodeFormat
         return playerNodeFormat
     }
 
-    private func stopEngine(state: inout State) {
-        state.playerNodeFormat = nil
+    private func stopEngine() {
+        playerNodeFormat = nil
         playerNodePool.stop()
         engine.stop()
     }
@@ -161,45 +157,49 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
         return converter.convert(from: buffer)
     }
 
+    private nonisolated static func decodeBuffer(from url: URL) async throws -> AVAudioPCMBuffer {
+        guard url.isFileURL else {
+            throw LiveKitError(.invalidParameter, message: "Only file URLs are supported")
+        }
+
+        return try await Task.detached(priority: .userInitiated) {
+            let audioFile = try AVAudioFile(forReading: url)
+            guard let readBuffer = AVAudioPCMBuffer(pcmFormat: audioFile.processingFormat,
+                                                    frameCapacity: AVAudioFrameCount(audioFile.length))
+            else {
+                throw LiveKitError(.audioEngine, message: "Failed to allocate audio buffer")
+            }
+            try audioFile.read(into: readBuffer, frameCount: AVAudioFrameCount(audioFile.length))
+            return readBuffer
+        }.value
+    }
+
     // MARK: - Public API
 
     /// Decodes and caches audio for the given identifier.
     ///
     /// Preparing a sound also acquires a playback session requirement and starts the
     /// local engine early to reduce first-play latency.
-    public func prepare(url: URL, withId id: String) throws {
-        // Already prepared, ignore.
-        guard _state.read({ $0.sounds[id] }) == nil else { return }
+    public func prepare(url: URL, withId id: String) async throws {
+        guard sounds[id] == nil else { return }
 
-        // Read audio file into raw PCM buffer.
-        let audioFile = try AVAudioFile(forReading: url)
-        guard let readBuffer = AVAudioPCMBuffer(pcmFormat: audioFile.processingFormat,
-                                                frameCapacity: AVAudioFrameCount(audioFile.length))
-        else {
-            throw LiveKitError(.audioEngine, message: "Failed to allocate audio buffer")
-        }
-        try audioFile.read(into: readBuffer, frameCount: AVAudioFrameCount(audioFile.length))
+        let readBuffer = try await Self.decodeBuffer(from: url)
 
-        // Acquire session requirement before starting engine.
         let requirementId = UUID()
         #if os(iOS) || os(visionOS) || os(tvOS)
         try AudioManager.shared.audioSession.set(requirement: .playbackOnly, for: requirementId)
         #endif
 
         do {
-            let wasAlreadyPrepared = try _state.mutate { state in
-                guard state.sounds[id] == nil else { return true }
-                _ = try startIfNeeded(state: &state)
-                state.sounds[id] = Sound(buffer: readBuffer, sessionRequirementId: requirementId)
-                return false
-            }
-
-            guard !wasAlreadyPrepared else {
+            guard sounds[id] == nil else {
                 #if os(iOS) || os(visionOS) || os(tvOS)
                 try? AudioManager.shared.audioSession.removeRequirement(for: requirementId)
                 #endif
                 return
             }
+
+            _ = try startIfNeeded()
+            sounds[id] = Sound(buffer: readBuffer, sessionRequirementId: requirementId)
         } catch {
             #if os(iOS) || os(visionOS) || os(tvOS)
             try? AudioManager.shared.audioSession.removeRequirement(for: requirementId)
@@ -210,56 +210,45 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
 
     /// Releases a prepared sound, stops any active playback, and relinquishes its session requirement.
     public func release(id: String) {
-        let sound = _state.mutate { state -> Sound? in
-            guard var sound = state.sounds.removeValue(forKey: id) else { return nil }
-            sound.stop(destination: .localAndRemote)
-            if state.sounds.isEmpty {
-                stopEngine(state: &state)
-            }
-            return sound
+        guard var sound = sounds.removeValue(forKey: id) else { return }
+        sound.stop(destination: .localAndRemote)
+        if sounds.isEmpty {
+            stopEngine()
         }
 
         #if os(iOS) || os(visionOS) || os(tvOS)
-        if let sound {
-            try? AudioManager.shared.audioSession.removeRequirement(for: sound.sessionRequirementId)
-        }
+        try? AudioManager.shared.audioSession.removeRequirement(for: sound.sessionRequirementId)
         #endif
     }
 
     /// Returns `true` if a sound has been prepared for the given identifier.
     public func isPrepared(id: String) -> Bool {
-        _state.read { $0.sounds[id] != nil }
+        sounds[id] != nil
     }
 
     /// Returns `true` if the sound currently has active playback for the selected destination.
     public func isPlaying(id: String, destination: PlaybackOptions.Destination = .localAndRemote) -> Bool {
-        _state.read { state in
-            guard let sound = state.sounds[id] else { return false }
-            switch destination {
-            case .local:
-                return sound.local.contains(where: \.isPlaying)
-            case .remote:
-                return sound.remote.contains(where: \.isPlaying)
-            case .localAndRemote:
-                return sound.local.contains(where: \.isPlaying) || sound.remote.contains(where: \.isPlaying)
-            }
+        guard let sound = sounds[id] else { return false }
+        switch destination {
+        case .local:
+            return sound.local.contains(where: \.isPlaying)
+        case .remote:
+            return sound.remote.contains(where: \.isPlaying)
+        case .localAndRemote:
+            return sound.local.contains(where: \.isPlaying) || sound.remote.contains(where: \.isPlaying)
         }
     }
 
     /// Stops all playing or queued sounds without releasing prepared audio buffers.
     public func stopAll(destination: PlaybackOptions.Destination = .localAndRemote) {
-        _state.mutate { state in
-            for id in state.sounds.keys {
-                state.sounds[id]?.stop(destination: destination)
-            }
+        for id in sounds.keys {
+            sounds[id]?.stop(destination: destination)
         }
     }
 
     /// Stops all playing or queued sounds for the specified id without releasing prepared audio buffers.
     public func stop(id: String, destination: PlaybackOptions.Destination = .localAndRemote) {
-        _state.mutate { state in
-            state.sounds[id]?.stop(destination: destination)
-        }
+        sounds[id]?.stop(destination: destination)
     }
 
     /// Plays a prepared sound.
@@ -271,39 +260,37 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
         let playLocal = options.destination == .local || options.destination == .localAndRemote
         let playRemote = options.destination == .remote || options.destination == .localAndRemote
 
-        try _state.mutate { state in
-            guard var sound = state.sounds[id] else {
-                throw LiveKitError(.audioEngine, message: "Sound not prepared")
-            }
-
-            if options.mode == .replace {
-                sound.stop(destination: .localAndRemote)
-            }
-
-            sound.cleanUp()
-
-            var localPlayback: SoundPlayback?
-            var remotePlayback: SoundPlayback?
-
-            if playLocal {
-                let playerNodeFormat = try startIfNeeded(state: &state)
-                let bufferToSchedule = try convertBuffer(sound.buffer, to: playerNodeFormat)
-                localPlayback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
-            }
-
-            if playRemote {
-                remotePlayback = AudioManager.shared.mixer.playSound(sound.buffer, loop: options.loop)
-            }
-
-            if let localPlayback {
-                sound.local.append(localPlayback)
-            }
-
-            if let remotePlayback {
-                sound.remote.append(remotePlayback)
-            }
-
-            state.sounds[id] = sound
+        guard var sound = sounds[id] else {
+            throw LiveKitError(.audioEngine, message: "Sound not prepared")
         }
+
+        if options.mode == .replace {
+            sound.stop(destination: .localAndRemote)
+        }
+
+        sound.cleanUp()
+
+        var localPlayback: SoundPlayback?
+        var remotePlayback: SoundPlayback?
+
+        if playLocal {
+            let playerNodeFormat = try startIfNeeded()
+            let bufferToSchedule = try convertBuffer(sound.buffer, to: playerNodeFormat)
+            localPlayback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
+        }
+
+        if playRemote {
+            remotePlayback = AudioManager.shared.mixer.playSound(sound.buffer, loop: options.loop)
+        }
+
+        if let localPlayback {
+            sound.local.append(localPlayback)
+        }
+
+        if let remotePlayback {
+            sound.remote.append(remotePlayback)
+        }
+
+        sounds[id] = sound
     }
 }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -108,6 +108,8 @@ public final class SoundPlayer: Loggable {
 
     private let engine = AVAudioEngine()
     private let playerNodePool: AVAudioPlayerNodePool
+    private let notificationCenter: NotificationCenter
+    private var engineConfigurationObserver: NSObjectProtocol?
 
     private struct Sound {
         let sourceBuffer: AVAudioPCMBuffer
@@ -169,11 +171,29 @@ public final class SoundPlayer: Loggable {
     }
 
     private var sounds: [String: Sound] = [:]
+    private var connectedOutputFormat: AVAudioFormat?
     private var playerNodeFormat: AVAudioFormat?
+    private var engineNeedsReconnect = false
 
-    init(poolSize: Int = 10) {
+    init(poolSize: Int = 10, notificationCenter: NotificationCenter = .default) {
+        self.notificationCenter = notificationCenter
         playerNodePool = AVAudioPlayerNodePool(poolSize: poolSize)
         engine.attach(playerNodePool)
+        engineConfigurationObserver = notificationCenter.addObserver(forName: .AVAudioEngineConfigurationChange,
+                                                                    object: engine,
+                                                                    queue: nil)
+        { [weak self] _ in
+            guard let self else { return }
+            Task {
+                await self.handleEngineConfigurationChange()
+            }
+        }
+    }
+
+    deinit {
+        if let engineConfigurationObserver {
+            notificationCenter.removeObserver(engineConfigurationObserver)
+        }
     }
 
     // MARK: - Engine lifecycle
@@ -191,24 +211,59 @@ public final class SoundPlayer: Loggable {
                       interleaved: outputFormat.isInterleaved)!
     }
 
-    private func startIfNeeded() throws -> AVAudioFormat {
-        if engine.isRunning, let playerNodeFormat {
-            return playerNodeFormat
+    private func invalidateLocalState() {
+        connectedOutputFormat = nil
+        playerNodeFormat = nil
+        engineNeedsReconnect = true
+        playerNodePool.reset()
+
+        for id in Array(sounds.keys) {
+            guard var sound = sounds[id] else { continue }
+            sound.cachedLocalBuffer = nil
+            sound.cachedLocalBufferFormat = nil
+            sound.local.removeAll()
+            sounds[id] = sound
         }
-        guard let outputFormat else {
-            throw LiveKitError(.audioEngine, message: "Invalid output format")
-        }
+    }
+
+    private func handleEngineConfigurationChange() {
+        invalidateLocalState()
+    }
+
+    private func reconnectEngine(outputFormat: AVAudioFormat, playerNodeFormat: AVAudioFormat) throws {
+        playerNodePool.stop()
+        engine.stop()
+        engine.disconnect(playerNodePool)
         playerNodePool.setMaximumFramesToRender(engine.outputNode.auAudioUnit.maximumFramesToRender)
-        let playerNodeFormat = makePlayerNodeFormat(for: outputFormat)
         engine.connect(playerNodePool, to: engine.mainMixerNode,
                        format: outputFormat, playerNodeFormat: playerNodeFormat)
         try engine.start()
+        connectedOutputFormat = outputFormat
         self.playerNodeFormat = playerNodeFormat
+        engineNeedsReconnect = false
+    }
+
+    private func startIfNeeded() throws -> AVAudioFormat {
+        guard let outputFormat else {
+            throw LiveKitError(.audioEngine, message: "Invalid output format")
+        }
+        let playerNodeFormat = makePlayerNodeFormat(for: outputFormat)
+        let needsReconnect = engineNeedsReconnect
+            || !engine.isRunning
+            || connectedOutputFormat != outputFormat
+            || self.playerNodeFormat != playerNodeFormat
+
+        if needsReconnect {
+            try reconnectEngine(outputFormat: outputFormat, playerNodeFormat: playerNodeFormat)
+        }
+
         return playerNodeFormat
     }
 
     private func stopEngine() {
+        connectedOutputFormat = nil
         playerNodeFormat = nil
+        engineNeedsReconnect = false
         playerNodePool.stop()
         engine.stop()
     }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -165,7 +165,7 @@ public final class SoundPlayer: Loggable {
         let replacedSoundID = name.flatMap { soundIDsByName[$0] }
 
         do {
-            _ = try startIfNeeded()
+            try startEngineIfNeeded()
             sounds[soundID] = PreparedSound(name: name,
                                             sourceBuffer: readBuffer,
                                             sessionRequirementHandle: sessionRequirementHandle)
@@ -217,7 +217,7 @@ public final class SoundPlayer: Loggable {
 
     /// Stops all playing or queued sounds without releasing prepared audio buffers.
     public func stopAll(destination: PlaybackOptions.Destination = .localAndRemote) async {
-        for soundID in sounds.keys {
+        for soundID in Array(sounds.keys) {
             if var sound = sounds[soundID] {
                 await sound.stop(destination: destination)
                 sounds[soundID] = sound
@@ -266,7 +266,7 @@ public final class SoundPlayer: Loggable {
         var remotePlayback: SoundPlayback?
 
         if options.destination.includesLocal {
-            let playerNodeFormat = try startIfNeeded()
+            let playerNodeFormat = try startEngineIfNeeded()
             let bufferToSchedule = try soundState.localBuffer(for: playerNodeFormat)
             localPlayback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
         }
@@ -338,7 +338,8 @@ private extension SoundPlayer {
         localEngineState.needsReconnect = false
     }
 
-    func startIfNeeded() throws -> AVAudioFormat {
+    @discardableResult
+    func startEngineIfNeeded() throws -> AVAudioFormat {
         guard let outputFormat else {
             throw LiveKitError(.audioEngine, message: "Invalid output format")
         }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -188,6 +188,8 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
         let playLocal = options.destination == .local || options.destination == .localAndRemote
         let playRemote = options.destination == .remote || options.destination == .localAndRemote
 
+        var playbacks = [SoundPlayback]()
+
         // Play locally through standalone engine
         if playLocal {
             try startIfNeeded()
@@ -197,21 +199,20 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
             }
 
             let bufferToSchedule = try convertBuffer(audioBuffer, to: outputFormat)
-            let playback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
-            _state.mutate {
-                // Clean up finished playbacks
-                $0.activePlaybacks[id] = ($0.activePlaybacks[id] ?? []).filter(\.isPlaying)
-                $0.activePlaybacks[id, default: []].append(playback)
-            }
+            playbacks.append(try playerNodePool.play(bufferToSchedule, loop: options.loop))
         }
 
         // Play remotely through MixerEngineObserver's input path (WebRTC)
         if playRemote {
             if let playback = AudioManager.shared.mixer.playSound(audioBuffer, loop: options.loop) {
-                _state.mutate {
-                    $0.activePlaybacks[id] = ($0.activePlaybacks[id] ?? []).filter(\.isPlaying)
-                    $0.activePlaybacks[id, default: []].append(playback)
-                }
+                playbacks.append(playback)
+            }
+        }
+
+        if !playbacks.isEmpty {
+            _state.mutate {
+                $0.activePlaybacks[id] = ($0.activePlaybacks[id] ?? []).filter(\.isPlaying)
+                $0.activePlaybacks[id, default: []].append(contentsOf: playbacks)
             }
         }
     }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -65,7 +65,7 @@ private struct PreparedSound {
                                                  to: playerNodeFormat,
                                                  outputBufferCapacity: outputBufferCapacity)
             else {
-                throw LiveKitError(.audioEngine, message: "Failed to create audio converter")
+                throw LiveKitError(.soundPlayer, message: "Failed to create audio converter")
             }
             localBuffer = converter.convert(from: sourceBuffer)
         }
@@ -119,7 +119,7 @@ public final class SoundPlayer: Loggable {
     private var engineConfigurationObserver: NSObjectProtocol?
 
     private var sounds: [UUID: PreparedSound] = [:]
-    private var soundIDsByName: [String: UUID] = [:]
+    private var soundIdsByName: [String: UUID] = [:]
     private var localEngineState = LocalEngineState()
 
     init(poolSize: Int = 10, notificationCenter: NotificationCenter = .default) {
@@ -161,23 +161,23 @@ public final class SoundPlayer: Loggable {
     public func prepare(fileURL: URL, named name: String? = nil) async throws -> SoundHandle {
         let readBuffer = try await Self.decodeBuffer(from: fileURL)
         let sessionRequirementHandle = try AudioManager.shared.acquireSessionRequirement(.playbackOnly)
-        let soundID = UUID()
-        let replacedSoundID = name.flatMap { soundIDsByName[$0] }
+        let soundId = UUID()
+        let replacedSoundId = name.flatMap { soundIdsByName[$0] }
 
         do {
             try startEngineIfNeeded()
-            sounds[soundID] = PreparedSound(name: name,
+            sounds[soundId] = PreparedSound(name: name,
                                             sourceBuffer: readBuffer,
                                             sessionRequirementHandle: sessionRequirementHandle)
             if let name {
-                soundIDsByName[name] = soundID
+                soundIdsByName[name] = soundId
             }
 
-            if let replacedSoundID {
-                await releaseSound(id: replacedSoundID)
+            if let replacedSoundId {
+                await releaseSound(id: replacedSoundId)
             }
 
-            return SoundHandle(id: soundID)
+            return SoundHandle(id: soundId)
         } catch {
             try? sessionRequirementHandle.release()
             throw error
@@ -186,8 +186,8 @@ public final class SoundPlayer: Loggable {
 
     /// Returns the prepared sound currently associated with `name`, if any.
     public func sound(named name: String) -> SoundHandle? {
-        guard let soundID = soundIDsByName[name], sounds[soundID] != nil else { return nil }
-        return SoundHandle(id: soundID)
+        guard let soundId = soundIdsByName[name], sounds[soundId] != nil else { return nil }
+        return SoundHandle(id: soundId)
     }
 
     /// Releases a prepared sound, stops any active playback, and relinquishes its session requirement.
@@ -217,10 +217,10 @@ public final class SoundPlayer: Loggable {
 
     /// Stops all playing or queued sounds without releasing prepared audio buffers.
     public func stopAll(destination: PlaybackOptions.Destination = .localAndRemote) async {
-        for soundID in Array(sounds.keys) {
-            if var sound = sounds[soundID] {
+        for soundId in Array(sounds.keys) {
+            if var sound = sounds[soundId] {
                 await sound.stop(destination: destination)
-                if sounds[soundID] != nil { sounds[soundID] = sound }
+                if sounds[soundId] != nil { sounds[soundId] = sound }
             }
         }
     }
@@ -253,13 +253,13 @@ public final class SoundPlayer: Loggable {
     ///   or the local player-node pool is exhausted.
     public func play(_ sound: SoundHandle, options: PlaybackOptions = PlaybackOptions()) async throws {
         guard var soundState = sounds[sound.id] else {
-            throw LiveKitError(.audioEngine, message: "Sound not prepared")
+            throw LiveKitError(.soundPlayer, message: "Sound not prepared")
         }
 
         if options.mode == .replace {
             await soundState.stop(destination: .localAndRemote)
             guard sounds[sound.id] != nil else {
-                throw LiveKitError(.audioEngine, message: "Sound not prepared")
+                throw LiveKitError(.soundPlayer, message: "Sound not prepared")
             }
         }
 
@@ -309,12 +309,12 @@ private extension SoundPlayer {
     }
 
     func invalidateCachedLocalBuffers() {
-        for soundID in Array(sounds.keys) {
-            guard var sound = sounds[soundID] else { continue }
+        for soundId in Array(sounds.keys) {
+            guard var sound = sounds[soundId] else { continue }
             sound.cachedLocalBuffer = nil
             sound.cachedLocalBufferFormat = nil
             sound.local.removeAll()
-            sounds[soundID] = sound
+            sounds[soundId] = sound
         }
     }
 
@@ -344,7 +344,7 @@ private extension SoundPlayer {
     @discardableResult
     func startEngineIfNeeded() throws -> AVAudioFormat {
         guard let outputFormat else {
-            throw LiveKitError(.audioEngine, message: "Invalid output format")
+            throw LiveKitError(.soundPlayer, message: "Invalid output format")
         }
         let playerNodeFormat = makePlayerNodeFormat(for: outputFormat)
         let needsReconnect = localEngineState.needsReconnect
@@ -365,11 +365,11 @@ private extension SoundPlayer {
         engine.stop()
     }
 
-    func releaseSound(id soundID: UUID) async {
-        guard var sound = sounds.removeValue(forKey: soundID) else { return }
+    func releaseSound(id soundId: UUID) async {
+        guard var sound = sounds.removeValue(forKey: soundId) else { return }
 
-        if let name = sound.name, soundIDsByName[name] == soundID {
-            soundIDsByName.removeValue(forKey: name)
+        if let name = sound.name, soundIdsByName[name] == soundId {
+            soundIdsByName.removeValue(forKey: name)
         }
 
         await sound.stop(destination: .localAndRemote)
@@ -390,7 +390,7 @@ private extension SoundPlayer {
             guard let readBuffer = AVAudioPCMBuffer(pcmFormat: audioFile.processingFormat,
                                                     frameCapacity: AVAudioFrameCount(audioFile.length))
             else {
-                throw LiveKitError(.audioEngine, message: "Failed to allocate audio buffer")
+                throw LiveKitError(.soundPlayer, message: "Failed to allocate audio buffer")
             }
             try audioFile.read(into: readBuffer, frameCount: AVAudioFrameCount(audioFile.length))
             return readBuffer

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -170,10 +170,14 @@ public final class SoundPlayer: Loggable {
         }
     }
 
+    private struct LocalEngineState {
+        var connectedOutputFormat: AVAudioFormat?
+        var playerNodeFormat: AVAudioFormat?
+        var needsReconnect = false
+    }
+
     private var sounds: [String: Sound] = [:]
-    private var connectedOutputFormat: AVAudioFormat?
-    private var playerNodeFormat: AVAudioFormat?
-    private var engineNeedsReconnect = false
+    private var localEngineState = LocalEngineState()
 
     init(poolSize: Int = 10, notificationCenter: NotificationCenter = .default) {
         self.notificationCenter = notificationCenter
@@ -212,9 +216,9 @@ public final class SoundPlayer: Loggable {
     }
 
     private func invalidateLocalState() {
-        connectedOutputFormat = nil
-        playerNodeFormat = nil
-        engineNeedsReconnect = true
+        localEngineState.connectedOutputFormat = nil
+        localEngineState.playerNodeFormat = nil
+        localEngineState.needsReconnect = true
         playerNodePool.reset()
 
         for id in Array(sounds.keys) {
@@ -238,9 +242,9 @@ public final class SoundPlayer: Loggable {
         engine.connect(playerNodePool, to: engine.mainMixerNode,
                        format: outputFormat, playerNodeFormat: playerNodeFormat)
         try engine.start()
-        connectedOutputFormat = outputFormat
-        self.playerNodeFormat = playerNodeFormat
-        engineNeedsReconnect = false
+        localEngineState.connectedOutputFormat = outputFormat
+        localEngineState.playerNodeFormat = playerNodeFormat
+        localEngineState.needsReconnect = false
     }
 
     private func startIfNeeded() throws -> AVAudioFormat {
@@ -248,10 +252,10 @@ public final class SoundPlayer: Loggable {
             throw LiveKitError(.audioEngine, message: "Invalid output format")
         }
         let playerNodeFormat = makePlayerNodeFormat(for: outputFormat)
-        let needsReconnect = engineNeedsReconnect
+        let needsReconnect = localEngineState.needsReconnect
             || !engine.isRunning
-            || connectedOutputFormat != outputFormat
-            || self.playerNodeFormat != playerNodeFormat
+            || localEngineState.connectedOutputFormat != outputFormat
+            || localEngineState.playerNodeFormat != playerNodeFormat
 
         if needsReconnect {
             try reconnectEngine(outputFormat: outputFormat, playerNodeFormat: playerNodeFormat)
@@ -261,9 +265,9 @@ public final class SoundPlayer: Loggable {
     }
 
     private func stopEngine() {
-        connectedOutputFormat = nil
-        playerNodeFormat = nil
-        engineNeedsReconnect = false
+        localEngineState.connectedOutputFormat = nil
+        localEngineState.playerNodeFormat = nil
+        localEngineState.needsReconnect = false
         playerNodePool.stop()
         engine.stop()
     }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -16,6 +16,13 @@
 
 @preconcurrency import AVFAudio
 
+@globalActor
+public actor SoundPlayerActor {
+    public static let shared = SoundPlayerActor()
+
+    private init() {}
+}
+
 /// Options for controlling sound playback behavior.
 public struct PlaybackOptions: Sendable {
     /// How to handle existing playback of the same sound.
@@ -90,7 +97,8 @@ public struct PlaybackOptions: Sendable {
 /// Remote playback is best-effort. It depends on the WebRTC mixer input path being available,
 /// which typically requires the microphone to be published. Local playback can still succeed
 /// even when remote playback is skipped.
-public actor SoundPlayer: Loggable {
+@SoundPlayerActor
+public final class SoundPlayer: Loggable {
     // MARK: - Public
 
     /// Shared sound player instance.

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -16,81 +16,6 @@
 
 @preconcurrency import AVFAudio
 
-private struct PreparedSound {
-    let name: String?
-    let sourceBuffer: AVAudioPCMBuffer
-    let sessionRequirementHandle: SessionRequirementHandle
-    var cachedLocalBuffer: AVAudioPCMBuffer?
-    var cachedLocalBufferFormat: AVAudioFormat?
-    var local: [SoundPlayback] = []
-    var remote: [SoundPlayback] = []
-
-    private static func stop(_ playbacks: inout [SoundPlayback]) async {
-        for playback in playbacks {
-            await playback.stop()
-        }
-        playbacks.removeAll()
-    }
-
-    mutating func cleanUp() {
-        local.removeAll { !$0.isPlaying }
-        remote.removeAll { !$0.isPlaying }
-    }
-
-    mutating func stop(destination: PlaybackOptions.Destination) async {
-        switch destination {
-        case .local:
-            await Self.stop(&local)
-        case .remote:
-            await Self.stop(&remote)
-        case .localAndRemote:
-            await Self.stop(&local)
-            await Self.stop(&remote)
-        }
-    }
-
-    mutating func localBuffer(for playerNodeFormat: AVAudioFormat) throws -> AVAudioPCMBuffer {
-        if let cachedLocalBuffer, let cachedLocalBufferFormat, cachedLocalBufferFormat == playerNodeFormat {
-            return cachedLocalBuffer
-        }
-
-        let localBuffer: AVAudioPCMBuffer
-        if sourceBuffer.format == playerNodeFormat {
-            localBuffer = sourceBuffer
-        } else {
-            let outputBufferCapacity = AudioConverter.frameCapacity(from: sourceBuffer.format,
-                                                                    to: playerNodeFormat,
-                                                                    inputFrameCount: sourceBuffer.frameLength)
-            guard let converter = AudioConverter(from: sourceBuffer.format,
-                                                 to: playerNodeFormat,
-                                                 outputBufferCapacity: outputBufferCapacity)
-            else {
-                throw LiveKitError(.soundPlayer, message: "Failed to create audio converter")
-            }
-            localBuffer = converter.convert(from: sourceBuffer)
-        }
-
-        cachedLocalBuffer = localBuffer
-        cachedLocalBufferFormat = playerNodeFormat
-        return localBuffer
-    }
-}
-
-private struct LocalEngineState {
-    var connectedOutputFormat: AVAudioFormat?
-    var playerNodeFormat: AVAudioFormat?
-    var needsReconnect = false
-
-    init(connectedOutputFormat: AVAudioFormat? = nil,
-         playerNodeFormat: AVAudioFormat? = nil,
-         needsReconnect: Bool = false)
-    {
-        self.connectedOutputFormat = connectedOutputFormat
-        self.playerNodeFormat = playerNodeFormat
-        self.needsReconnect = needsReconnect
-    }
-}
-
 /// High-level API for preparing and playing short sounds locally and over the room mixer.
 ///
 /// ```swift
@@ -113,14 +38,14 @@ public final class SoundPlayer: Loggable {
 
     // MARK: - Private
 
-    private let engine = AVAudioEngine()
-    private let playerNodePool: AVAudioPlayerNodePool
-    private let notificationCenter: NotificationCenter
-    private var engineConfigurationObserver: NSObjectProtocol?
+    let engine = AVAudioEngine()
+    let playerNodePool: AVAudioPlayerNodePool
+    let notificationCenter: NotificationCenter
+    var engineConfigurationObserver: NSObjectProtocol?
 
-    private var sounds: [UUID: PreparedSound] = [:]
-    private var soundIdsByName: [String: UUID] = [:]
-    private var localEngineState = LocalEngineState()
+    var sounds: [UUID: PreparedSound] = [:]
+    var soundIdsByName: [String: UUID] = [:]
+    var localEngineState = LocalEngineState()
 
     init(poolSize: Int = 10, notificationCenter: NotificationCenter = .default) {
         self.notificationCenter = notificationCenter
@@ -143,15 +68,17 @@ public final class SoundPlayer: Loggable {
         }
     }
 
-    // MARK: - Public API
-
-    /// Decodes and caches audio, optionally associating it with a unique name.
+    /// Decodes and caches audio, returning a handle for playback and release.
     ///
     /// Preparing a sound also acquires a playback session requirement and starts the
     /// local engine early to reduce first-play latency.
     ///
+    /// The returned ``SoundHandle`` is a lightweight value token. `SoundPlayer` owns the
+    /// prepared sound until the handle is released with ``SoundHandle/release()``.
+    ///
     /// If `name` is provided and another prepared sound already uses the same name,
-    /// the previous sound is stopped, released, and replaced.
+    /// the previous sound is stopped, released, and replaced. Use ``sound(named:)`` to look up
+    /// the current handle for a name.
     ///
     /// - Note: Only local file URLs are supported.
     /// - Note: The file format must be readable by `AVAudioFile` on the current platform.
@@ -184,35 +111,13 @@ public final class SoundPlayer: Loggable {
         }
     }
 
-    /// Returns the prepared sound currently associated with `name`, if any.
+    /// Returns the current handle for a prepared sound associated with `name`, if any.
+    ///
+    /// Names are optional aliases. Preparing another sound with the same name replaces the
+    /// previous mapping, so this returns the latest prepared sound for that name.
     public func sound(named name: String) -> SoundHandle? {
         guard let soundId = soundIdsByName[name], sounds[soundId] != nil else { return nil }
         return SoundHandle(id: soundId)
-    }
-
-    /// Releases a prepared sound, stops any active playback, and relinquishes its session requirement.
-    ///
-    /// Releasing the last prepared sound also stops the local playback engine owned by `SoundPlayer`.
-    public func release(_ sound: SoundHandle) async {
-        await releaseSound(id: sound.id)
-    }
-
-    /// Returns `true` if the handle still refers to a prepared sound.
-    public func isPrepared(_ sound: SoundHandle) -> Bool {
-        sounds[sound.id] != nil
-    }
-
-    /// Returns `true` if the sound currently has active playback for the selected destination.
-    public func isPlaying(_ sound: SoundHandle, destination: PlaybackOptions.Destination = .localAndRemote) -> Bool {
-        guard let sound = sounds[sound.id] else { return false }
-        switch destination {
-        case .local:
-            return sound.local.contains(where: \.isPlaying)
-        case .remote:
-            return sound.remote.contains(where: \.isPlaying)
-        case .localAndRemote:
-            return sound.local.contains(where: \.isPlaying) || sound.remote.contains(where: \.isPlaying)
-        }
     }
 
     /// Stops all playing or queued sounds without releasing prepared audio buffers.
@@ -224,73 +129,9 @@ public final class SoundPlayer: Loggable {
             }
         }
     }
-
-    /// Stops all playing or queued instances of a prepared sound without releasing its buffer.
-    public func stop(_ sound: SoundHandle, destination: PlaybackOptions.Destination = .localAndRemote) async {
-        guard var soundState = sounds[sound.id] else { return }
-        await soundState.stop(destination: destination)
-        if sounds[sound.id] != nil { sounds[sound.id] = soundState }
-    }
-
-    /// Stops all playing or queued sounds associated with the given name without releasing the prepared buffer.
-    public func stop(named name: String, destination: PlaybackOptions.Destination = .localAndRemote) async {
-        guard let sound = sound(named: name) else { return }
-        await sound.stop(destination: destination)
-    }
-
-    /// Plays a prepared sound.
-    ///
-    /// Remote playback is best-effort and is skipped when the WebRTC mixer input path
-    /// is unavailable.
-    ///
-    /// When `options.mode` is `.replace`, any existing playback for the same prepared sound
-    /// is stopped for both local and remote destinations before the new playback starts.
-    ///
-    /// When `options.destination` includes `.localAndRemote`, local playback may still succeed
-    /// even if remote playback is skipped.
-    ///
-    /// - Throws: ``LiveKitError`` if the sound is not prepared, local playback setup fails,
-    ///   or the local player-node pool is exhausted.
-    public func play(_ sound: SoundHandle, options: PlaybackOptions = PlaybackOptions()) async throws {
-        guard var soundState = sounds[sound.id] else {
-            throw LiveKitError(.soundPlayer, message: "Sound not prepared")
-        }
-
-        if options.mode == .replace {
-            await soundState.stop(destination: .localAndRemote)
-            guard sounds[sound.id] != nil else {
-                throw LiveKitError(.soundPlayer, message: "Sound not prepared")
-            }
-        }
-
-        soundState.cleanUp()
-
-        var localPlayback: SoundPlayback?
-        var remotePlayback: SoundPlayback?
-
-        if options.destination.includesLocal {
-            let playerNodeFormat = try startEngineIfNeeded()
-            let bufferToSchedule = try soundState.localBuffer(for: playerNodeFormat)
-            localPlayback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
-        }
-
-        if options.destination.includesRemote {
-            remotePlayback = AudioManager.shared.mixer.playSound(soundState.sourceBuffer, loop: options.loop)
-        }
-
-        if let localPlayback {
-            soundState.local.append(localPlayback)
-        }
-
-        if let remotePlayback {
-            soundState.remote.append(remotePlayback)
-        }
-
-        sounds[sound.id] = soundState
-    }
 }
 
-private extension SoundPlayer {
+extension SoundPlayer {
     var outputFormat: AVAudioFormat? {
         let format = engine.outputNode.outputFormat(forBus: 0)
         guard format.channelCount > 0 else { return nil }
@@ -378,6 +219,70 @@ private extension SoundPlayer {
         }
 
         try? sound.sessionRequirementHandle.release()
+    }
+
+    func release(_ sound: SoundHandle) async {
+        await releaseSound(id: sound.id)
+    }
+
+    func isPrepared(_ sound: SoundHandle) -> Bool {
+        sounds[sound.id] != nil
+    }
+
+    func isPlaying(_ sound: SoundHandle, destination: PlaybackOptions.Destination = .localAndRemote) -> Bool {
+        guard let sound = sounds[sound.id] else { return false }
+        switch destination {
+        case .local:
+            return sound.local.contains(where: \.isPlaying)
+        case .remote:
+            return sound.remote.contains(where: \.isPlaying)
+        case .localAndRemote:
+            return sound.local.contains(where: \.isPlaying) || sound.remote.contains(where: \.isPlaying)
+        }
+    }
+
+    func stop(_ sound: SoundHandle, destination: PlaybackOptions.Destination = .localAndRemote) async {
+        guard var soundState = sounds[sound.id] else { return }
+        await soundState.stop(destination: destination)
+        if sounds[sound.id] != nil { sounds[sound.id] = soundState }
+    }
+
+    func play(_ sound: SoundHandle, options: PlaybackOptions = PlaybackOptions()) async throws {
+        guard var soundState = sounds[sound.id] else {
+            throw LiveKitError(.soundPlayer, message: "Sound not prepared")
+        }
+
+        if options.mode == .replace {
+            await soundState.stop(destination: .localAndRemote)
+            guard sounds[sound.id] != nil else {
+                throw LiveKitError(.soundPlayer, message: "Sound not prepared")
+            }
+        }
+
+        soundState.cleanUp()
+
+        var localPlayback: SoundPlayback?
+        var remotePlayback: SoundPlayback?
+
+        if options.destination.includesLocal {
+            let playerNodeFormat = try startEngineIfNeeded()
+            let bufferToSchedule = try soundState.localBuffer(for: playerNodeFormat)
+            localPlayback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
+        }
+
+        if options.destination.includesRemote {
+            remotePlayback = AudioManager.shared.mixer.playSound(soundState.sourceBuffer, loop: options.loop)
+        }
+
+        if let localPlayback {
+            soundState.local.append(localPlayback)
+        }
+
+        if let remotePlayback {
+            soundState.remote.append(remotePlayback)
+        }
+
+        sounds[sound.id] = soundState
     }
 
     static func decodeBuffer(from fileURL: URL) async throws -> AVAudioPCMBuffer {

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -220,7 +220,7 @@ public final class SoundPlayer: Loggable {
         for soundID in Array(sounds.keys) {
             if var sound = sounds[soundID] {
                 await sound.stop(destination: destination)
-                sounds[soundID] = sound
+                if sounds[soundID] != nil { sounds[soundID] = sound }
             }
         }
     }
@@ -229,7 +229,7 @@ public final class SoundPlayer: Loggable {
     public func stop(_ sound: SoundHandle, destination: PlaybackOptions.Destination = .localAndRemote) async {
         guard var soundState = sounds[sound.id] else { return }
         await soundState.stop(destination: destination)
-        sounds[sound.id] = soundState
+        if sounds[sound.id] != nil { sounds[sound.id] = soundState }
     }
 
     /// Stops all playing or queued sounds associated with the given name without releasing the prepared buffer.
@@ -258,6 +258,9 @@ public final class SoundPlayer: Loggable {
 
         if options.mode == .replace {
             await soundState.stop(destination: .localAndRemote)
+            guard sounds[sound.id] != nil else {
+                throw LiveKitError(.audioEngine, message: "Sound not prepared")
+            }
         }
 
         soundState.cleanUp()

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -76,7 +76,7 @@ public actor SoundPlayer: Loggable {
 
     private struct Sound {
         let buffer: AVAudioPCMBuffer
-        let sessionRequirementId: UUID
+        let releaseSessionRequirement: @Sendable () -> Void
         var local: [SoundPlayback] = []
         var remote: [SoundPlayback] = []
 
@@ -201,25 +201,24 @@ public actor SoundPlayer: Loggable {
 
         let readBuffer = try await Self.decodeBuffer(from: url)
 
-        let requirementId = UUID()
+        let releaseSessionRequirement: @Sendable () -> Void
         #if os(iOS) || os(visionOS) || os(tvOS)
-        try AudioManager.shared.audioSession.set(requirement: .playbackOnly, for: requirementId)
+        let sessionRequirementHandle = try AudioManager.shared.audioSession.acquire(requirement: .playbackOnly)
+        releaseSessionRequirement = { try? sessionRequirementHandle.release() }
+        #else
+        releaseSessionRequirement = {}
         #endif
 
         do {
             guard sounds[id] == nil else {
-                #if os(iOS) || os(visionOS) || os(tvOS)
-                try? AudioManager.shared.audioSession.removeRequirement(for: requirementId)
-                #endif
+                releaseSessionRequirement()
                 return
             }
 
             _ = try startIfNeeded()
-            sounds[id] = Sound(buffer: readBuffer, sessionRequirementId: requirementId)
+            sounds[id] = Sound(buffer: readBuffer, releaseSessionRequirement: releaseSessionRequirement)
         } catch {
-            #if os(iOS) || os(visionOS) || os(tvOS)
-            try? AudioManager.shared.audioSession.removeRequirement(for: requirementId)
-            #endif
+            releaseSessionRequirement()
             throw error
         }
     }
@@ -232,9 +231,7 @@ public actor SoundPlayer: Loggable {
             stopEngine()
         }
 
-        #if os(iOS) || os(visionOS) || os(tvOS)
-        try? AudioManager.shared.audioSession.removeRequirement(for: sound.sessionRequirementId)
-        #endif
+        sound.releaseSessionRequirement()
     }
 
     /// Returns `true` if a sound has been prepared for the given identifier.

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -56,11 +56,14 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
 
     private let engine = AVAudioEngine()
     private let playerNodePool: AVAudioPlayerNodePool
-    private let sessionRequirementId = UUID()
-
     private struct State {
-        var sounds: [String: AVAudioPCMBuffer] = [:]
+        var sounds: [String: PreparedSound] = [:]
         var activePlaybacks: [String: [SoundPlayback]] = [:]
+    }
+
+    private struct PreparedSound {
+        let buffer: AVAudioPCMBuffer
+        let sessionRequirementId: UUID
     }
 
     private let _state = StateSync(State())
@@ -89,60 +92,57 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
                                              interleaved: outputFormat.isInterleaved)!
         engine.connect(playerNodePool, to: engine.mainMixerNode,
                        format: outputFormat, playerNodeFormat: playerNodeFormat)
-
-        #if os(iOS) || os(visionOS) || os(tvOS)
-        try AudioManager.shared.audioSession.set(requirement: .playbackOnly, for: sessionRequirementId)
-        #endif
-
         try engine.start()
     }
 
     private func stopEngine() {
         playerNodePool.stop()
         engine.stop()
+    }
 
-        #if os(iOS) || os(visionOS) || os(tvOS)
-        try? AudioManager.shared.audioSession.set(requirement: .none, for: sessionRequirementId)
-        #endif
+    /// Converts a buffer to the target format. Returns the buffer as-is if formats already match.
+    private func convertBuffer(_ buffer: AVAudioPCMBuffer, to targetFormat: AVAudioFormat) throws -> AVAudioPCMBuffer {
+        guard buffer.format != targetFormat else { return buffer }
+        let outputBufferCapacity = AudioConverter.frameCapacity(from: buffer.format,
+                                                                to: targetFormat,
+                                                                inputFrameCount: buffer.frameLength)
+        guard let converter = AudioConverter(from: buffer.format,
+                                             to: targetFormat,
+                                             outputBufferCapacity: outputBufferCapacity)
+        else {
+            throw LiveKitError(.audioEngine, message: "Failed to create audio converter")
+        }
+        return converter.convert(from: buffer)
     }
 
     // MARK: - Public API
 
     public func prepare(url: URL, withId id: String) throws {
-        try startIfNeeded()
-
-        guard let outputFormat else {
-            throw LiveKitError(.audioEngine, message: "Failed to get output format")
-        }
-
         // Prepare audio file
         let audioFile = try AVAudioFile(forReading: url)
-        // Prepare buffer
+        // Read into buffer using the file's processing format (always standard Float32 PCM)
         guard let readBuffer = AVAudioPCMBuffer(pcmFormat: audioFile.processingFormat, frameCapacity: AVAudioFrameCount(audioFile.length)) else {
             throw LiveKitError(.audioEngine, message: "Failed to allocate audio buffer")
         }
-        // Read all into buffer
         try audioFile.read(into: readBuffer, frameCount: AVAudioFrameCount(audioFile.length))
-        // Compute required convert buffer capacity
-        let outputBufferCapacity = AudioConverter.frameCapacity(from: readBuffer.format, to: outputFormat, inputFrameCount: readBuffer.frameLength)
-        // Create converter
-        guard let converter = AudioConverter(from: readBuffer.format, to: outputFormat, outputBufferCapacity: outputBufferCapacity) else {
-            throw LiveKitError(.audioEngine, message: "Failed to create audio converter")
-        }
-        // Convert to suitable format for audio engine
-        let convertedBuffer = converter.convert(from: readBuffer)
-        // Register
+
+        let requirementId = UUID()
+        #if os(iOS) || os(visionOS) || os(tvOS)
+        try AudioManager.shared.audioSession.set(requirement: .playbackOnly, for: requirementId)
+        #endif
+
+        try startIfNeeded()
+
         _state.mutate {
-            $0.sounds[id] = convertedBuffer
+            $0.sounds[id] = PreparedSound(buffer: readBuffer, sessionRequirementId: requirementId)
         }
     }
 
     public func release(id: String) {
-        // Stop active playbacks before removing
-        let (playbacks, shouldStop) = _state.mutate {
+        let (playbacks, sound, shouldStop) = _state.mutate {
             let playbacks = $0.activePlaybacks.removeValue(forKey: id) ?? []
-            $0.sounds.removeValue(forKey: id)
-            return (playbacks, $0.sounds.isEmpty)
+            let sound = $0.sounds.removeValue(forKey: id)
+            return (playbacks, sound, $0.sounds.isEmpty)
         }
 
         for playback in playbacks {
@@ -152,6 +152,12 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
         if shouldStop {
             stopEngine()
         }
+
+        #if os(iOS) || os(visionOS) || os(tvOS)
+        if let sound {
+            try? AudioManager.shared.audioSession.set(requirement: .none, for: sound.sessionRequirementId)
+        }
+        #endif
     }
 
     /// Stops all playing or queued sounds without releasing prepared audio buffers.
@@ -175,7 +181,7 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
             stop(id: id)
         }
 
-        guard let audioBuffer = _state.read(\.sounds[id]) else {
+        guard let audioBuffer = _state.read({ $0.sounds[id]?.buffer }) else {
             throw LiveKitError(.audioEngine, message: "Sound not prepared")
         }
 
@@ -190,24 +196,7 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
                 throw LiveKitError(.audioEngine, message: "Failed to get output format")
             }
 
-            // Convert if format doesn't match. A new converter is created each time
-            // to avoid thread-safety issues with shared converter state.
-            let bufferToSchedule: AVAudioPCMBuffer
-            if audioBuffer.format != outputFormat {
-                let outputBufferCapacity = AudioConverter.frameCapacity(from: audioBuffer.format,
-                                                                        to: outputFormat,
-                                                                        inputFrameCount: audioBuffer.frameLength)
-                guard let converter = AudioConverter(from: audioBuffer.format,
-                                                     to: outputFormat,
-                                                     outputBufferCapacity: outputBufferCapacity)
-                else {
-                    throw LiveKitError(.audioEngine, message: "Failed to create audio converter")
-                }
-                bufferToSchedule = converter.convert(from: audioBuffer)
-            } else {
-                bufferToSchedule = audioBuffer
-            }
-
+            let bufferToSchedule = try convertBuffer(audioBuffer, to: outputFormat)
             let playback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
             _state.mutate {
                 // Clean up finished playbacks

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -110,8 +110,10 @@ public final class SoundPlayer: Loggable {
     private let playerNodePool: AVAudioPlayerNodePool
 
     private struct Sound {
-        let buffer: AVAudioPCMBuffer
+        let sourceBuffer: AVAudioPCMBuffer
         let sessionRequirementHandle: SessionRequirementHandle
+        var cachedLocalBuffer: AVAudioPCMBuffer?
+        var cachedLocalBufferFormat: AVAudioFormat?
         var local: [SoundPlayback] = []
         var remote: [SoundPlayback] = []
 
@@ -137,6 +139,32 @@ public final class SoundPlayer: Loggable {
                 await Self.stop(&local)
                 await Self.stop(&remote)
             }
+        }
+
+        mutating func localBuffer(for playerNodeFormat: AVAudioFormat) throws -> AVAudioPCMBuffer {
+            if let cachedLocalBuffer, let cachedLocalBufferFormat, cachedLocalBufferFormat == playerNodeFormat {
+                return cachedLocalBuffer
+            }
+
+            let localBuffer: AVAudioPCMBuffer
+            if sourceBuffer.format == playerNodeFormat {
+                localBuffer = sourceBuffer
+            } else {
+                let outputBufferCapacity = AudioConverter.frameCapacity(from: sourceBuffer.format,
+                                                                        to: playerNodeFormat,
+                                                                        inputFrameCount: sourceBuffer.frameLength)
+                guard let converter = AudioConverter(from: sourceBuffer.format,
+                                                     to: playerNodeFormat,
+                                                     outputBufferCapacity: outputBufferCapacity)
+                else {
+                    throw LiveKitError(.audioEngine, message: "Failed to create audio converter")
+                }
+                localBuffer = converter.convert(from: sourceBuffer)
+            }
+
+            cachedLocalBuffer = localBuffer
+            cachedLocalBufferFormat = playerNodeFormat
+            return localBuffer
         }
     }
 
@@ -185,21 +213,6 @@ public final class SoundPlayer: Loggable {
         engine.stop()
     }
 
-    /// Converts a buffer to the target format. Returns the buffer as-is if formats already match.
-    private func convertBuffer(_ buffer: AVAudioPCMBuffer, to targetFormat: AVAudioFormat) throws -> AVAudioPCMBuffer {
-        guard buffer.format != targetFormat else { return buffer }
-        let outputBufferCapacity = AudioConverter.frameCapacity(from: buffer.format,
-                                                                to: targetFormat,
-                                                                inputFrameCount: buffer.frameLength)
-        guard let converter = AudioConverter(from: buffer.format,
-                                             to: targetFormat,
-                                             outputBufferCapacity: outputBufferCapacity)
-        else {
-            throw LiveKitError(.audioEngine, message: "Failed to create audio converter")
-        }
-        return converter.convert(from: buffer)
-    }
-
     private nonisolated static func decodeBuffer(from fileURL: URL) async throws -> AVAudioPCMBuffer {
         guard fileURL.isFileURL else {
             throw LiveKitError(.invalidParameter, message: "Only file URLs are supported")
@@ -241,7 +254,7 @@ public final class SoundPlayer: Loggable {
             }
 
             _ = try startIfNeeded()
-            sounds[id] = Sound(buffer: readBuffer, sessionRequirementHandle: sessionRequirementHandle)
+            sounds[id] = Sound(sourceBuffer: readBuffer, sessionRequirementHandle: sessionRequirementHandle)
         } catch {
             try? sessionRequirementHandle.release()
             throw error
@@ -325,12 +338,12 @@ public final class SoundPlayer: Loggable {
 
         if options.destination.includesLocal {
             let playerNodeFormat = try startIfNeeded()
-            let bufferToSchedule = try convertBuffer(sound.buffer, to: playerNodeFormat)
+            let bufferToSchedule = try sound.localBuffer(for: playerNodeFormat)
             localPlayback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
         }
 
         if options.destination.includesRemote {
-            remotePlayback = AudioManager.shared.mixer.playSound(sound.buffer, loop: options.loop)
+            remotePlayback = AudioManager.shared.mixer.playSound(sound.sourceBuffer, loop: options.loop)
         }
 
         if let localPlayback {

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -56,14 +56,28 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
 
     private let engine = AVAudioEngine()
     private let playerNodePool: AVAudioPlayerNodePool
-    private struct State {
-        var sounds: [String: PreparedSound] = [:]
-        var activePlaybacks: [String: [SoundPlayback]] = [:]
-    }
 
-    private struct PreparedSound {
+    private struct Sound {
         let buffer: AVAudioPCMBuffer
         let sessionRequirementId: UUID
+        var local: [SoundPlayback] = []
+        var remote: [SoundPlayback] = []
+
+        mutating func cleanUp() {
+            local.removeAll { !$0.isPlaying }
+            remote.removeAll { !$0.isPlaying }
+        }
+
+        mutating func stopAll() {
+            for p in local { p.stop() }
+            for p in remote { p.stop() }
+            local.removeAll()
+            remote.removeAll()
+        }
+    }
+
+    private struct State {
+        var sounds: [String: Sound] = [:]
     }
 
     private let _state = StateSync(State())
@@ -118,14 +132,19 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
     // MARK: - Public API
 
     public func prepare(url: URL, withId id: String) throws {
-        // Prepare audio file
+        // Already prepared, ignore.
+        guard _state.read({ $0.sounds[id] }) == nil else { return }
+
+        // Read audio file into raw PCM buffer.
         let audioFile = try AVAudioFile(forReading: url)
-        // Read into buffer using the file's processing format (always standard Float32 PCM)
-        guard let readBuffer = AVAudioPCMBuffer(pcmFormat: audioFile.processingFormat, frameCapacity: AVAudioFrameCount(audioFile.length)) else {
+        guard let readBuffer = AVAudioPCMBuffer(pcmFormat: audioFile.processingFormat,
+                                                frameCapacity: AVAudioFrameCount(audioFile.length))
+        else {
             throw LiveKitError(.audioEngine, message: "Failed to allocate audio buffer")
         }
         try audioFile.read(into: readBuffer, frameCount: AVAudioFrameCount(audioFile.length))
 
+        // Acquire session requirement before starting engine.
         let requirementId = UUID()
         #if os(iOS) || os(visionOS) || os(tvOS)
         try AudioManager.shared.audioSession.set(requirement: .playbackOnly, for: requirementId)
@@ -134,19 +153,15 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
         try startIfNeeded()
 
         _state.mutate {
-            $0.sounds[id] = PreparedSound(buffer: readBuffer, sessionRequirementId: requirementId)
+            $0.sounds[id] = Sound(buffer: readBuffer, sessionRequirementId: requirementId)
         }
     }
 
     public func release(id: String) {
-        let (playbacks, sound, shouldStop) = _state.mutate {
-            let playbacks = $0.activePlaybacks.removeValue(forKey: id) ?? []
+        let (sound, shouldStop) = _state.mutate {
+            $0.sounds[id]?.stopAll()
             let sound = $0.sounds.removeValue(forKey: id)
-            return (playbacks, sound, $0.sounds.isEmpty)
-        }
-
-        for playback in playbacks {
-            playback.stop()
+            return (sound, $0.sounds.isEmpty)
         }
 
         if shouldStop {
@@ -162,17 +177,17 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
 
     /// Stops all playing or queued sounds without releasing prepared audio buffers.
     public func stopAll() {
-        playerNodePool.reset()
-        _state.mutate { $0.activePlaybacks.removeAll() }
+        _state.mutate {
+            for id in $0.sounds.keys {
+                $0.sounds[id]?.stopAll()
+            }
+        }
     }
 
     /// Stops all playing or queued sounds for the specified id without releasing prepared audio buffers.
     public func stop(id: String) {
-        let playbacks = _state.mutate {
-            $0.activePlaybacks.removeValue(forKey: id) ?? []
-        }
-        for playback in playbacks {
-            playback.stop()
+        _state.mutate {
+            $0.sounds[id]?.stopAll()
         }
     }
 
@@ -181,16 +196,16 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
             stop(id: id)
         }
 
-        guard let audioBuffer = _state.read({ $0.sounds[id]?.buffer }) else {
+        guard let buffer = _state.read({ $0.sounds[id]?.buffer }) else {
             throw LiveKitError(.audioEngine, message: "Sound not prepared")
         }
 
         let playLocal = options.destination == .local || options.destination == .localAndRemote
         let playRemote = options.destination == .remote || options.destination == .localAndRemote
 
-        var playbacks = [SoundPlayback]()
+        var localPlayback: SoundPlayback?
+        var remotePlayback: SoundPlayback?
 
-        // Play locally through standalone engine
         if playLocal {
             try startIfNeeded()
 
@@ -198,21 +213,23 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
                 throw LiveKitError(.audioEngine, message: "Failed to get output format")
             }
 
-            let bufferToSchedule = try convertBuffer(audioBuffer, to: outputFormat)
-            playbacks.append(try playerNodePool.play(bufferToSchedule, loop: options.loop))
+            let bufferToSchedule = try convertBuffer(buffer, to: outputFormat)
+            localPlayback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
         }
 
-        // Play remotely through MixerEngineObserver's input path (WebRTC)
         if playRemote {
-            if let playback = AudioManager.shared.mixer.playSound(audioBuffer, loop: options.loop) {
-                playbacks.append(playback)
-            }
+            remotePlayback = AudioManager.shared.mixer.playSound(buffer, loop: options.loop)
         }
 
-        if !playbacks.isEmpty {
+        if localPlayback != nil || remotePlayback != nil {
             _state.mutate {
-                $0.activePlaybacks[id] = ($0.activePlaybacks[id] ?? []).filter(\.isPlaying)
-                $0.activePlaybacks[id, default: []].append(contentsOf: playbacks)
+                $0.sounds[id]?.cleanUp()
+                if let localPlayback {
+                    $0.sounds[id]?.local.append(localPlayback)
+                }
+                if let remotePlayback {
+                    $0.sounds[id]?.remote.append(remotePlayback)
+                }
             }
         }
     }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -138,11 +138,15 @@ extension SoundPlayer {
         return format
     }
 
-    func makePlayerNodeFormat(for outputFormat: AVAudioFormat) -> AVAudioFormat {
-        AVAudioFormat(commonFormat: .pcmFormatFloat32,
-                      sampleRate: outputFormat.sampleRate,
-                      channels: outputFormat.channelCount,
-                      interleaved: outputFormat.isInterleaved)!
+    func makePlayerNodeFormat(for outputFormat: AVAudioFormat) throws -> AVAudioFormat {
+        guard let format = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                         sampleRate: outputFormat.sampleRate,
+                                         channels: outputFormat.channelCount,
+                                         interleaved: outputFormat.isInterleaved)
+        else {
+            throw LiveKitError(.soundPlayer, message: "Failed to create player node format")
+        }
+        return format
     }
 
     func resetLocalEngineState(needsReconnect: Bool) {
@@ -187,7 +191,7 @@ extension SoundPlayer {
         guard let outputFormat else {
             throw LiveKitError(.soundPlayer, message: "Invalid output format")
         }
-        let playerNodeFormat = makePlayerNodeFormat(for: outputFormat)
+        let playerNodeFormat = try makePlayerNodeFormat(for: outputFormat)
         let needsReconnect = localEngineState.needsReconnect
             || !engine.isRunning
             || localEngineState.connectedOutputFormat != outputFormat

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -122,11 +122,8 @@ public final class SoundPlayer: Loggable {
 
     /// Stops all playing or queued sounds without releasing prepared audio buffers.
     public func stopAll(destination: SoundPlaybackOptions.Destination = .localAndRemote) async {
-        for soundId in Array(sounds.keys) {
-            if var sound = sounds[soundId] {
-                await sound.stop(destination: destination)
-                if sounds[soundId] != nil { sounds[soundId] = sound }
-            }
+        for sound in sounds.values {
+            await sound.stop(destination: destination)
         }
     }
 }
@@ -154,12 +151,10 @@ extension SoundPlayer {
     }
 
     func invalidateCachedLocalBuffers() {
-        for soundId in Array(sounds.keys) {
-            guard var sound = sounds[soundId] else { continue }
+        for sound in sounds.values {
             sound.cachedLocalBuffer = nil
             sound.cachedLocalBufferFormat = nil
             sound.local.removeAll()
-            sounds[soundId] = sound
         }
     }
 
@@ -211,7 +206,7 @@ extension SoundPlayer {
     }
 
     func releaseSound(id soundId: UUID) async {
-        guard var sound = sounds.removeValue(forKey: soundId) else { return }
+        guard let sound = sounds.removeValue(forKey: soundId) else { return }
 
         if let name = sound.name, soundIdsByName[name] == soundId {
             soundIdsByName.removeValue(forKey: name)
@@ -246,13 +241,12 @@ extension SoundPlayer {
     }
 
     func stop(_ sound: SoundHandle, destination: SoundPlaybackOptions.Destination = .localAndRemote) async {
-        guard var soundState = sounds[sound.id] else { return }
+        guard let soundState = sounds[sound.id] else { return }
         await soundState.stop(destination: destination)
-        if sounds[sound.id] != nil { sounds[sound.id] = soundState }
     }
 
     func play(_ sound: SoundHandle, options: SoundPlaybackOptions = SoundPlaybackOptions()) async throws {
-        guard var soundState = sounds[sound.id] else {
+        guard let soundState = sounds[sound.id] else {
             throw LiveKitError(.soundPlayer, message: "Sound not prepared")
         }
 
@@ -265,28 +259,17 @@ extension SoundPlayer {
 
         soundState.cleanUp()
 
-        var localPlayback: SoundPlayback?
-        var remotePlayback: SoundPlayback?
-
         if options.destination.includesLocal {
             let playerNodeFormat = try startEngineIfNeeded()
             let bufferToSchedule = try soundState.localBuffer(for: playerNodeFormat)
-            localPlayback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
+            soundState.local.append(try playerNodePool.play(bufferToSchedule, loop: options.loop))
         }
 
         if options.destination.includesRemote {
-            remotePlayback = AudioManager.shared.mixer.playSound(soundState.sourceBuffer, loop: options.loop)
+            if let remotePlayback = AudioManager.shared.mixer.playSound(soundState.sourceBuffer, loop: options.loop) {
+                soundState.remote.append(remotePlayback)
+            }
         }
-
-        if let localPlayback {
-            soundState.local.append(localPlayback)
-        }
-
-        if let remotePlayback {
-            soundState.remote.append(remotePlayback)
-        }
-
-        sounds[sound.id] = soundState
     }
 
     static func decodeBuffer(from fileURL: URL) async throws -> AVAudioPCMBuffer {

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -85,24 +85,24 @@ public actor SoundPlayer: Loggable {
             remote.removeAll { !$0.isPlaying }
         }
 
-        mutating func stop(destination: PlaybackOptions.Destination) {
+        mutating func stop(destination: PlaybackOptions.Destination) async {
             switch destination {
             case .local:
                 for p in local {
-                    p.stop()
+                    await p.stop()
                 }
                 local.removeAll()
             case .remote:
                 for p in remote {
-                    p.stop()
+                    await p.stop()
                 }
                 remote.removeAll()
             case .localAndRemote:
                 for p in local {
-                    p.stop()
+                    await p.stop()
                 }
                 for p in remote {
-                    p.stop()
+                    await p.stop()
                 }
                 local.removeAll()
                 remote.removeAll()
@@ -225,9 +225,9 @@ public actor SoundPlayer: Loggable {
     }
 
     /// Releases a prepared sound, stops any active playback, and relinquishes its session requirement.
-    public func release(id: String) {
+    public func release(id: String) async {
         guard var sound = sounds.removeValue(forKey: id) else { return }
-        sound.stop(destination: .localAndRemote)
+        await sound.stop(destination: .localAndRemote)
         if sounds.isEmpty {
             stopEngine()
         }
@@ -256,15 +256,20 @@ public actor SoundPlayer: Loggable {
     }
 
     /// Stops all playing or queued sounds without releasing prepared audio buffers.
-    public func stopAll(destination: PlaybackOptions.Destination = .localAndRemote) {
+    public func stopAll(destination: PlaybackOptions.Destination = .localAndRemote) async {
         for id in sounds.keys {
-            sounds[id]?.stop(destination: destination)
+            if var sound = sounds[id] {
+                await sound.stop(destination: destination)
+                sounds[id] = sound
+            }
         }
     }
 
     /// Stops all playing or queued sounds for the specified id without releasing prepared audio buffers.
-    public func stop(id: String, destination: PlaybackOptions.Destination = .localAndRemote) {
-        sounds[id]?.stop(destination: destination)
+    public func stop(id: String, destination: PlaybackOptions.Destination = .localAndRemote) async {
+        guard var sound = sounds[id] else { return }
+        await sound.stop(destination: destination)
+        sounds[id] = sound
     }
 
     /// Plays a prepared sound.
@@ -273,7 +278,7 @@ public actor SoundPlayer: Loggable {
     ///
     /// - Throws: ``LiveKitError`` if the sound is not prepared, local playback setup fails,
     ///   or the local player-node pool is exhausted.
-    public func play(id: String, options: PlaybackOptions = PlaybackOptions()) throws {
+    public func play(id: String, options: PlaybackOptions = PlaybackOptions()) async throws {
         let playLocal = options.destination == .local || options.destination == .localAndRemote
         let playRemote = options.destination == .remote || options.destination == .localAndRemote
 
@@ -282,7 +287,7 @@ public actor SoundPlayer: Loggable {
         }
 
         if options.mode == .replace {
-            sound.stop(destination: .localAndRemote)
+            await sound.stop(destination: .localAndRemote)
         }
 
         sound.cleanUp()

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@preconcurrency import AVFAudio
+
+public class SoundPlayer: Loggable, @unchecked Sendable {
+    // MARK: - Public
+
+    public static let shared = SoundPlayer()
+
+    // MARK: - Private
+
+    private let engine = AVAudioEngine()
+    private let playerNodePool: AVAudioPlayerNodePool
+
+    private struct State {
+        var sounds: [String: AVAudioPCMBuffer] = [:]
+        var activePlaybacks: [String: [SoundPlayback]] = [:]
+    }
+
+    private let _state = StateSync(State())
+
+    init(poolSize: Int = 10) {
+        playerNodePool = AVAudioPlayerNodePool(poolSize: poolSize)
+        engine.attach(playerNodePool)
+    }
+
+    // MARK: - Engine lifecycle
+
+    private var outputFormat: AVAudioFormat? {
+        let format = engine.outputNode.outputFormat(forBus: 0)
+        guard format.channelCount > 0 else { return nil }
+        return format
+    }
+
+    private func startIfNeeded() throws {
+        guard !engine.isRunning else { return }
+        guard let outputFormat else {
+            throw LiveKitError(.audioEngine, message: "Invalid output format")
+        }
+        let playerNodeFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                             sampleRate: outputFormat.sampleRate,
+                                             channels: outputFormat.channelCount,
+                                             interleaved: outputFormat.isInterleaved)!
+        engine.connect(playerNodePool, to: engine.mainMixerNode,
+                       format: outputFormat, playerNodeFormat: playerNodeFormat)
+        try engine.start()
+    }
+
+    // MARK: - Public API
+
+    public func prepare(url: URL, withId id: String) throws {
+        try startIfNeeded()
+
+        guard let outputFormat else {
+            throw LiveKitError(.audioEngine, message: "Failed to get output format")
+        }
+
+        // Prepare audio file
+        let audioFile = try AVAudioFile(forReading: url)
+        // Prepare buffer
+        guard let readBuffer = AVAudioPCMBuffer(pcmFormat: audioFile.processingFormat, frameCapacity: AVAudioFrameCount(audioFile.length)) else {
+            throw LiveKitError(.audioEngine, message: "Failed to allocate audio buffer")
+        }
+        // Read all into buffer
+        try audioFile.read(into: readBuffer, frameCount: AVAudioFrameCount(audioFile.length))
+        // Compute required convert buffer capacity
+        let outputBufferCapacity = AudioConverter.frameCapacity(from: readBuffer.format, to: outputFormat, inputFrameCount: readBuffer.frameLength)
+        // Create converter
+        guard let converter = AudioConverter(from: readBuffer.format, to: outputFormat, outputBufferCapacity: outputBufferCapacity) else {
+            throw LiveKitError(.audioEngine, message: "Failed to create audio converter")
+        }
+        // Convert to suitable format for audio engine
+        let convertedBuffer = converter.convert(from: readBuffer)
+        // Register
+        _state.mutate {
+            $0.sounds[id] = convertedBuffer
+        }
+    }
+
+    public func release(id: String) {
+        // Stop active playbacks before removing
+        let (playbacks, shouldStop) = _state.mutate {
+            let playbacks = $0.activePlaybacks.removeValue(forKey: id) ?? []
+            $0.sounds.removeValue(forKey: id)
+            return (playbacks, $0.sounds.isEmpty)
+        }
+
+        for playback in playbacks {
+            playback.stop()
+        }
+
+        if shouldStop {
+            playerNodePool.stop()
+            engine.stop()
+        }
+    }
+
+    /// Stops all playing or queued sounds without releasing prepared audio buffers.
+    public func stopAll() {
+        playerNodePool.reset()
+        _state.mutate { $0.activePlaybacks.removeAll() }
+    }
+
+    /// Stops all playing or queued sounds for the specified id without releasing prepared audio buffers.
+    public func stop(id: String) {
+        let playbacks = _state.mutate {
+            $0.activePlaybacks.removeValue(forKey: id) ?? []
+        }
+        for playback in playbacks {
+            playback.stop()
+        }
+    }
+
+    public func play(id: String) throws {
+        try startIfNeeded()
+
+        guard let audioBuffer = _state.read(\.sounds[id]) else {
+            throw LiveKitError(.audioEngine, message: "Sound not prepared")
+        }
+
+        guard let outputFormat else {
+            throw LiveKitError(.audioEngine, message: "Failed to get output format")
+        }
+
+        // Convert if format doesn't match. A new converter is created each time
+        // to avoid thread-safety issues with shared converter state.
+        let bufferToSchedule: AVAudioPCMBuffer
+        if audioBuffer.format != outputFormat {
+            let outputBufferCapacity = AudioConverter.frameCapacity(from: audioBuffer.format,
+                                                                    to: outputFormat,
+                                                                    inputFrameCount: audioBuffer.frameLength)
+            guard let converter = AudioConverter(from: audioBuffer.format,
+                                                 to: outputFormat,
+                                                 outputBufferCapacity: outputBufferCapacity)
+            else {
+                throw LiveKitError(.audioEngine, message: "Failed to create audio converter")
+            }
+            bufferToSchedule = converter.convert(from: audioBuffer)
+        } else {
+            bufferToSchedule = audioBuffer
+        }
+
+        let playback = try playerNodePool.play(bufferToSchedule)
+        _state.mutate {
+            // Clean up finished playbacks
+            $0.activePlaybacks[id] = ($0.activePlaybacks[id] ?? []).filter { $0.isPlaying }
+            $0.activePlaybacks[id, default: []].append(playback)
+        }
+    }
+}

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -26,12 +26,24 @@ public struct PlaybackOptions: Sendable {
         case replace
     }
 
+    /// Where the sound should be played.
+    public enum Destination: Sendable {
+        /// Play locally only (through device speakers).
+        case local
+        /// Play for remote participants only (through WebRTC). Requires an active Room connection.
+        case remote
+        /// Play both locally and for remote participants.
+        case localAndRemote
+    }
+
     public var mode: Mode
     public var loop: Bool
+    public var destination: Destination
 
-    public init(mode: Mode = .concurrent, loop: Bool = false) {
+    public init(mode: Mode = .concurrent, loop: Bool = false, destination: Destination = .localAndRemote) {
         self.mode = mode
         self.loop = loop
+        self.destination = destination
     }
 }
 
@@ -145,8 +157,6 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
     }
 
     public func play(id: String, options: PlaybackOptions = PlaybackOptions()) throws {
-        try startIfNeeded()
-
         if options.mode == .replace {
             stop(id: id)
         }
@@ -155,33 +165,46 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
             throw LiveKitError(.audioEngine, message: "Sound not prepared")
         }
 
-        guard let outputFormat else {
-            throw LiveKitError(.audioEngine, message: "Failed to get output format")
-        }
+        let playLocal = options.destination == .local || options.destination == .localAndRemote
+        let playRemote = options.destination == .remote || options.destination == .localAndRemote
 
-        // Convert if format doesn't match. A new converter is created each time
-        // to avoid thread-safety issues with shared converter state.
-        let bufferToSchedule: AVAudioPCMBuffer
-        if audioBuffer.format != outputFormat {
-            let outputBufferCapacity = AudioConverter.frameCapacity(from: audioBuffer.format,
-                                                                    to: outputFormat,
-                                                                    inputFrameCount: audioBuffer.frameLength)
-            guard let converter = AudioConverter(from: audioBuffer.format,
-                                                 to: outputFormat,
-                                                 outputBufferCapacity: outputBufferCapacity)
-            else {
-                throw LiveKitError(.audioEngine, message: "Failed to create audio converter")
+        // Play locally through standalone engine
+        if playLocal {
+            try startIfNeeded()
+
+            guard let outputFormat else {
+                throw LiveKitError(.audioEngine, message: "Failed to get output format")
             }
-            bufferToSchedule = converter.convert(from: audioBuffer)
-        } else {
-            bufferToSchedule = audioBuffer
+
+            // Convert if format doesn't match. A new converter is created each time
+            // to avoid thread-safety issues with shared converter state.
+            let bufferToSchedule: AVAudioPCMBuffer
+            if audioBuffer.format != outputFormat {
+                let outputBufferCapacity = AudioConverter.frameCapacity(from: audioBuffer.format,
+                                                                        to: outputFormat,
+                                                                        inputFrameCount: audioBuffer.frameLength)
+                guard let converter = AudioConverter(from: audioBuffer.format,
+                                                     to: outputFormat,
+                                                     outputBufferCapacity: outputBufferCapacity)
+                else {
+                    throw LiveKitError(.audioEngine, message: "Failed to create audio converter")
+                }
+                bufferToSchedule = converter.convert(from: audioBuffer)
+            } else {
+                bufferToSchedule = audioBuffer
+            }
+
+            let playback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
+            _state.mutate {
+                // Clean up finished playbacks
+                $0.activePlaybacks[id] = ($0.activePlaybacks[id] ?? []).filter { $0.isPlaying }
+                $0.activePlaybacks[id, default: []].append(playback)
+            }
         }
 
-        let playback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
-        _state.mutate {
-            // Clean up finished playbacks
-            $0.activePlaybacks[id] = ($0.activePlaybacks[id] ?? []).filter { $0.isPlaying }
-            $0.activePlaybacks[id, default: []].append(playback)
+        // Play remotely through MixerEngineObserver's input path (WebRTC)
+        if playRemote {
+            AudioManager.shared.mixer.playSound(audioBuffer, loop: options.loop)
         }
     }
 }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -51,9 +51,22 @@ public struct PlaybackOptions: Sendable {
     }
 }
 
+/// High-level API for preparing and playing short sounds locally and over the room mixer.
+///
+/// ```swift
+/// try await SoundPlayer.shared.prepare(url: clickURL, withId: "click")
+/// try await SoundPlayer.shared.play(id: "click")
+/// ```
+///
+/// Prepared sounds must come from local file URLs and use a format supported by `AVAudioFile`
+/// on the current platform.
+///
+/// Local playback uses a fixed internal player-node pool. If that pool is exhausted, `play(id:)`
+/// throws instead of silently dropping local playback.
 public actor SoundPlayer: Loggable {
     // MARK: - Public
 
+    /// Shared sound player instance.
     public static let shared = SoundPlayer()
 
     // MARK: - Private
@@ -180,6 +193,9 @@ public actor SoundPlayer: Loggable {
     ///
     /// Preparing a sound also acquires a playback session requirement and starts the
     /// local engine early to reduce first-play latency.
+    ///
+    /// - Note: Only local file URLs are supported.
+    /// - Note: The file format must be readable by `AVAudioFile` on the current platform.
     public func prepare(url: URL, withId id: String) async throws {
         guard sounds[id] == nil else { return }
 
@@ -255,7 +271,8 @@ public actor SoundPlayer: Loggable {
     ///
     /// Remote playback is best-effort and is skipped if remote routing is unavailable.
     ///
-    /// - Throws: ``LiveKitError`` if the sound is not prepared or local playback setup fails.
+    /// - Throws: ``LiveKitError`` if the sound is not prepared, local playback setup fails,
+    ///   or the local player-node pool is exhausted.
     public func play(id: String, options: PlaybackOptions = PlaybackOptions()) throws {
         let playLocal = options.destination == .local || options.destination == .localAndRemote
         let playRemote = options.destination == .remote || options.destination == .localAndRemote

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -262,7 +262,7 @@ extension SoundPlayer {
         if options.destination.includesLocal {
             let playerNodeFormat = try startEngineIfNeeded()
             let bufferToSchedule = try soundState.localBuffer(for: playerNodeFormat)
-            soundState.local.append(try playerNodePool.play(bufferToSchedule, loop: options.loop))
+            try soundState.local.append(playerNodePool.play(bufferToSchedule, loop: options.loop))
         }
 
         if options.destination.includesRemote {

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -56,6 +56,7 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
 
     private let engine = AVAudioEngine()
     private let playerNodePool: AVAudioPlayerNodePool
+    private let sessionRequirementId = UUID()
 
     private struct State {
         var sounds: [String: AVAudioPCMBuffer] = [:]
@@ -88,7 +89,21 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
                                              interleaved: outputFormat.isInterleaved)!
         engine.connect(playerNodePool, to: engine.mainMixerNode,
                        format: outputFormat, playerNodeFormat: playerNodeFormat)
+
+        #if os(iOS) || os(visionOS) || os(tvOS)
+        AudioManager.shared.audioSession.set(requirement: .playbackOnly, for: sessionRequirementId)
+        #endif
+
         try engine.start()
+    }
+
+    private func stopEngine() {
+        playerNodePool.stop()
+        engine.stop()
+
+        #if os(iOS) || os(visionOS) || os(tvOS)
+        AudioManager.shared.audioSession.set(requirement: .none, for: sessionRequirementId)
+        #endif
     }
 
     // MARK: - Public API
@@ -135,8 +150,7 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
         }
 
         if shouldStop {
-            playerNodePool.stop()
-            engine.stop()
+            stopEngine()
         }
     }
 
@@ -197,7 +211,7 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
             let playback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
             _state.mutate {
                 // Clean up finished playbacks
-                $0.activePlaybacks[id] = ($0.activePlaybacks[id] ?? []).filter { $0.isPlaying }
+                $0.activePlaybacks[id] = ($0.activePlaybacks[id] ?? []).filter(\.isPlaying)
                 $0.activePlaybacks[id, default: []].append(playback)
             }
         }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -91,7 +91,7 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
                        format: outputFormat, playerNodeFormat: playerNodeFormat)
 
         #if os(iOS) || os(visionOS) || os(tvOS)
-        AudioManager.shared.audioSession.set(requirement: .playbackOnly, for: sessionRequirementId)
+        try AudioManager.shared.audioSession.set(requirement: .playbackOnly, for: sessionRequirementId)
         #endif
 
         try engine.start()
@@ -102,7 +102,7 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
         engine.stop()
 
         #if os(iOS) || os(visionOS) || os(tvOS)
-        AudioManager.shared.audioSession.set(requirement: .none, for: sessionRequirementId)
+        try? AudioManager.shared.audioSession.set(requirement: .none, for: sessionRequirementId)
         #endif
     }
 

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -75,14 +75,22 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
         mutating func stop(destination: PlaybackOptions.Destination) {
             switch destination {
             case .local:
-                for p in local { p.stop() }
+                for p in local {
+                    p.stop()
+                }
                 local.removeAll()
             case .remote:
-                for p in remote { p.stop() }
+                for p in remote {
+                    p.stop()
+                }
                 remote.removeAll()
             case .localAndRemote:
-                for p in local { p.stop() }
-                for p in remote { p.stop() }
+                for p in local {
+                    p.stop()
+                }
+                for p in remote {
+                    p.stop()
+                }
                 local.removeAll()
                 remote.removeAll()
             }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -84,7 +84,7 @@ public actor SoundPlayer: Loggable {
 
     private struct Sound {
         let buffer: AVAudioPCMBuffer
-        let releaseSessionRequirement: @Sendable () -> Void
+        let sessionRequirementHandle: SessionRequirementHandle
         var local: [SoundPlayback] = []
         var remote: [SoundPlayback] = []
 
@@ -173,15 +173,6 @@ public actor SoundPlayer: Loggable {
         return converter.convert(from: buffer)
     }
 
-    private nonisolated static func acquirePlaybackSessionRelease() throws -> @Sendable () -> Void {
-        #if os(iOS) || os(visionOS) || os(tvOS)
-        let handle = try AudioManager.shared.audioSession.acquire(requirement: .playbackOnly)
-        return { try? handle.release() }
-        #else
-        return {}
-        #endif
-    }
-
     private nonisolated static func decodeBuffer(from url: URL) async throws -> AVAudioPCMBuffer {
         guard url.isFileURL else {
             throw LiveKitError(.invalidParameter, message: "Only file URLs are supported")
@@ -212,18 +203,18 @@ public actor SoundPlayer: Loggable {
         guard sounds[id] == nil else { return }
 
         let readBuffer = try await Self.decodeBuffer(from: url)
-        let releaseSessionRequirement = try Self.acquirePlaybackSessionRelease()
+        let sessionRequirementHandle = try AudioManager.shared.acquireSessionRequirement(.playbackOnly)
 
         do {
             guard sounds[id] == nil else {
-                releaseSessionRequirement()
+                try? sessionRequirementHandle.release()
                 return
             }
 
             _ = try startIfNeeded()
-            sounds[id] = Sound(buffer: readBuffer, releaseSessionRequirement: releaseSessionRequirement)
+            sounds[id] = Sound(buffer: readBuffer, sessionRequirementHandle: sessionRequirementHandle)
         } catch {
-            releaseSessionRequirement()
+            try? sessionRequirementHandle.release()
             throw error
         }
     }
@@ -236,7 +227,7 @@ public actor SoundPlayer: Loggable {
             stopEngine()
         }
 
-        sound.releaseSessionRequirement()
+        try? sound.sessionRequirementHandle.release()
     }
 
     /// Returns `true` if a sound has been prepared for the given identifier.

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -121,7 +121,7 @@ public final class SoundPlayer: Loggable {
     }
 
     /// Stops all playing or queued sounds without releasing prepared audio buffers.
-    public func stopAll(destination: PlaybackOptions.Destination = .localAndRemote) async {
+    public func stopAll(destination: SoundPlaybackOptions.Destination = .localAndRemote) async {
         for soundId in Array(sounds.keys) {
             if var sound = sounds[soundId] {
                 await sound.stop(destination: destination)
@@ -229,7 +229,7 @@ extension SoundPlayer {
         sounds[sound.id] != nil
     }
 
-    func isPlaying(_ sound: SoundHandle, destination: PlaybackOptions.Destination = .localAndRemote) -> Bool {
+    func isPlaying(_ sound: SoundHandle, destination: SoundPlaybackOptions.Destination = .localAndRemote) -> Bool {
         guard let sound = sounds[sound.id] else { return false }
         switch destination {
         case .local:
@@ -241,13 +241,13 @@ extension SoundPlayer {
         }
     }
 
-    func stop(_ sound: SoundHandle, destination: PlaybackOptions.Destination = .localAndRemote) async {
+    func stop(_ sound: SoundHandle, destination: SoundPlaybackOptions.Destination = .localAndRemote) async {
         guard var soundState = sounds[sound.id] else { return }
         await soundState.stop(destination: destination)
         if sounds[sound.id] != nil { sounds[sound.id] = soundState }
     }
 
-    func play(_ sound: SoundHandle, options: PlaybackOptions = PlaybackOptions()) async throws {
+    func play(_ sound: SoundHandle, options: SoundPlaybackOptions = SoundPlaybackOptions()) async throws {
         guard var soundState = sounds[sound.id] else {
             throw LiveKitError(.soundPlayer, message: "Sound not prepared")
         }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -174,6 +174,15 @@ public final class SoundPlayer: Loggable {
         var connectedOutputFormat: AVAudioFormat?
         var playerNodeFormat: AVAudioFormat?
         var needsReconnect = false
+
+        init(connectedOutputFormat: AVAudioFormat? = nil,
+             playerNodeFormat: AVAudioFormat? = nil,
+             needsReconnect: Bool = false)
+        {
+            self.connectedOutputFormat = connectedOutputFormat
+            self.playerNodeFormat = playerNodeFormat
+            self.needsReconnect = needsReconnect
+        }
     }
 
     private var sounds: [String: Sound] = [:]
@@ -215,12 +224,11 @@ public final class SoundPlayer: Loggable {
                       interleaved: outputFormat.isInterleaved)!
     }
 
-    private func invalidateLocalState() {
-        localEngineState.connectedOutputFormat = nil
-        localEngineState.playerNodeFormat = nil
-        localEngineState.needsReconnect = true
-        playerNodePool.reset()
+    private func resetLocalEngineState(needsReconnect: Bool) {
+        localEngineState = LocalEngineState(needsReconnect: needsReconnect)
+    }
 
+    private func invalidateCachedLocalBuffers() {
         for id in Array(sounds.keys) {
             guard var sound = sounds[id] else { continue }
             sound.cachedLocalBuffer = nil
@@ -228,6 +236,12 @@ public final class SoundPlayer: Loggable {
             sound.local.removeAll()
             sounds[id] = sound
         }
+    }
+
+    private func invalidateLocalState() {
+        resetLocalEngineState(needsReconnect: true)
+        playerNodePool.reset()
+        invalidateCachedLocalBuffers()
     }
 
     private func handleEngineConfigurationChange() {
@@ -265,9 +279,7 @@ public final class SoundPlayer: Loggable {
     }
 
     private func stopEngine() {
-        localEngineState.connectedOutputFormat = nil
-        localEngineState.playerNodeFormat = nil
-        localEngineState.needsReconnect = false
+        resetLocalEngineState(needsReconnect: false)
         playerNodePool.stop()
         engine.stop()
     }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -38,6 +38,14 @@ public struct PlaybackOptions: Sendable {
         ///
         /// Remote playback is best-effort and may be skipped if remote routing is unavailable.
         case localAndRemote
+
+        var includesLocal: Bool {
+            self == .local || self == .localAndRemote
+        }
+
+        var includesRemote: Bool {
+            self == .remote || self == .localAndRemote
+        }
     }
 
     public var mode: Mode
@@ -80,6 +88,13 @@ public actor SoundPlayer: Loggable {
         var local: [SoundPlayback] = []
         var remote: [SoundPlayback] = []
 
+        private static func stop(_ playbacks: inout [SoundPlayback]) async {
+            for playback in playbacks {
+                await playback.stop()
+            }
+            playbacks.removeAll()
+        }
+
         mutating func cleanUp() {
             local.removeAll { !$0.isPlaying }
             remote.removeAll { !$0.isPlaying }
@@ -88,24 +103,12 @@ public actor SoundPlayer: Loggable {
         mutating func stop(destination: PlaybackOptions.Destination) async {
             switch destination {
             case .local:
-                for p in local {
-                    await p.stop()
-                }
-                local.removeAll()
+                await Self.stop(&local)
             case .remote:
-                for p in remote {
-                    await p.stop()
-                }
-                remote.removeAll()
+                await Self.stop(&remote)
             case .localAndRemote:
-                for p in local {
-                    await p.stop()
-                }
-                for p in remote {
-                    await p.stop()
-                }
-                local.removeAll()
-                remote.removeAll()
+                await Self.stop(&local)
+                await Self.stop(&remote)
             }
         }
     }
@@ -170,6 +173,15 @@ public actor SoundPlayer: Loggable {
         return converter.convert(from: buffer)
     }
 
+    private nonisolated static func acquirePlaybackSessionRelease() throws -> @Sendable () -> Void {
+        #if os(iOS) || os(visionOS) || os(tvOS)
+        let handle = try AudioManager.shared.audioSession.acquire(requirement: .playbackOnly)
+        return { try? handle.release() }
+        #else
+        return {}
+        #endif
+    }
+
     private nonisolated static func decodeBuffer(from url: URL) async throws -> AVAudioPCMBuffer {
         guard url.isFileURL else {
             throw LiveKitError(.invalidParameter, message: "Only file URLs are supported")
@@ -200,14 +212,7 @@ public actor SoundPlayer: Loggable {
         guard sounds[id] == nil else { return }
 
         let readBuffer = try await Self.decodeBuffer(from: url)
-
-        let releaseSessionRequirement: @Sendable () -> Void
-        #if os(iOS) || os(visionOS) || os(tvOS)
-        let sessionRequirementHandle = try AudioManager.shared.audioSession.acquire(requirement: .playbackOnly)
-        releaseSessionRequirement = { try? sessionRequirementHandle.release() }
-        #else
-        releaseSessionRequirement = {}
-        #endif
+        let releaseSessionRequirement = try Self.acquirePlaybackSessionRelease()
 
         do {
             guard sounds[id] == nil else {
@@ -276,9 +281,6 @@ public actor SoundPlayer: Loggable {
     /// - Throws: ``LiveKitError`` if the sound is not prepared, local playback setup fails,
     ///   or the local player-node pool is exhausted.
     public func play(id: String, options: PlaybackOptions = PlaybackOptions()) async throws {
-        let playLocal = options.destination == .local || options.destination == .localAndRemote
-        let playRemote = options.destination == .remote || options.destination == .localAndRemote
-
         guard var sound = sounds[id] else {
             throw LiveKitError(.audioEngine, message: "Sound not prepared")
         }
@@ -292,13 +294,13 @@ public actor SoundPlayer: Loggable {
         var localPlayback: SoundPlayback?
         var remotePlayback: SoundPlayback?
 
-        if playLocal {
+        if options.destination.includesLocal {
             let playerNodeFormat = try startIfNeeded()
             let bufferToSchedule = try convertBuffer(sound.buffer, to: playerNodeFormat)
             localPlayback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
         }
 
-        if playRemote {
+        if options.destination.includesRemote {
             remotePlayback = AudioManager.shared.mixer.playSound(sound.buffer, loop: options.loop)
         }
 

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -224,18 +224,15 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
 
     /// Returns `true` if the sound currently has active playback for the selected destination.
     public func isPlaying(id: String, destination: PlaybackOptions.Destination = .localAndRemote) -> Bool {
-        _state.mutate { state in
-            guard var sound = state.sounds[id] else { return false }
-            sound.cleanUp()
-            state.sounds[id] = sound
-
+        _state.read { state in
+            guard let sound = state.sounds[id] else { return false }
             switch destination {
             case .local:
-                return !sound.local.isEmpty
+                return sound.local.contains(where: \.isPlaying)
             case .remote:
-                return !sound.remote.isEmpty
+                return sound.remote.contains(where: \.isPlaying)
             case .localAndRemote:
-                return !sound.local.isEmpty || !sound.remote.isEmpty
+                return sound.local.contains(where: \.isPlaying) || sound.remote.contains(where: \.isPlaying)
             }
         }
     }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -30,9 +30,13 @@ public struct PlaybackOptions: Sendable {
     public enum Destination: Sendable {
         /// Play locally only (through device speakers).
         case local
-        /// Play for remote participants only (through WebRTC). Requires an active Room connection.
+        /// Play for remote participants only (through WebRTC).
+        ///
+        /// If remote routing is unavailable, playback is skipped.
         case remote
         /// Play both locally and for remote participants.
+        ///
+        /// Remote playback is best-effort and may be skipped if remote routing is unavailable.
         case localAndRemote
     }
 
@@ -87,6 +91,7 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
 
     private struct State {
         var sounds: [String: Sound] = [:]
+        var playerNodeFormat: AVAudioFormat?
     }
 
     private let _state = StateSync(State())
@@ -104,21 +109,30 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
         return format
     }
 
-    private func startIfNeeded() throws {
-        guard !engine.isRunning else { return }
+    private func makePlayerNodeFormat(for outputFormat: AVAudioFormat) -> AVAudioFormat {
+        AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                      sampleRate: outputFormat.sampleRate,
+                      channels: outputFormat.channelCount,
+                      interleaved: outputFormat.isInterleaved)!
+    }
+
+    private func startIfNeeded(state: inout State) throws -> AVAudioFormat {
+        if engine.isRunning, let playerNodeFormat = state.playerNodeFormat {
+            return playerNodeFormat
+        }
         guard let outputFormat else {
             throw LiveKitError(.audioEngine, message: "Invalid output format")
         }
-        let playerNodeFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
-                                             sampleRate: outputFormat.sampleRate,
-                                             channels: outputFormat.channelCount,
-                                             interleaved: outputFormat.isInterleaved)!
+        let playerNodeFormat = makePlayerNodeFormat(for: outputFormat)
         engine.connect(playerNodePool, to: engine.mainMixerNode,
                        format: outputFormat, playerNodeFormat: playerNodeFormat)
         try engine.start()
+        state.playerNodeFormat = playerNodeFormat
+        return playerNodeFormat
     }
 
-    private func stopEngine() {
+    private func stopEngine(state: inout State) {
+        state.playerNodeFormat = nil
         playerNodePool.stop()
         engine.stop()
     }
@@ -140,6 +154,10 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
 
     // MARK: - Public API
 
+    /// Decodes and caches audio for the given identifier.
+    ///
+    /// Preparing a sound also acquires a playback session requirement and starts the
+    /// local engine early to reduce first-play latency.
     public func prepare(url: URL, withId id: String) throws {
         // Already prepared, ignore.
         guard _state.read({ $0.sounds[id] }) == nil else { return }
@@ -159,87 +177,127 @@ public class SoundPlayer: Loggable, @unchecked Sendable {
         try AudioManager.shared.audioSession.set(requirement: .playbackOnly, for: requirementId)
         #endif
 
-        try startIfNeeded()
+        do {
+            let wasAlreadyPrepared = try _state.mutate { state in
+                guard state.sounds[id] == nil else { return true }
+                _ = try startIfNeeded(state: &state)
+                state.sounds[id] = Sound(buffer: readBuffer, sessionRequirementId: requirementId)
+                return false
+            }
 
-        _state.mutate {
-            $0.sounds[id] = Sound(buffer: readBuffer, sessionRequirementId: requirementId)
+            guard !wasAlreadyPrepared else {
+                #if os(iOS) || os(visionOS) || os(tvOS)
+                try? AudioManager.shared.audioSession.removeRequirement(for: requirementId)
+                #endif
+                return
+            }
+        } catch {
+            #if os(iOS) || os(visionOS) || os(tvOS)
+            try? AudioManager.shared.audioSession.removeRequirement(for: requirementId)
+            #endif
+            throw error
         }
     }
 
+    /// Releases a prepared sound, stops any active playback, and relinquishes its session requirement.
     public func release(id: String) {
-        let (sound, shouldStop) = _state.mutate {
-            $0.sounds[id]?.stop(destination: .localAndRemote)
-            let sound = $0.sounds.removeValue(forKey: id)
-            return (sound, $0.sounds.isEmpty)
-        }
-
-        if shouldStop {
-            stopEngine()
+        let sound = _state.mutate { state -> Sound? in
+            guard var sound = state.sounds.removeValue(forKey: id) else { return nil }
+            sound.stop(destination: .localAndRemote)
+            if state.sounds.isEmpty {
+                stopEngine(state: &state)
+            }
+            return sound
         }
 
         #if os(iOS) || os(visionOS) || os(tvOS)
         if let sound {
-            try? AudioManager.shared.audioSession.set(requirement: .none, for: sound.sessionRequirementId)
+            try? AudioManager.shared.audioSession.removeRequirement(for: sound.sessionRequirementId)
         }
         #endif
     }
 
+    /// Returns `true` if a sound has been prepared for the given identifier.
+    public func isPrepared(id: String) -> Bool {
+        _state.read { $0.sounds[id] != nil }
+    }
+
+    /// Returns `true` if the sound currently has active playback for the selected destination.
+    public func isPlaying(id: String, destination: PlaybackOptions.Destination = .localAndRemote) -> Bool {
+        _state.mutate { state in
+            guard var sound = state.sounds[id] else { return false }
+            sound.cleanUp()
+            state.sounds[id] = sound
+
+            switch destination {
+            case .local:
+                return !sound.local.isEmpty
+            case .remote:
+                return !sound.remote.isEmpty
+            case .localAndRemote:
+                return !sound.local.isEmpty || !sound.remote.isEmpty
+            }
+        }
+    }
+
     /// Stops all playing or queued sounds without releasing prepared audio buffers.
     public func stopAll(destination: PlaybackOptions.Destination = .localAndRemote) {
-        _state.mutate {
-            for id in $0.sounds.keys {
-                $0.sounds[id]?.stop(destination: destination)
+        _state.mutate { state in
+            for id in state.sounds.keys {
+                state.sounds[id]?.stop(destination: destination)
             }
         }
     }
 
     /// Stops all playing or queued sounds for the specified id without releasing prepared audio buffers.
     public func stop(id: String, destination: PlaybackOptions.Destination = .localAndRemote) {
-        _state.mutate {
-            $0.sounds[id]?.stop(destination: destination)
+        _state.mutate { state in
+            state.sounds[id]?.stop(destination: destination)
         }
     }
 
+    /// Plays a prepared sound.
+    ///
+    /// Remote playback is best-effort and is skipped if remote routing is unavailable.
+    ///
+    /// - Throws: ``LiveKitError`` if the sound is not prepared or local playback setup fails.
     public func play(id: String, options: PlaybackOptions = PlaybackOptions()) throws {
-        if options.mode == .replace {
-            stop(id: id)
-        }
-
-        guard let buffer = _state.read({ $0.sounds[id]?.buffer }) else {
-            throw LiveKitError(.audioEngine, message: "Sound not prepared")
-        }
-
         let playLocal = options.destination == .local || options.destination == .localAndRemote
         let playRemote = options.destination == .remote || options.destination == .localAndRemote
 
-        var localPlayback: SoundPlayback?
-        var remotePlayback: SoundPlayback?
-
-        if playLocal {
-            try startIfNeeded()
-
-            guard let outputFormat else {
-                throw LiveKitError(.audioEngine, message: "Failed to get output format")
+        try _state.mutate { state in
+            guard var sound = state.sounds[id] else {
+                throw LiveKitError(.audioEngine, message: "Sound not prepared")
             }
 
-            let bufferToSchedule = try convertBuffer(buffer, to: outputFormat)
-            localPlayback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
-        }
-
-        if playRemote {
-            remotePlayback = AudioManager.shared.mixer.playSound(buffer, loop: options.loop)
-        }
-
-        if localPlayback != nil || remotePlayback != nil {
-            _state.mutate {
-                $0.sounds[id]?.cleanUp()
-                if let localPlayback {
-                    $0.sounds[id]?.local.append(localPlayback)
-                }
-                if let remotePlayback {
-                    $0.sounds[id]?.remote.append(remotePlayback)
-                }
+            if options.mode == .replace {
+                sound.stop(destination: .localAndRemote)
             }
+
+            sound.cleanUp()
+
+            var localPlayback: SoundPlayback?
+            var remotePlayback: SoundPlayback?
+
+            if playLocal {
+                let playerNodeFormat = try startIfNeeded(state: &state)
+                let bufferToSchedule = try convertBuffer(sound.buffer, to: playerNodeFormat)
+                localPlayback = try playerNodePool.play(bufferToSchedule, loop: options.loop)
+            }
+
+            if playRemote {
+                remotePlayback = AudioManager.shared.mixer.playSound(sound.buffer, loop: options.loop)
+            }
+
+            if let localPlayback {
+                sound.local.append(localPlayback)
+            }
+
+            if let remotePlayback {
+                sound.remote.append(remotePlayback)
+            }
+
+            state.sounds[id] = sound
         }
     }
 }

--- a/Sources/LiveKit/Errors.swift
+++ b/Sources/LiveKit/Errors.swift
@@ -57,6 +57,7 @@ public enum LiveKitErrorType: Int, Sendable {
     // Audio
     case audioEngine = 801
     case audioSession = 802
+    case soundPlayer = 803
 
     case codecNotSupported = 901
 
@@ -118,6 +119,8 @@ extension LiveKitErrorType: CustomStringConvertible {
             "Audio Engine Error"
         case .audioSession:
             "Audio Session Error"
+        case .soundPlayer:
+            "Sound Player Error"
         case .codecNotSupported:
             "Codec not supported"
         case .encryptionFailed:

--- a/Sources/LiveKit/Support/Audio/AudioConverter.swift
+++ b/Sources/LiveKit/Support/Audio/AudioConverter.swift
@@ -17,6 +17,8 @@
 @preconcurrency import AVFAudio
 
 final class AudioConverter: Sendable {
+    static let defaultOutputBufferCapacity: AVAudioFrameCount = 1024 * 10
+
     let inputFormat: AVAudioFormat
     let outputFormat: AVAudioFormat
 
@@ -28,10 +30,10 @@ final class AudioConverter: Sendable {
         let inputSampleRate = inputFormat.sampleRate
         let outputSampleRate = outputFormat.sampleRate
         // Compute the output frame capacity based on sample rate ratio
-        return AVAudioFrameCount(Double(inputFrameCount) * (outputSampleRate / inputSampleRate))
+        return AVAudioFrameCount(ceil(Double(inputFrameCount) * (outputSampleRate / inputSampleRate)))
     }
 
-    init?(from inputFormat: AVAudioFormat, to outputFormat: AVAudioFormat, outputBufferCapacity: AVAudioFrameCount = 9600) {
+    init?(from inputFormat: AVAudioFormat, to outputFormat: AVAudioFormat, outputBufferCapacity: AVAudioFrameCount = AudioConverter.defaultOutputBufferCapacity) {
         guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat),
               let buffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: outputBufferCapacity)
         else {


### PR DESCRIPTION
Conveniently prepare and play short audio clips locally and/or for remote participants.

```swift
// Prepare
let sound = try await SoundPlayer.shared.prepare(
    fileURL: fileURL,
    named: "sample01" // optional
)

// Playback
try await sound.play(
    options: SoundPlaybackOptions(
        mode: .concurrent,
        loop: false,
        destination: .localAndRemote
    )
)

// Stop / release
await sound.stop()
await sound.release()
```

Remote playback is best-effort and usually requires the microphone/WebRTC input path to be published.

Example: https://github.com/livekit-examples/swift-example/pull/89