### PR TITLE
Clamp lower-layer encoding against the top layer

### DIFF
--- a/.changes/simulcast-layer-clamping
+++ b/.changes/simulcast-layer-clamping
@@ -1,0 +1,1 @@
+patch type="fixed" "Clamp simulcast lower-layer maxFps to the top layer, and clamp maxBitrate for layers that don't scale resolution down, so the user-configured top layer is always the highest-quality tier"

--- a/Sources/LiveKit/Support/Utils+VideoEncodings.swift
+++ b/Sources/LiveKit/Support/Utils+VideoEncodings.swift
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+internal import LiveKitWebRTC
+
+extension Utils {
+    static func computeVideoEncodings(
+        dimensions: Dimensions,
+        publishOptions: VideoPublishOptions?,
+        isScreenShare: Bool = false,
+        overrideVideoCodec: VideoCodec? = nil
+    ) -> [LKRTCRtpEncodingParameters] {
+        let publishOptions = publishOptions ?? VideoPublishOptions()
+        let preferredEncoding: VideoEncoding? = isScreenShare ? publishOptions.screenShareEncoding : publishOptions.encoding
+        let encoding = preferredEncoding ?? dimensions.computeSuggestedPreset(in: dimensions.computeSuggestedPresets(isScreenShare: isScreenShare))
+
+        let videoCodec = overrideVideoCodec ?? publishOptions.preferredCodec
+
+        if let videoCodec, videoCodec.isSVC {
+            // SVC mode
+            log("Using SVC mode")
+            // VP9/AV1 with screen sharing requires single spatial layer
+            return [RTC.createRtpEncodingParameters(encoding: encoding, scalabilityMode: isScreenShare ? .L1T3 : .L3T3_KEY)]
+        } else if !publishOptions.simulcast {
+            // Not-simulcast mode
+            log("Simulcast not enabled")
+            return [RTC.createRtpEncodingParameters(encoding: encoding)]
+        }
+
+        // Continue to simulcast encoding computation...
+
+        let baseParameters = VideoParameters(dimensions: dimensions,
+                                             encoding: encoding)
+
+        let requestedPresets = isScreenShare ? publishOptions.screenShareSimulcastLayers : publishOptions.simulcastLayers
+        let resultPresets = computeSimulcastPresets(dimensions: dimensions,
+                                                    baseParameters: baseParameters,
+                                                    requestedPresets: requestedPresets,
+                                                    isScreenShare: isScreenShare)
+
+        log("Using presets: \(resultPresets), count: \(resultPresets.count) isScreenShare: \(isScreenShare)")
+
+        return dimensions.encodings(from: resultPresets)
+    }
+
+    /// Builds the ordered simulcast layer list (low → high). The top layer is always
+    /// `baseParameters`; lower layers are clamped so that no layer exceeds the top layer's
+    /// `maxFps`, and same-resolution lower layers are additionally clamped against the top's
+    /// `maxBitrate` (a layer that does not scale resolution down must not be allowed to spend
+    /// more bandwidth than the top). Layer count depends on the larger output dimension:
+    /// `< 480` → 1 layer, `[480, 960)` → 2 layers, `≥ 960` → 3 layers.
+    static func computeSimulcastPresets(
+        dimensions: Dimensions,
+        baseParameters: VideoParameters,
+        requestedPresets: [VideoParameters],
+        isScreenShare: Bool
+    ) -> [VideoParameters] {
+        let presets = (!requestedPresets.isEmpty
+            ? requestedPresets
+            : baseParameters.defaultSimulcastLayers(isScreenShare: isScreenShare))
+            .sorted { $0 < $1 }
+
+        guard let lowPreset = presets.first else {
+            return [baseParameters]
+        }
+        let midPreset = presets[safe: 1]
+
+        if dimensions.max >= 960, let midPreset {
+            return [clamp(preset: lowPreset, to: baseParameters, in: dimensions),
+                    clamp(preset: midPreset, to: baseParameters, in: dimensions),
+                    baseParameters]
+        }
+        if dimensions.max >= 480 {
+            return [clamp(preset: lowPreset, to: baseParameters, in: dimensions),
+                    baseParameters]
+        }
+        return [baseParameters]
+    }
+
+    private static func clamp(preset: VideoParameters,
+                              to base: VideoParameters,
+                              in dimensions: Dimensions) -> VideoParameters
+    {
+        let presetEncoding = preset.encoding
+        let baseEncoding = base.encoding
+        let scaleDownBy = Double(dimensions.max) / Double(preset.dimensions.max)
+
+        let clampedFps = Swift.min(presetEncoding.maxFps, baseEncoding.maxFps)
+        // Only clamp bitrate when the preset would not actually scale resolution down — a
+        // same-resolution lower layer must not be allowed to spend more bandwidth than the top.
+        let clampedBitrate = scaleDownBy <= 1.0
+            ? Swift.min(presetEncoding.maxBitrate, baseEncoding.maxBitrate)
+            : presetEncoding.maxBitrate
+
+        if clampedFps == presetEncoding.maxFps, clampedBitrate == presetEncoding.maxBitrate {
+            return preset
+        }
+        return VideoParameters(
+            dimensions: preset.dimensions,
+            encoding: VideoEncoding(
+                maxBitrate: clampedBitrate,
+                maxFps: clampedFps,
+                bitratePriority: presetEncoding.bitratePriority,
+                networkPriority: presetEncoding.networkPriority
+            )
+        )
+    }
+}

--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -298,53 +298,6 @@ class Utils: Loggable {
 
         return wrappedData.base64EncodedString()
     }
-
-    static func computeVideoEncodings(
-        dimensions: Dimensions,
-        publishOptions: VideoPublishOptions?,
-        isScreenShare: Bool = false,
-        overrideVideoCodec: VideoCodec? = nil
-    ) -> [LKRTCRtpEncodingParameters] {
-        let publishOptions = publishOptions ?? VideoPublishOptions()
-        let preferredEncoding: VideoEncoding? = isScreenShare ? publishOptions.screenShareEncoding : publishOptions.encoding
-        let encoding = preferredEncoding ?? dimensions.computeSuggestedPreset(in: dimensions.computeSuggestedPresets(isScreenShare: isScreenShare))
-
-        let videoCodec = overrideVideoCodec ?? publishOptions.preferredCodec
-
-        if let videoCodec, videoCodec.isSVC {
-            // SVC mode
-            log("Using SVC mode")
-            // VP9/AV1 with screen sharing requires single spatial layer
-            return [RTC.createRtpEncodingParameters(encoding: encoding, scalabilityMode: isScreenShare ? .L1T3 : .L3T3_KEY)]
-        } else if !publishOptions.simulcast {
-            // Not-simulcast mode
-            log("Simulcast not enabled")
-            return [RTC.createRtpEncodingParameters(encoding: encoding)]
-        }
-
-        // Continue to simulcast encoding computation...
-
-        let baseParameters = VideoParameters(dimensions: dimensions,
-                                             encoding: encoding)
-
-        // get suggested presets for the dimensions
-        let preferredPresets = (isScreenShare ? publishOptions.screenShareSimulcastLayers : publishOptions.simulcastLayers)
-        let presets = (!preferredPresets.isEmpty ? preferredPresets : baseParameters.defaultSimulcastLayers(isScreenShare: isScreenShare)).sorted { $0 < $1 }
-
-        log("Using presets: \(presets), count: \(presets.count) isScreenShare: \(isScreenShare)")
-
-        let lowPreset = presets[0]
-        let midPreset = presets[safe: 1]
-
-        var resultPresets = [baseParameters]
-        if dimensions.max >= 960, let midPreset {
-            resultPresets = [lowPreset, midPreset, baseParameters]
-        } else if dimensions.max >= 480 {
-            resultPresets = [lowPreset, baseParameters]
-        }
-
-        return dimensions.encodings(from: resultPresets)
-    }
 }
 
 extension Collection {

--- a/Tests/LiveKitCoreTests/SimulcastPresetsTests.swift
+++ b/Tests/LiveKitCoreTests/SimulcastPresetsTests.swift
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+@testable import LiveKit
+import Testing
+
+@Suite(.tags(.media))
+struct SimulcastPresetsTests {
+    @Test("Mid simulcast layer does not exceed user-configured top layer",
+          .bug("https://github.com/livekit/client-sdk-swift/issues/1000"))
+    func midLayerClampedToTop() throws {
+        let dimensions = Dimensions(width: 1280, height: 720)
+        let base = VideoParameters(
+            dimensions: dimensions,
+            encoding: VideoEncoding(maxBitrate: 1_500_000, maxFps: 24)
+        )
+
+        let result = Utils.computeSimulcastPresets(
+            dimensions: dimensions,
+            baseParameters: base,
+            requestedPresets: [.presetH720_169, .presetH360_169],
+            isScreenShare: false
+        )
+
+        try #require(result.count == 3)
+        // Low (presetH360_169): smaller resolution, fps/bitrate already ≤ top — untouched.
+        #expect(result[0].dimensions == .h360_169)
+        #expect(result[0].encoding.maxFps == 20)
+        #expect(result[0].encoding.maxBitrate == 450_000)
+        // Mid (presetH720_169): same resolution as base, both fps and bitrate clamped down.
+        #expect(result[1].dimensions == .h720_169)
+        #expect(result[1].encoding.maxFps == 24)
+        #expect(result[1].encoding.maxBitrate == 1_500_000)
+        #expect(result[2] == base)
+    }
+
+    @Test("Layer ladder length follows the larger output dimension",
+          arguments: [
+              (Dimensions(width: 320, height: 240), 1),
+              (Dimensions(width: 640, height: 480), 2),
+              (Dimensions(width: 1280, height: 720), 3),
+          ])
+    func ladderLength(dimensions: Dimensions, expectedCount: Int) {
+        let base = VideoParameters(
+            dimensions: dimensions,
+            encoding: VideoEncoding(maxBitrate: 1_000_000, maxFps: 30)
+        )
+
+        let result = Utils.computeSimulcastPresets(
+            dimensions: dimensions,
+            baseParameters: base,
+            requestedPresets: [],
+            isScreenShare: false
+        )
+
+        #expect(result.count == expectedCount)
+    }
+
+    @Test("Lower-resolution layer clamps fps but preserves preset bitrate")
+    func lowerResolutionFpsOnlyClamp() throws {
+        let dimensions = Dimensions(width: 1280, height: 720)
+        let base = VideoParameters(
+            dimensions: dimensions,
+            encoding: VideoEncoding(maxBitrate: 500_000, maxFps: 15)
+        )
+
+        let result = Utils.computeSimulcastPresets(
+            dimensions: dimensions,
+            baseParameters: base,
+            requestedPresets: [],
+            isScreenShare: false
+        )
+
+        try #require(result.count == 3)
+        // Default 16:9 ladder is [presetH180_169 (15fps, 160kbps), presetH360_169 (20fps, 450kbps)].
+        // presetH360_169 has scaleDownBy=2 so its 450kbps survives; only fps is clamped to 15.
+        #expect(result[1].dimensions == .h360_169)
+        #expect(result[1].encoding.maxFps == 15)
+        #expect(result[1].encoding.maxBitrate == 450_000)
+    }
+
+    @Test("Same-resolution lower layer clamps both fps and bitrate")
+    func sameResolutionFullClamp() throws {
+        let dimensions = Dimensions(width: 854, height: 480)
+        let base = VideoParameters(
+            dimensions: dimensions,
+            encoding: VideoEncoding(maxBitrate: 600_000, maxFps: 15)
+        )
+        let aggressive = VideoParameters(
+            dimensions: dimensions,
+            encoding: VideoEncoding(maxBitrate: 2_000_000, maxFps: 30)
+        )
+
+        let result = Utils.computeSimulcastPresets(
+            dimensions: dimensions,
+            baseParameters: base,
+            requestedPresets: [aggressive],
+            isScreenShare: false
+        )
+
+        try #require(result.count == 2)
+        #expect(result[0].encoding.maxFps == 15)
+        #expect(result[0].encoding.maxBitrate == 600_000)
+        #expect(result[1] == base)
+    }
+
+    @Test("Presets that don't overshoot are passed through unchanged")
+    func happyPathUnchanged() throws {
+        let dimensions = Dimensions(width: 1920, height: 1080)
+        let base = VideoParameters(
+            dimensions: dimensions,
+            encoding: VideoEncoding(maxBitrate: 5_000_000, maxFps: 30)
+        )
+
+        let result = Utils.computeSimulcastPresets(
+            dimensions: dimensions,
+            baseParameters: base,
+            requestedPresets: [.presetH360_169, .presetH720_169],
+            isScreenShare: false
+        )
+
+        try #require(result.count == 3)
+        #expect(result[0] == VideoParameters.presetH360_169)
+        #expect(result[1] == VideoParameters.presetH720_169)
+        #expect(result[2] == base)
+    }
+
+    @Test("Clamped layer carries forward per-layer priorities")
+    func priorities() throws {
+        let dimensions = Dimensions(width: 1280, height: 720)
+        let base = VideoParameters(
+            dimensions: dimensions,
+            encoding: VideoEncoding(maxBitrate: 1_500_000, maxFps: 24)
+        )
+        let prioritized = VideoParameters(
+            dimensions: dimensions,
+            encoding: VideoEncoding(
+                maxBitrate: 1_700_000,
+                maxFps: 30,
+                bitratePriority: .high,
+                networkPriority: .high
+            )
+        )
+
+        let result = Utils.computeSimulcastPresets(
+            dimensions: dimensions,
+            baseParameters: base,
+            requestedPresets: [.presetH360_169, prioritized],
+            isScreenShare: false
+        )
+
+        try #require(result.count == 3)
+        #expect(result[1].encoding.maxFps == 24)
+        #expect(result[1].encoding.maxBitrate == 1_500_000)
+        #expect(result[1].encoding.bitratePriority == .high)
+        #expect(result[1].encoding.networkPriority == .high)
+    }
+}


### PR DESCRIPTION
## Summary
- Lower simulcast layers (`q`, `h`) are now clamped against the user-configured top encoding: `maxFps` unconditionally, and `maxBitrate` when `scaleDownBy <= 1.0`. A same-resolution lower layer can no longer outspend the top.
- Extracts `computeVideoEncodings` and a new pure helper `computeSimulcastPresets` into `Sources/LiveKit/Support/Utils+VideoEncodings.swift` so the preset-resolution logic is testable from `LiveKitCoreTests` (the WebRTC-typed return of `computeVideoEncodings` is not reachable via `@testable import`).

Fixes #1000.

## Test plan
- [x] `xcodebuild test -scheme LiveKit -only-testing LiveKitCoreTests/SimulcastPresetsTests -destination 'platform=macOS'` — 7 new tests pass.
- [ ] CI matrix (macOS 14/15/26 × Xcode 16.2/16.4/26.4, TSan job).
- [ ] Manual repro from #1000: 1280×720 / 24 fps / 1.5 Mbps top with `simulcastLayers: [.presetH720_169, .presetH360_169]` no longer emits a 30 fps / 1.7 Mbps `h` layer.