### PR TITLE
ci: old pod validation

### DIFF
--- a/.github/workflows/cocoapods-lint.yaml
+++ b/.github/workflows/cocoapods-lint.yaml
@@ -16,8 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-14
-            xcode: 16.2
           - os: macos-15
             xcode: 16.4
           - os: macos-26

--- a/LiveKitClient.podspec
+++ b/LiveKitClient.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = "13.0"
   spec.osx.deployment_target = "10.15"
 
-  spec.swift_versions = ["6.0"]
+  spec.swift_versions = ["5.9"]
   spec.source = {:git => "https://github.com/livekit/client-sdk-swift.git", :tag => spec.version.to_s}
 
   spec.source_files = "Sources/**/*"

--- a/LiveKitClient.podspec
+++ b/LiveKitClient.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = "13.0"
   spec.osx.deployment_target = "10.15"
 
-  spec.swift_versions = ["5.9"]
+  spec.swift_versions = ["6.0"]
   spec.source = {:git => "https://github.com/livekit/client-sdk-swift.git", :tag => spec.version.to_s}
 
   spec.source_files = "Sources/**/*"


### PR DESCRIPTION
Protobufs already removed support for Swift 6.0 https://github.com/apple/swift-protobuf/releases/tag/1.38.0

The current App Store min is 26 anyway.