### PR TITLE
Add E2EE configuration to Session API

### DIFF
--- a/.changes/session-e2ee
+++ b/.changes/session-e2ee
@@ -1,0 +1,1 @@
+minor type="added" "Configure end-to-end encryption directly through Session initialization"

--- a/Sources/LiveKit/Agent/Session.swift
+++ b/Sources/LiveKit/Agent/Session.swift
@@ -33,6 +33,22 @@ import Foundation
 /// conversation. The session can be configured with custom message senders and receivers
 /// to support different communication channels, such as text messages or transcription streams.
 ///
+/// To enable end-to-end encryption, use the convenience
+/// ``SessionOptions/init(encryption:preConnectAudio:agentConnectTimeout:)``
+/// initializer:
+///
+/// ```swift
+/// let session = Session(
+///     tokenSource: tokenSource,
+///     options: SessionOptions(encryption: .sharedKey("my-shared-secret"))
+/// )
+/// ```
+///
+/// For advanced E2EE flows (custom key provider, per-participant keys, custom
+/// `RoomOptions`), build and configure a ``Room`` yourself and pass it via
+/// ``SessionOptions/init(room:preConnectAudio:agentConnectTimeout:)``. Use
+/// ``setEncryptionEnabled(_:)`` to toggle encryption at runtime.
+///
 /// - SeeAlso: [LiveKit SwiftUI Agent Starter](https://github.com/livekit-examples/agent-starter-swift).
 /// - SeeAlso: [LiveKit Agents documentation](https://docs.livekit.io/agents/).
 @MainActor
@@ -296,6 +312,18 @@ open class Session: ObservableObject {
     /// Resets the last error.
     public func dismissError() {
         error = nil
+    }
+
+    /// Enables or disables end-to-end encryption on the underlying ``Room``.
+    ///
+    /// Requires that encryption was configured via
+    /// ``SessionOptions/init(encryption:preConnectAudio:agentConnectTimeout:)``
+    /// or that the ``Room`` was created with `EncryptionOptions`. Otherwise
+    /// this is a no-op.
+    ///
+    /// - Parameter enabled: Whether to enable encryption.
+    public func setEncryptionEnabled(_ enabled: Bool) {
+        room.setE2EEEnabled(enabled)
     }
 
     // MARK: - Messages

--- a/Sources/LiveKit/Agent/SessionOptions.swift
+++ b/Sources/LiveKit/Agent/SessionOptions.swift
@@ -38,4 +38,29 @@ public struct SessionOptions: Sendable {
         self.preConnectAudio = preConnectAudio
         self.agentConnectTimeout = agentConnectTimeout
     }
+
+    /// Convenience initializer that configures the underlying ``Room`` with
+    /// end-to-end encryption.
+    ///
+    /// The ``Room`` is constructed internally with
+    /// `RoomOptions(encryptionOptions: encryption)`. Use this for the common
+    /// case where you only need to enable E2EE; for advanced configuration
+    /// (custom `RoomOptions`, delegate, per-participant key management),
+    /// build a ``Room`` yourself and use ``init(room:preConnectAudio:agentConnectTimeout:)``.
+    ///
+    /// - Parameters:
+    ///   - encryption: The end-to-end encryption configuration.
+    ///   - preConnectAudio: Whether to enable audio pre-connect.
+    ///   - agentConnectTimeout: Timeout for the agent to connect, in seconds.
+    public init(
+        encryption: EncryptionOptions,
+        preConnectAudio: Bool = true,
+        agentConnectTimeout: TimeInterval = 20
+    ) {
+        self.init(
+            room: Room(roomOptions: RoomOptions(encryptionOptions: encryption)),
+            preConnectAudio: preConnectAudio,
+            agentConnectTimeout: agentConnectTimeout
+        )
+    }
 }

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -96,6 +96,17 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
         set { _e2eeManager.mutate { $0 = newValue } }
     }
 
+    /// Enables or disables end-to-end encryption on this Room.
+    ///
+    /// Requires the Room to have been constructed with ``EncryptionOptions``
+    /// (via ``RoomOptions/encryptionOptions``) and to be connected.
+    /// Otherwise this is a no-op.
+    ///
+    /// - Parameter enabled: Whether to enable encryption.
+    public func setE2EEEnabled(_ enabled: Bool) {
+        e2eeManager?.enableE2EE(enabled: enabled)
+    }
+
     public lazy var localParticipant: LocalParticipant = .init(room: self)
 
     let primaryTransportConnectedCompleter = AsyncCompleter<Void>(label: "Primary transport connect", defaultTimeout: .defaultTransportState)

--- a/Sources/LiveKit/E2EE/Options.swift
+++ b/Sources/LiveKit/E2EE/Options.swift
@@ -88,6 +88,19 @@ public final class EncryptionOptions: NSObject, Sendable {
         self.encryptionType = encryptionType
     }
 
+    /// Creates `EncryptionOptions` configured with a shared-key
+    /// `BaseKeyProvider` derived from the given passphrase.
+    ///
+    /// - Parameters:
+    ///   - key: The shared passphrase used to derive the encryption key.
+    ///   - encryptionType: The encryption algorithm to use. Defaults to `.gcm`.
+    public static func sharedKey(_ key: String,
+                                 encryptionType: EncryptionType = .gcm) -> EncryptionOptions
+    {
+        EncryptionOptions(keyProvider: BaseKeyProvider(isSharedKey: true, sharedKey: key),
+                          encryptionType: encryptionType)
+    }
+
     // MARK: - Equal
 
     override public func isEqual(_ object: Any?) -> Bool {

--- a/Tests/LiveKitCoreTests/Agent/SessionOptionsTests.swift
+++ b/Tests/LiveKitCoreTests/Agent/SessionOptionsTests.swift
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+class SessionOptionsTests: LKTestCase, @unchecked Sendable {
+    // MARK: - EncryptionOptions.sharedKey
+
+    func testSharedKeyFactoryDefaults() {
+        let options = EncryptionOptions.sharedKey("my-secret")
+
+        XCTAssertEqual(options.encryptionType, .gcm)
+        XCTAssertTrue(options.keyProvider.options.sharedKey)
+    }
+
+    func testSharedKeyFactoryRespectsEncryptionType() {
+        let options = EncryptionOptions.sharedKey("my-secret", encryptionType: .custom)
+
+        XCTAssertEqual(options.encryptionType, .custom)
+        XCTAssertTrue(options.keyProvider.options.sharedKey)
+    }
+
+    // MARK: - SessionOptions(encryption:)
+
+    func testEncryptionInitPlumbsOptionsThroughToRoom() {
+        let encryption = EncryptionOptions.sharedKey("my-secret")
+        let options = SessionOptions(encryption: encryption)
+
+        // The underlying Room carries the encryption options in its RoomOptions.
+        let plumbed = options.room._state.roomOptions.encryptionOptions
+        XCTAssertNotNil(plumbed)
+        XCTAssertTrue(plumbed === encryption)
+    }
+
+    func testEncryptionInitPreservesOtherDefaults() {
+        let options = SessionOptions(encryption: .sharedKey("k"))
+
+        XCTAssertTrue(options.preConnectAudio)
+        XCTAssertEqual(options.agentConnectTimeout, 20)
+    }
+
+    func testEncryptionInitForwardsOtherOptions() {
+        let options = SessionOptions(
+            encryption: .sharedKey("k"),
+            preConnectAudio: false,
+            agentConnectTimeout: 5
+        )
+
+        XCTAssertFalse(options.preConnectAudio)
+        XCTAssertEqual(options.agentConnectTimeout, 5)
+    }
+
+    // MARK: - SessionOptions(room:) escape hatch
+
+    func testRoomInitPreservesProvidedRoom() {
+        let provided = Room()
+        let options = SessionOptions(room: provided)
+
+        XCTAssertTrue(options.room === provided)
+    }
+}


### PR DESCRIPTION
Mirrors the recent JS and Flutter improvements that let users enable end-to-end encryption directly through `Session` initialization, instead of building a `Room` with `RoomOptions` + `EncryptionOptions` manually.

- `SessionOptions(encryption: .sharedKey("..."))` convenience init builds the underlying Room with the encryption options baked in.
- `EncryptionOptions.sharedKey(_:encryptionType:)` static factory for the common shared-passphrase case.
- `Session.setEncryptionEnabled(_:)` and `Room.setE2EEEnabled(_:)` for runtime toggling, matching the JS/Flutter API surface.
- Mutual exclusion of `room:` and `encryption:` is enforced at compile time via init overloads (no overload accepts both), rather than the runtime validation Flutter uses.
- Fully non-breaking: the existing `var room: Room` field and `init(room:)` are unchanged.