### PR TITLE
Fix Room.sid resolution from room updates

### DIFF
--- a/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
@@ -112,7 +112,9 @@ extension Room: SignalClientDelegate {
             }
 
             _state.mutate {
-                $0.sid = Room.Sid(from: joinResponse.room.sid)
+                if !joinResponse.room.sid.isEmpty {
+                    $0.sid = Room.Sid(from: joinResponse.room.sid)
+                }
                 $0.name = joinResponse.room.name
                 $0.serverInfo = joinResponse.serverInfo
                 $0.maxParticipants = Int(joinResponse.room.maxParticipants)
@@ -143,6 +145,9 @@ extension Room: SignalClientDelegate {
 
     func signalClient(_: SignalClient, didUpdateRoom room: Livekit_Room) async {
         _state.mutate {
+            if !room.sid.isEmpty {
+                $0.sid = Room.Sid(from: room.sid)
+            }
             $0.metadata = room.metadata
             $0.isRecording = room.activeRecording
             $0.numParticipants = Int(room.numParticipants)

--- a/Tests/LiveKitCoreTests/Room/RoomTests.swift
+++ b/Tests/LiveKitCoreTests/Room/RoomTests.swift
@@ -22,6 +22,32 @@ import LiveKitTestSupport
 #endif
 
 @Suite(.serialized, .tags(.e2e)) final class RoomTests: @unchecked Sendable {
+    @Test func roomSidResolvesFromRoomUpdateWhenJoinSidIsEmpty() async throws {
+        let room = Room()
+
+        var joinResponse = Livekit_JoinResponse()
+        joinResponse.room.name = "room-test"
+        joinResponse.room.sid = ""
+        await room.signalClient(room.signalClient, didReceiveConnectResponse: .join(joinResponse))
+
+        #expect(room.sid == nil)
+
+        let sidTask = Task {
+            try await room.sid().stringValue
+        }
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(room.sid == nil)
+
+        var roomUpdate = Livekit_Room()
+        roomUpdate.sid = "RM_test_room_sid"
+        await room.signalClient(room.signalClient, didUpdateRoom: roomUpdate)
+
+        let sid = try await sidTask.value
+        #expect(sid == "RM_test_room_sid")
+        #expect(room.sid?.stringValue == "RM_test_room_sid")
+    }
+
     @Test func roomProperties() async throws {
         try await TestEnvironment.withRoom { room in
             // SID


### PR DESCRIPTION
## Summary
Fixes `Room.sid` resolution when the initial join response contains an empty room SID.

Previously, the SDK assigned `Room.Sid(from: joinResponse.room.sid)` unconditionally. If the join response SID was empty, `Room.sid` became a non-nil empty SID and `try await
room.sid()` could resolve with that empty value. Later `RoomUpdate` messages did not update `Room.sid`.

This PR:
- ignores empty `JoinResponse.room.sid` values
- updates `Room.sid` from non-empty `RoomUpdate.room.sid`
- adds coverage for an empty join SID followed by a non-empty room update SID

## Why
This matches Android SDK behavior, where room updates can populate the room SID after join.

## Test plan
```sh
xcodebuild test \
  -scheme LiveKit \
  -destination 'platform=iOS Simulator,name=iPhone 17' \
  -only-testing:LiveKitCoreTests/RoomTests \
  -parallel-testing-enabled NO
```

Fixes #1009 