### PR TITLE
Expose key derivation algorithm on KeyProviderOptions

### DIFF
--- a/.changes/e2ee-key-derivation-algo
+++ b/.changes/e2ee-key-derivation-algo
@@ -1,0 +1,1 @@
+minor type="added" "Expose `keyDerivationAlgorithm` (PBKDF2/HKDF) and `discardFrameWhenCryptorNotReady` on `KeyProviderOptions` for parity with Android"

--- a/Sources/LiveKit/E2EE/KeyProvider.swift
+++ b/Sources/LiveKit/E2EE/KeyProvider.swift
@@ -25,6 +25,17 @@ public let defaultRatchetWindowSize: Int32 = 0
 public let defaultFailureTolerance: Int32 = -1
 public let defaultKeyRingSize: Int32 = 16
 
+/// Algorithm used to derive encryption keys from the input key material.
+///
+/// - SeeAlso: ``KeyProviderOptions``
+@objc
+public enum KeyDerivationAlgorithm: Int, Sendable {
+    /// PBKDF2 — matches the WebRTC default and prior SDK behavior.
+    case pbkdf2 = 0
+    /// HKDF — required for interop with peers that derive keys via HKDF.
+    case hkdf = 1
+}
+
 @objcMembers
 public final class KeyProviderOptions: NSObject, Sendable {
     public let sharedKey: Bool
@@ -39,12 +50,18 @@ public final class KeyProviderOptions: NSObject, Sendable {
 
     public let keyRingSize: Int32
 
+    public let discardFrameWhenCryptorNotReady: Bool
+
+    public let keyDerivationAlgorithm: KeyDerivationAlgorithm
+
     public init(sharedKey: Bool = true,
                 ratchetSalt: Data = defaultRatchetSalt.data(using: .utf8)!,
                 ratchetWindowSize: Int32 = defaultRatchetWindowSize,
                 uncryptedMagicBytes: Data = defaultMagicBytes.data(using: .utf8)!,
                 failureTolerance: Int32 = defaultFailureTolerance,
-                keyRingSize: Int32 = defaultKeyRingSize)
+                keyRingSize: Int32 = defaultKeyRingSize,
+                discardFrameWhenCryptorNotReady: Bool = false,
+                keyDerivationAlgorithm: KeyDerivationAlgorithm = .pbkdf2)
     {
         self.sharedKey = sharedKey
         self.ratchetSalt = ratchetSalt
@@ -52,6 +69,8 @@ public final class KeyProviderOptions: NSObject, Sendable {
         self.uncryptedMagicBytes = uncryptedMagicBytes
         self.failureTolerance = failureTolerance
         self.keyRingSize = keyRingSize
+        self.discardFrameWhenCryptorNotReady = discardFrameWhenCryptorNotReady
+        self.keyDerivationAlgorithm = keyDerivationAlgorithm
     }
 
     // MARK: - Equal
@@ -63,7 +82,9 @@ public final class KeyProviderOptions: NSObject, Sendable {
             ratchetWindowSize == other.ratchetWindowSize &&
             uncryptedMagicBytes == other.uncryptedMagicBytes &&
             failureTolerance == other.failureTolerance &&
-            keyRingSize == other.keyRingSize
+            keyRingSize == other.keyRingSize &&
+            discardFrameWhenCryptorNotReady == other.discardFrameWhenCryptorNotReady &&
+            keyDerivationAlgorithm == other.keyDerivationAlgorithm
     }
 
     override public var hash: Int {
@@ -74,6 +95,8 @@ public final class KeyProviderOptions: NSObject, Sendable {
         hasher.combine(uncryptedMagicBytes)
         hasher.combine(failureTolerance)
         hasher.combine(keyRingSize)
+        hasher.combine(discardFrameWhenCryptorNotReady)
+        hasher.combine(keyDerivationAlgorithm)
         return hasher.finalize()
     }
 }
@@ -103,7 +126,9 @@ public final class BaseKeyProvider: NSObject, Loggable, Sendable {
                                                       sharedKeyMode: isSharedKey,
                                                       uncryptedMagicBytes: options.uncryptedMagicBytes,
                                                       failureTolerance: options.failureTolerance,
-                                                      keyRingSize: options.keyRingSize)
+                                                      keyRingSize: options.keyRingSize,
+                                                      discardFrameWhenCryptorNotReady: options.discardFrameWhenCryptorNotReady,
+                                                      keyDerivationAlgorithm: options.keyDerivationAlgorithm.toRTCType())
         if isSharedKey, sharedKey != nil {
             let keyData = sharedKey!.data(using: .utf8)!
             rtcKeyProvider.setSharedKey(keyData, with: 0)
@@ -117,7 +142,9 @@ public final class BaseKeyProvider: NSObject, Loggable, Sendable {
                                                       sharedKeyMode: options.sharedKey,
                                                       uncryptedMagicBytes: options.uncryptedMagicBytes,
                                                       failureTolerance: options.failureTolerance,
-                                                      keyRingSize: options.keyRingSize)
+                                                      keyRingSize: options.keyRingSize,
+                                                      discardFrameWhenCryptorNotReady: options.discardFrameWhenCryptorNotReady,
+                                                      keyDerivationAlgorithm: options.keyDerivationAlgorithm.toRTCType())
     }
 
     // MARK: - Key management
@@ -196,5 +223,14 @@ public final class BaseKeyProvider: NSObject, Loggable, Sendable {
         hasher.combine(options)
         hasher.combine(rtcKeyProvider)
         return hasher.finalize()
+    }
+}
+
+extension KeyDerivationAlgorithm {
+    func toRTCType() -> LKRTCKeyDerivationAlgorithm {
+        switch self {
+        case .pbkdf2: LKRTCKeyDerivationAlgorithm(rawValue: 0)!
+        case .hkdf: LKRTCKeyDerivationAlgorithm(rawValue: 1)!
+        }
     }
 }

--- a/Tests/LiveKitCoreTests/DataChannel/EncryptedDataChannelTests.swift
+++ b/Tests/LiveKitCoreTests/DataChannel/EncryptedDataChannelTests.swift
@@ -44,18 +44,31 @@ import LiveKitWebRTC
         }
     }
 
-    @Test func encryptionWithSharedKey() async throws {
+    /// Builds a publisher/subscriber room pair, each with its own key provider.
+    private func encryptedRooms(sender: BaseKeyProvider, receiver: BaseKeyProvider) -> [RoomTestingOptions] {
+        [
+            RoomTestingOptions(encryptionOptions: EncryptionOptions(keyProvider: sender), canPublishData: true),
+            RoomTestingOptions(delegate: self, encryptionOptions: EncryptionOptions(keyProvider: receiver), canSubscribe: true),
+        ]
+    }
+
+    @Test(arguments: [KeyDerivationAlgorithm.pbkdf2, .hkdf])
+    func encryptionWithSharedKey(algorithm: KeyDerivationAlgorithm) async throws {
         let testMessage = "Hello, encrypted world!"
         let testData = try #require(testMessage.data(using: .utf8))
+
+        let sharedKey = "shared-key-\(UUID().uuidString)"
+        let options = KeyProviderOptions(sharedKey: true, keyDerivationAlgorithm: algorithm)
+        let senderKeyProvider = BaseKeyProvider(options: options)
+        let receiverKeyProvider = BaseKeyProvider(options: options)
+        senderKeyProvider.setKey(key: sharedKey)
+        receiverKeyProvider.setKey(key: sharedKey)
 
         try await confirmation("Encrypted data received") { confirm in
             self._receivedData.mutate { $0 = Data() }
             self._onDataReceived.mutate { $0 = { confirm() } }
 
-            try await TestEnvironment.withRooms([
-                RoomTestingOptions(canPublishData: true),
-                RoomTestingOptions(delegate: self, canSubscribe: true),
-            ]) { rooms in
+            try await TestEnvironment.withRooms(encryptedRooms(sender: senderKeyProvider, receiver: receiverKeyProvider)) { rooms in
                 let sender = rooms[0]
                 let remoteIdentity = try #require(sender.remoteParticipants.keys.first)
 
@@ -74,12 +87,14 @@ import LiveKitWebRTC
         }
     }
 
-    @Test func encryptionWithPerParticipantKeys() async throws {
+    @Test(arguments: [KeyDerivationAlgorithm.pbkdf2, .hkdf])
+    func encryptionWithPerParticipantKeys(algorithm: KeyDerivationAlgorithm) async throws {
         let testMessage = "Hello, per-participant encrypted world!"
         let testData = try #require(testMessage.data(using: .utf8))
 
-        let senderKeyProvider = BaseKeyProvider(isSharedKey: false)
-        let receiverKeyProvider = BaseKeyProvider(isSharedKey: false)
+        let perParticipantOptions = KeyProviderOptions(sharedKey: false, keyDerivationAlgorithm: algorithm)
+        let senderKeyProvider = BaseKeyProvider(options: perParticipantOptions)
+        let receiverKeyProvider = BaseKeyProvider(options: perParticipantOptions)
 
         let senderKey = "sender-secret-key-123"
         let receiverKey = "receiver-secret-key-456"
@@ -88,15 +103,7 @@ import LiveKitWebRTC
             self._receivedData.mutate { $0 = Data() }
             self._onDataReceived.mutate { $0 = { confirm() } }
 
-            try await TestEnvironment.withRooms([
-                RoomTestingOptions(
-                    encryptionOptions: EncryptionOptions(keyProvider: senderKeyProvider), canPublishData: true
-                ),
-                RoomTestingOptions(
-                    delegate: self,
-                    encryptionOptions: EncryptionOptions(keyProvider: receiverKeyProvider), canSubscribe: true
-                ),
-            ]) { rooms in
+            try await TestEnvironment.withRooms(encryptedRooms(sender: senderKeyProvider, receiver: receiverKeyProvider)) { rooms in
                 let sender = rooms[0]
                 let receiver = rooms[1]
 
@@ -125,32 +132,26 @@ import LiveKitWebRTC
         }
     }
 
-    @Test func decryptionFailureWithSharedKey() async throws {
+    @Test(arguments: [KeyDerivationAlgorithm.pbkdf2, .hkdf])
+    func decryptionFailureWithSharedKey(algorithm: KeyDerivationAlgorithm) async throws {
         let testMessage = "This should fail to decrypt!"
         let testData = try #require(testMessage.data(using: .utf8))
 
         let senderKey = "sender-shared-key-123"
         let receiverKey = "receiver-shared-key-456"
 
-        let senderKeyProvider = BaseKeyProvider(isSharedKey: true, sharedKey: senderKey)
-        let receiverKeyProvider = BaseKeyProvider(isSharedKey: true, sharedKey: receiverKey)
+        let sharedOptions = KeyProviderOptions(sharedKey: true, keyDerivationAlgorithm: algorithm)
+        let senderKeyProvider = BaseKeyProvider(options: sharedOptions)
+        let receiverKeyProvider = BaseKeyProvider(options: sharedOptions)
+        senderKeyProvider.setKey(key: senderKey)
+        receiverKeyProvider.setKey(key: receiverKey)
 
         try await confirmation("Decryption error occurred") { confirm in
             self._receivedData.mutate { $0 = Data() }
             self._lastDecryptionError.mutate { $0 = nil }
             self._onDecryptionError.mutate { $0 = { confirm() } }
 
-            try await TestEnvironment.withRooms([
-                RoomTestingOptions(
-                    encryptionOptions: EncryptionOptions(keyProvider: senderKeyProvider),
-                    canPublishData: true
-                ),
-                RoomTestingOptions(
-                    delegate: self,
-                    encryptionOptions: EncryptionOptions(keyProvider: receiverKeyProvider),
-                    canSubscribe: true
-                ),
-            ]) { rooms in
+            try await TestEnvironment.withRooms(encryptedRooms(sender: senderKeyProvider, receiver: receiverKeyProvider)) { rooms in
                 let sender = rooms[0]
                 let remoteIdentity = try #require(sender.remoteParticipants.keys.first)
 
@@ -169,12 +170,14 @@ import LiveKitWebRTC
         }
     }
 
-    @Test func decryptionFailureWithPerParticipantKeys() async throws {
+    @Test(arguments: [KeyDerivationAlgorithm.pbkdf2, .hkdf])
+    func decryptionFailureWithPerParticipantKeys(algorithm: KeyDerivationAlgorithm) async throws {
         let testMessage = "This should fail to decrypt with per-participant keys!"
         let testData = try #require(testMessage.data(using: .utf8))
 
-        let senderKeyProvider = BaseKeyProvider(isSharedKey: false)
-        let receiverKeyProvider = BaseKeyProvider(isSharedKey: false)
+        let perParticipantOptions = KeyProviderOptions(sharedKey: false, keyDerivationAlgorithm: algorithm)
+        let senderKeyProvider = BaseKeyProvider(options: perParticipantOptions)
+        let receiverKeyProvider = BaseKeyProvider(options: perParticipantOptions)
 
         let senderKey = "sender-secret-key-123"
         let wrongSenderKey = "wrong-secret-key-999"
@@ -185,17 +188,7 @@ import LiveKitWebRTC
             self._lastDecryptionError.mutate { $0 = nil }
             self._onDecryptionError.mutate { $0 = { confirm() } }
 
-            try await TestEnvironment.withRooms([
-                RoomTestingOptions(
-                    encryptionOptions: EncryptionOptions(keyProvider: senderKeyProvider),
-                    canPublishData: true
-                ),
-                RoomTestingOptions(
-                    delegate: self,
-                    encryptionOptions: EncryptionOptions(keyProvider: receiverKeyProvider),
-                    canSubscribe: true
-                ),
-            ]) { rooms in
+            try await TestEnvironment.withRooms(encryptedRooms(sender: senderKeyProvider, receiver: receiverKeyProvider)) { rooms in
                 let sender = rooms[0]
                 let receiver = rooms[1]
 
@@ -224,18 +217,18 @@ import LiveKitWebRTC
         }
     }
 
-    @Test func keyRatcheting() async throws {
+    @Test(arguments: [KeyDerivationAlgorithm.pbkdf2, .hkdf])
+    func keyRatcheting(algorithm: KeyDerivationAlgorithm) async throws {
         let testMessage = "Hello with automatic ratcheting!"
         let testData = try #require(testMessage.data(using: .utf8))
 
-        let senderKeyProvider = BaseKeyProvider(options: KeyProviderOptions(
+        let ratchetOptions = KeyProviderOptions(
             sharedKey: true,
-            ratchetWindowSize: 2
-        ))
-        let receiverKeyProvider = BaseKeyProvider(options: KeyProviderOptions(
-            sharedKey: true,
-            ratchetWindowSize: 2
-        ))
+            ratchetWindowSize: 2,
+            keyDerivationAlgorithm: algorithm
+        )
+        let senderKeyProvider = BaseKeyProvider(options: ratchetOptions)
+        let receiverKeyProvider = BaseKeyProvider(options: ratchetOptions)
 
         let initialKey = "initial-key-\(UUID().uuidString)"
         senderKeyProvider.setKey(key: initialKey)
@@ -245,17 +238,7 @@ import LiveKitWebRTC
             self._receivedData.mutate { $0 = Data() }
             self._onDataReceived.mutate { $0 = { confirm() } }
 
-            try await TestEnvironment.withRooms([
-                RoomTestingOptions(
-                    encryptionOptions: EncryptionOptions(keyProvider: senderKeyProvider),
-                    canPublishData: true
-                ),
-                RoomTestingOptions(
-                    delegate: self,
-                    encryptionOptions: EncryptionOptions(keyProvider: receiverKeyProvider),
-                    canSubscribe: true
-                ),
-            ]) { rooms in
+            try await TestEnvironment.withRooms(encryptedRooms(sender: senderKeyProvider, receiver: receiverKeyProvider)) { rooms in
                 let sender = rooms[0]
                 let remoteIdentity = try #require(sender.remoteParticipants.keys.first)
 
@@ -281,18 +264,18 @@ import LiveKitWebRTC
         }
     }
 
-    @Test func multipleKeysInKeyRing() async throws {
+    @Test(arguments: [KeyDerivationAlgorithm.pbkdf2, .hkdf])
+    func multipleKeysInKeyRing(algorithm: KeyDerivationAlgorithm) async throws {
         let testMessage = "Hello with multiple keys in key ring!"
         let testData = try #require(testMessage.data(using: .utf8))
 
-        let senderKeyProvider = BaseKeyProvider(options: KeyProviderOptions(
+        let keyRingOptions = KeyProviderOptions(
             sharedKey: true,
-            keyRingSize: 2
-        ))
-        let receiverKeyProvider = BaseKeyProvider(options: KeyProviderOptions(
-            sharedKey: true,
-            keyRingSize: 2
-        ))
+            keyRingSize: 2,
+            keyDerivationAlgorithm: algorithm
+        )
+        let senderKeyProvider = BaseKeyProvider(options: keyRingOptions)
+        let receiverKeyProvider = BaseKeyProvider(options: keyRingOptions)
 
         let key1 = "secret-key-1"
         let key2 = "secret-key-2"
@@ -305,17 +288,7 @@ import LiveKitWebRTC
             self._receivedData.mutate { $0 = Data() }
             self._onDataReceived.mutate { $0 = { confirm() } }
 
-            try await TestEnvironment.withRooms([
-                RoomTestingOptions(
-                    encryptionOptions: EncryptionOptions(keyProvider: senderKeyProvider),
-                    canPublishData: true
-                ),
-                RoomTestingOptions(
-                    delegate: self,
-                    encryptionOptions: EncryptionOptions(keyProvider: receiverKeyProvider),
-                    canSubscribe: true
-                ),
-            ]) { rooms in
+            try await TestEnvironment.withRooms(encryptedRooms(sender: senderKeyProvider, receiver: receiverKeyProvider)) { rooms in
                 let sender = rooms[0]
                 let remoteIdentity = try #require(sender.remoteParticipants.keys.first)
 


### PR DESCRIPTION
## Summary
- Adds `keyDerivationAlgorithm` (`.pbkdf2` / `.hkdf`, default `.pbkdf2`) and `discardFrameWhenCryptorNotReady` (default `false`) to `KeyProviderOptions`, matching the Android SDK shape.
- Resolves #997 — HKDF was previously unreachable because `BaseKeyProvider` is `final` and `rtcKeyProvider` (typed `LKRTCFrameCryptorKeyProvider`) lives behind `internal import LiveKitWebRTC`, so subclassing couldn't bridge the WebRTC ctor parameter.
- Fully source-compatible: new fields default to the values WebRTC was already using.

## Test plan
- [x] Parametrized the 6 existing tests in `EncryptedDataChannelTests` over `[.pbkdf2, .hkdf]` — 12 cases pass against a local `livekit-server --dev` (~50s).
- [x] `swiftlint` clean, `xcodebuild build` clean on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)