### PR TITLE
ci: remove unused dependabot field

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    versioning-strategy: "increase-if-necessary"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
As mentioned [here](https://github.com/livekit/client-sdk-swift/pull/989#discussion_r3199891397) it fails
<img width="938" height="196" alt="image" src="https://github.com/user-attachments/assets/4f9343fd-cee7-4ece-b2a5-fb483dd89c52" />

