### PR TITLE
Skip audio session config in manual rendering mode

### DIFF
--- a/.changes/manual-mode-skip-session-config
+++ b/.changes/manual-mode-skip-session-config
@@ -1,0 +1,1 @@
+patch type="changed" "Skip AVAudioSession configuration in manual rendering mode"

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -215,6 +215,11 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
     // MARK: - AudioEngineObserver
 
     public func engineWillEnable(_ engine: AVAudioEngine, isPlayoutEnabled: Bool, isRecordingEnabled: Bool) -> Int {
+        // No device access in manual rendering mode, skip session requirement.
+        if engine.isInManualRenderingMode {
+            return _state.next?.engineWillEnable(engine, isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled) ?? 0
+        }
+
         let requirement = SessionRequirement(isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled)
         do {
             try set(requirement: requirement, for: sessionRequirementId)
@@ -226,6 +231,10 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
 
     public func engineDidDisable(_ engine: AVAudioEngine, isPlayoutEnabled: Bool, isRecordingEnabled: Bool) -> Int {
         let nextResult = _state.next?.engineDidDisable(engine, isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled) ?? 0
+
+        if engine.isInManualRenderingMode {
+            return nextResult
+        }
 
         let requirement = SessionRequirement(isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled)
         do {

--- a/Sources/LiveKit/Audio/Manager/AudioManager.swift
+++ b/Sources/LiveKit/Audio/Manager/AudioManager.swift
@@ -366,6 +366,7 @@ public class AudioManager: Loggable {
     /// Enables manual rendering (no-device) mode of AVAudioEngine.
     /// In this mode, you can provide audio buffers by calling `AudioManager.shared.mixer.capture(appAudio:)` continuously.
     /// Remote audio will not play out automatically. Get remote mixed audio buffers with `AudioManager.shared.add(localAudioRenderer:)` or individual tracks with ``RemoteAudioTrack/add(audioRenderer:)``.
+    /// - Note: While enabled, the SDK will not configure `AVAudioSession`. Configure it yourself if your app does its own audio I/O.
     public func setManualRenderingMode(_ enabled: Bool) throws {
         let result = RTC.audioDeviceModule.setManualRenderingMode(enabled)
         try checkAdmResult(code: result)


### PR DESCRIPTION
I think we had this before but it got lost somewhere 🤔