### PR TITLE
ci: fix permissions

### DIFF
--- a/.github/workflows/cocoapods-lint.yaml
+++ b/.github/workflows/cocoapods-lint.yaml
@@ -8,6 +8,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   lint:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/livekit/client-sdk-swift/security/code-scanning/23](https://github.com/livekit/client-sdk-swift/security/code-scanning/23)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (including `lint`). The minimal safe setting here is:

- `contents: read`

This preserves current functionality (`actions/checkout` needs read access to contents) while preventing unnecessary token write privileges.  
Edit `.github/workflows/cocoapods-lint.yaml` near the top-level keys, ideally after `concurrency` (or after `on`) and before `jobs`.

No imports, methods, or dependencies are required—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
