### PR TITLE
Fix Room.sid() resolving with empty SID

### DIFF
--- a/.changes/room-sid-from-later-update
+++ b/.changes/room-sid-from-later-update
@@ -1,0 +1,1 @@
+patch type="fixed" "`Room.sid()` no longer resolves with an empty SID"

--- a/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
@@ -112,22 +112,8 @@ extension Room: SignalClientDelegate {
             }
 
             _state.mutate {
-                $0.sid = Room.Sid(from: joinResponse.room.sid)
-                $0.name = joinResponse.room.name
+                $0.apply(roomInfo: joinResponse.room)
                 $0.serverInfo = joinResponse.serverInfo
-                $0.maxParticipants = Int(joinResponse.room.maxParticipants)
-
-                $0.metadata = joinResponse.room.metadata
-                $0.isRecording = joinResponse.room.activeRecording
-                $0.numParticipants = Int(joinResponse.room.numParticipants)
-                $0.numPublishers = Int(joinResponse.room.numPublishers)
-
-                // Attempt to get millisecond precision.
-                if joinResponse.room.creationTimeMs != 0 {
-                    $0.creationTime = Date(timeIntervalSince1970: TimeInterval(Double(joinResponse.room.creationTimeMs) / 1000))
-                } else if joinResponse.room.creationTime != 0 {
-                    $0.creationTime = Date(timeIntervalSince1970: TimeInterval(joinResponse.room.creationTime))
-                }
 
                 localParticipant.set(info: joinResponse.participant, connectionState: $0.connectionState)
                 localParticipant.set(enabledPublishCodecs: joinResponse.enabledPublishCodecs)
@@ -142,12 +128,7 @@ extension Room: SignalClientDelegate {
     }
 
     func signalClient(_: SignalClient, didUpdateRoom room: Livekit_Room) async {
-        _state.mutate {
-            $0.metadata = room.metadata
-            $0.isRecording = room.activeRecording
-            $0.numParticipants = Int(room.numParticipants)
-            $0.numPublishers = Int(room.numPublishers)
-        }
+        _state.mutate { $0.apply(roomInfo: room) }
     }
 
     func signalClient(_: SignalClient, didReceiveRoomMoved response: Livekit_RoomMovedResponse) async {
@@ -437,22 +418,7 @@ private extension Room {
         // Update room info if available
         guard response.hasRoom else { return }
 
-        _state.mutate {
-            $0.sid = Room.Sid(from: response.room.sid)
-            $0.name = response.room.name
-            $0.metadata = response.room.metadata
-            $0.isRecording = response.room.activeRecording
-            $0.numParticipants = Int(response.room.numParticipants)
-            $0.numPublishers = Int(response.room.numPublishers)
-            $0.maxParticipants = Int(response.room.maxParticipants)
-
-            // Attempt to get millisecond precision.
-            if response.room.creationTimeMs != 0 {
-                $0.creationTime = Date(timeIntervalSince1970: TimeInterval(Double(response.room.creationTimeMs) / 1000))
-            } else if response.room.creationTime != 0 {
-                $0.creationTime = Date(timeIntervalSince1970: TimeInterval(response.room.creationTime))
-            }
-        }
+        _state.mutate { $0.apply(roomInfo: response.room) }
     }
 
     func _disconnectAllParticipants() async {

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -189,6 +189,35 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
         // Agents
         var transcriptionReceivedTimes: [String: Date] = [:]
 
+        // Server can deliver `sid` / `name` in a later `RoomUpdate` (e.g. when the
+        // initial `JoinResponse.room.sid` is empty). Don't overwrite a known value
+        // with an empty one, otherwise `Room.sid()` resolves with an empty SID and
+        // never updates.
+        mutating func apply(roomInfo: Livekit_Room) {
+            if !roomInfo.sid.isEmpty {
+                sid = Room.Sid(from: roomInfo.sid)
+            }
+            if !roomInfo.name.isEmpty {
+                name = roomInfo.name
+            }
+
+            metadata = roomInfo.metadata
+            isRecording = roomInfo.activeRecording
+            numParticipants = Int(roomInfo.numParticipants)
+            numPublishers = Int(roomInfo.numPublishers)
+
+            if roomInfo.maxParticipants != 0 {
+                maxParticipants = Int(roomInfo.maxParticipants)
+            }
+
+            // Attempt to get millisecond precision.
+            if roomInfo.creationTimeMs != 0 {
+                creationTime = Date(timeIntervalSince1970: TimeInterval(Double(roomInfo.creationTimeMs) / 1000))
+            } else if roomInfo.creationTime != 0 {
+                creationTime = Date(timeIntervalSince1970: TimeInterval(roomInfo.creationTime))
+            }
+        }
+
         @discardableResult
         mutating func updateRemoteParticipant(info: Livekit_ParticipantInfo, room: Room) -> RemoteParticipant {
             let identity = Participant.Identity(from: info.identity)

--- a/Tests/LiveKitCoreTests/Room/RoomSidTests.swift
+++ b/Tests/LiveKitCoreTests/Room/RoomSidTests.swift
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+@testable import LiveKit
+import Testing
+
+struct RoomSidTests {
+    // MARK: - State.apply(roomInfo:)
+
+    @Test func applyPopulatesSidWhenNonEmpty() {
+        var state = makeState()
+        var info = Livekit_Room()
+        info.sid = "RM_abc"
+        info.name = "my-room"
+
+        state.apply(roomInfo: info)
+
+        #expect(state.sid?.stringValue == "RM_abc")
+        #expect(state.name == "my-room")
+    }
+
+    @Test func applyDoesNotOverwriteSidWithEmpty() {
+        var state = makeState()
+        state.sid = Room.Sid(from: "RM_existing")
+        state.name = "existing-name"
+
+        var info = Livekit_Room()
+        info.sid = ""
+        info.name = ""
+
+        state.apply(roomInfo: info)
+
+        #expect(state.sid?.stringValue == "RM_existing")
+        #expect(state.name == "existing-name")
+    }
+
+    @Test func applyLeavesSidNilWhenEmptyAndPreviouslyUnset() {
+        var state = makeState()
+        var info = Livekit_Room()
+        info.sid = ""
+
+        state.apply(roomInfo: info)
+
+        #expect(state.sid == nil)
+    }
+
+    @Test func applyUpdatesSidOnSubsequentNonEmptyValue() {
+        var state = makeState()
+
+        var first = Livekit_Room()
+        first.sid = ""
+        state.apply(roomInfo: first)
+        #expect(state.sid == nil)
+
+        var second = Livekit_Room()
+        second.sid = "RM_late"
+        state.apply(roomInfo: second)
+        #expect(state.sid?.stringValue == "RM_late")
+    }
+
+    @Test func applyPreservesMaxParticipantsAndCreationTimeOnZero() {
+        var state = makeState()
+        state.maxParticipants = 50
+        state.creationTime = Date(timeIntervalSince1970: 1000)
+
+        let info = Livekit_Room() // all zero / empty
+
+        state.apply(roomInfo: info)
+
+        #expect(state.maxParticipants == 50)
+        #expect(state.creationTime == Date(timeIntervalSince1970: 1000))
+    }
+
+    // MARK: - SignalClient delegate integration
+
+    @Test func joinResponseWithEmptySidThenRoomUpdatePopulatesSid() async throws {
+        let room = Room()
+
+        var join = Livekit_JoinResponse()
+        join.room.sid = ""
+        join.room.name = "my-room"
+
+        await room.signalClient(room.signalClient, didReceiveConnectResponse: .join(join))
+
+        #expect(room.sid == nil)
+        #expect(room.name == "my-room")
+
+        var update = Livekit_Room()
+        update.sid = "RM_delivered_later"
+        update.name = "my-room"
+
+        await room.signalClient(room.signalClient, didUpdateRoom: update)
+
+        #expect(room.sid?.stringValue == "RM_delivered_later")
+        let awaited = try await room.sid()
+        #expect(awaited.stringValue == "RM_delivered_later")
+    }
+
+    @Test func joinResponseWithSidResolvesAwaitedSid() async throws {
+        let room = Room()
+
+        var join = Livekit_JoinResponse()
+        join.room.sid = "RM_from_join"
+        join.room.name = "my-room"
+
+        await room.signalClient(room.signalClient, didReceiveConnectResponse: .join(join))
+
+        let awaited = try await room.sid()
+        #expect(awaited.stringValue == "RM_from_join")
+    }
+
+    @Test func roomUpdateWithEmptySidDoesNotClearExistingSid() async {
+        let room = Room()
+
+        var join = Livekit_JoinResponse()
+        join.room.sid = "RM_initial"
+        await room.signalClient(room.signalClient, didReceiveConnectResponse: .join(join))
+        #expect(room.sid?.stringValue == "RM_initial")
+
+        var update = Livekit_Room()
+        update.sid = ""
+        await room.signalClient(room.signalClient, didUpdateRoom: update)
+
+        #expect(room.sid?.stringValue == "RM_initial")
+    }
+
+    // MARK: - Helpers
+
+    private func makeState() -> Room.State {
+        Room.State(connectOptions: ConnectOptions(), roomOptions: RoomOptions())
+    }
+}

--- a/Tests/LiveKitCoreTests/Room/RoomStateTests.swift
+++ b/Tests/LiveKitCoreTests/Room/RoomStateTests.swift
@@ -18,82 +18,65 @@ import Foundation
 @testable import LiveKit
 import Testing
 
-struct RoomSidTests {
-    // MARK: - State.apply(roomInfo:)
+struct RoomStateTests {
+    // MARK: - apply(roomInfo:): sid and name
 
-    @Test func applyPopulatesSidWhenNonEmpty() {
+    struct ApplyCase {
+        let initialSid: String?
+        let initialName: String?
+        let infoSid: String
+        let infoName: String
+        let expectedSid: String?
+        let expectedName: String?
+    }
+
+    /// `apply(roomInfo:)` never overwrites a known `sid` or `name` with an empty value;
+    /// non-empty values always replace.
+    @Test(arguments: [
+        ApplyCase(initialSid: nil, initialName: nil, infoSid: "RM_a", infoName: "n",
+                  expectedSid: "RM_a", expectedName: "n"),
+        ApplyCase(initialSid: nil, initialName: nil, infoSid: "", infoName: "",
+                  expectedSid: nil, expectedName: nil),
+        ApplyCase(initialSid: "RM_keep", initialName: "keep", infoSid: "", infoName: "",
+                  expectedSid: "RM_keep", expectedName: "keep"),
+        ApplyCase(initialSid: "RM_old", initialName: "old", infoSid: "RM_new", infoName: "new",
+                  expectedSid: "RM_new", expectedName: "new"),
+    ])
+    func applyMergesSidAndName(_ c: ApplyCase) {
         var state = makeState()
-        var info = Livekit_Room()
-        info.sid = "RM_abc"
-        info.name = "my-room"
+        if let sid = c.initialSid { state.sid = Room.Sid(from: sid) }
+        state.name = c.initialName
 
+        var info = Livekit_Room()
+        info.sid = c.infoSid
+        info.name = c.infoName
         state.apply(roomInfo: info)
 
-        #expect(state.sid?.stringValue == "RM_abc")
-        #expect(state.name == "my-room")
+        #expect(state.sid?.stringValue == c.expectedSid)
+        #expect(state.name == c.expectedName)
     }
 
-    @Test func applyDoesNotOverwriteSidWithEmpty() {
-        var state = makeState()
-        state.sid = Room.Sid(from: "RM_existing")
-        state.name = "existing-name"
-
-        var info = Livekit_Room()
-        info.sid = ""
-        info.name = ""
-
-        state.apply(roomInfo: info)
-
-        #expect(state.sid?.stringValue == "RM_existing")
-        #expect(state.name == "existing-name")
-    }
-
-    @Test func applyLeavesSidNilWhenEmptyAndPreviouslyUnset() {
-        var state = makeState()
-        var info = Livekit_Room()
-        info.sid = ""
-
-        state.apply(roomInfo: info)
-
-        #expect(state.sid == nil)
-    }
-
-    @Test func applyUpdatesSidOnSubsequentNonEmptyValue() {
-        var state = makeState()
-
-        var first = Livekit_Room()
-        first.sid = ""
-        state.apply(roomInfo: first)
-        #expect(state.sid == nil)
-
-        var second = Livekit_Room()
-        second.sid = "RM_late"
-        state.apply(roomInfo: second)
-        #expect(state.sid?.stringValue == "RM_late")
-    }
-
+    /// `apply(roomInfo:)` preserves existing `maxParticipants` and `creationTime` when info reports zero.
     @Test func applyPreservesMaxParticipantsAndCreationTimeOnZero() {
         var state = makeState()
         state.maxParticipants = 50
         state.creationTime = Date(timeIntervalSince1970: 1000)
 
-        let info = Livekit_Room() // all zero / empty
-
-        state.apply(roomInfo: info)
+        state.apply(roomInfo: Livekit_Room())
 
         #expect(state.maxParticipants == 50)
         #expect(state.creationTime == Date(timeIntervalSince1970: 1000))
     }
 
-    // MARK: - SignalClient delegate integration
+    // MARK: - SignalClient delegate (Room.sid() flow)
 
-    @Test func joinResponseWithEmptySidThenRoomUpdatePopulatesSid() async throws {
+    /// Issue #1009: SID delivered in a later `RoomUpdate` after an empty `JoinResponse.room.sid`.
+    @Test func joinWithEmptySidThenRoomUpdatePopulatesSid() async throws {
         let room = Room()
 
         var join = Livekit_JoinResponse()
         join.room.sid = ""
         join.room.name = "my-room"
-
         await room.signalClient(room.signalClient, didReceiveConnectResponse: .join(join))
 
         #expect(room.sid == nil)
@@ -102,21 +85,17 @@ struct RoomSidTests {
         var update = Livekit_Room()
         update.sid = "RM_delivered_later"
         update.name = "my-room"
-
         await room.signalClient(room.signalClient, didUpdateRoom: update)
 
-        #expect(room.sid?.stringValue == "RM_delivered_later")
         let awaited = try await room.sid()
         #expect(awaited.stringValue == "RM_delivered_later")
     }
 
-    @Test func joinResponseWithSidResolvesAwaitedSid() async throws {
+    @Test func joinWithSidResolvesAwaitedSid() async throws {
         let room = Room()
 
         var join = Livekit_JoinResponse()
         join.room.sid = "RM_from_join"
-        join.room.name = "my-room"
-
         await room.signalClient(room.signalClient, didReceiveConnectResponse: .join(join))
 
         let awaited = try await room.sid()
@@ -129,7 +108,6 @@ struct RoomSidTests {
         var join = Livekit_JoinResponse()
         join.room.sid = "RM_initial"
         await room.signalClient(room.signalClient, didReceiveConnectResponse: .join(join))
-        #expect(room.sid?.stringValue == "RM_initial")
 
         var update = Livekit_Room()
         update.sid = ""


### PR DESCRIPTION
## Summary

`JoinResponse` / `RoomUpdate` / `RoomMovedResponse` are now funneled through a single `Room.State.apply(roomInfo:)` helper that won't overwrite a known `sid` / `name` with empty (or `maxParticipants` / `creationTime` with zero). The SID is populated from a later `RoomUpdate` when the initial `JoinResponse` omits it, and `Room.sid()` suspends until a non-empty SID is available.

Resolves #1009

## Behavior vs. Android / JS

| Field on `RoomUpdate` | Android | JS | Swift (before) | Swift (now) |
|---|---|---|---|---|
| `sid` | overwrites, even if empty | overwrites (whole `roomInfo`) | not updated | overwrites **only if non-empty** |
| `name` | not updated | overwrites | not updated | overwrites only if non-empty |
| `metadata` / `isRecording` | overwrites | overwrites | overwrites | overwrites |
| `numParticipants` / `numPublishers` | not updated | overwrites | overwrites | overwrites |
| `maxParticipants` | not updated | overwrites | not updated | overwrites only if non-zero |
| `creationTime` | not updated | overwrites | not updated | overwrites only if non-zero |

## Test plan

- [x] New `RoomSidTests` covers the State helper and the `signalClient` delegate flow
- [x] `xcodebuild test -only-testing LiveKitCoreTests/RoomSidTests` (8 / 8 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)