### PR TITLE
DataChannel: document state-machine events, concurrency fixes

### DIFF
--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -33,7 +33,7 @@ protocol DataChannelDelegate: AnyObject, Sendable {
 /// and serializes all outgoing sends through a private FIFO event loop.
 ///
 /// ## Send flow
-/// `send(dataPacket:)` builds a `PublishDataRequest` and yields a `.publishData`
+/// `send(dataPacket:)` builds a `PublishDataRequest` and yields a `.sendRequested`
 /// event onto the internal `AsyncStream`. The event loop's single observer is the
 /// only mutator of `Buffers` (lossy / reliable send buffers + reliable retry
 /// buffer), so all bookkeeping is race-free without locks.
@@ -66,7 +66,7 @@ protocol DataChannelDelegate: AnyObject, Sendable {
 /// ## Permanent teardown
 /// `reset(throwing:)` clears channel references, yields a `.drain(error)`
 /// event, then resets the completer. The drain runs through the same FIFO
-/// stream, so it's ordered after any `.publishData` enqueues already in
+/// stream, so it's ordered after any `.sendRequested` enqueues already in
 /// flight from concurrent callers. Every parked request's continuation is
 /// resumed with `error` (or `LiveKitError(.cancelled)` if `nil`), so no
 /// continuation leaks across a disconnect / full reconnect.
@@ -195,16 +195,41 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
         let detail: Detail
 
         enum Detail {
-            case publishData(PublishDataRequest)
-            case publishedData(PublishDataRequest)
+            /// Yielded by `send(dataPacket:)`. Consumer enqueues the request
+            /// into the matching `SendBuffer` and tries to flush.
+            case sendRequested(PublishDataRequest)
+
+            /// Yielded by `processSendQueue` after a successful
+            /// `channel.sendData`. Consumer copies reliable requests into the
+            /// retry buffer for potential SCTP-level replay on resume;
+            /// lossy requests are a no-op (they aren't replayed).
+            case sendDispatched(PublishDataRequest)
+
+            /// Yielded by `LKRTCDataChannelDelegate.didChangeBufferedAmount`
+            /// when WebRTC reports its outbound buffer has drained. Consumer
+            /// updates `SendBuffer.rtcAmount` (the backpressure target) and,
+            /// on the reliable channel, trims the retry buffer down to the
+            /// new bound so only un-acked bytes are retained.
             case bufferedAmountChanged(UInt64)
+
+            /// Yielded by `retryReliable(lastSequence:)` when the server
+            /// asks the client to replay packets after a reconnect resume.
+            /// Consumer re-enqueues every retry-buffer entry whose sequence
+            /// is greater than `lastSeq` as a fresh `.sendRequested`.
             case retryRequested(UInt32)
-            /// A data channel transitioned into `.open`; flush both send buffers
-            /// so requests parked while `channel(for:)` returned `nil` can ship.
+
+            /// Yielded when channel readiness *may* have improved
+            /// (`set(reliable:)`, `set(lossy:)`, `dataChannelDidChangeState`).
+            /// The case itself is a no-op; the common flush at the end of
+            /// `processEvent` re-runs `processSendQueue` to ship anything
+            /// that was parked while `channel(for:)` returned `nil`.
             case wakeup
-            /// Fail every parked send-buffer request with `error`; yielded by
-            /// `reset(throwing:)` so callers don't hang on continuations queued
-            /// for now-discarded channels.
+
+            /// Yielded by `reset(throwing:)` to permanently fail every
+            /// parked send-buffer request with `error` (or
+            /// `LiveKitError(.cancelled)` when `nil`). Routed through the
+            /// stream so it's ordered after any in-flight `.sendRequested`
+            /// enqueues from concurrent callers.
             case drain(Error?)
         }
     }
@@ -214,12 +239,12 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
     // swiftlint:disable:next cyclomatic_complexity
     private func processEvent(_ event: ChannelEvent, buffers: inout Buffers) {
         switch event.detail {
-        case let .publishData(request):
+        case let .sendRequested(request):
             switch event.channelKind {
             case .lossy: buffers.lossyBuffer.enqueue(request)
             case .reliable: buffers.reliableBuffer.enqueue(request)
             }
-        case let .publishedData(request):
+        case let .sendDispatched(request):
             switch event.channelKind {
             case .lossy: ()
             case .reliable: buffers.reliableRetryBuffer.enqueue(request)
@@ -290,7 +315,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
             }
             request.continuation?.resume()
 
-            let event = ChannelEvent(channelKind: kind, detail: .publishedData(request))
+            let event = ChannelEvent(channelKind: kind, detail: .sendDispatched(request))
             eventContinuation.yield(event)
         }
     }
@@ -319,7 +344,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
         while let request = buffer.dequeue() {
             assert(request.continuation == nil, "Continuation may fire multiple times while retrying causing crash")
             if request.sequence > lastSeq {
-                let event = ChannelEvent(channelKind: .reliable, detail: .publishData(request))
+                let event = ChannelEvent(channelKind: .reliable, detail: .sendRequested(request))
                 eventContinuation.yield(event)
             }
         }
@@ -392,7 +417,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
         reliable?.close()
 
         // Drain parked sends through the same event stream so they're ordered
-        // after any in-flight `publishData` enqueues from concurrent callers.
+        // after any in-flight `.sendRequested` enqueues from concurrent callers.
         eventContinuation.yield(ChannelEvent(channelKind: .reliable, detail: .drain(error)))
 
         openCompleter.reset(throwing: error)
@@ -420,7 +445,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
             )
             let event = ChannelEvent(
                 channelKind: ChannelKind(packet.kind), // TODO: field is deprecated
-                detail: .publishData(request)
+                detail: .sendRequested(request)
             )
             eventContinuation.yield(event)
         }

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -321,7 +321,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
         }
     }
 
-    // MARK: - Cache
+    // MARK: - Buffer helpers
 
     private func updateTarget(
         buffer: inout SendBuffer,
@@ -375,23 +375,19 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
     }
 
     func set(reliable channel: LKRTCDataChannel?) {
-        let isOpen = _state.mutate {
-            $0.reliable = channel
-            return $0.isOpen
-        }
-
-        channel?.delegate = self
-
-        if isOpen {
-            // Wake parked sends — pairs with `dataChannelDidChangeState`.
-            openCompleter.resume(returning: ())
-            eventContinuation.yield(ChannelEvent(channelKind: .reliable, detail: .wakeup))
-        }
+        setChannel(channel, kind: .reliable)
     }
 
     func set(lossy channel: LKRTCDataChannel?) {
+        setChannel(channel, kind: .lossy)
+    }
+
+    private func setChannel(_ channel: LKRTCDataChannel?, kind: ChannelKind) {
         let isOpen = _state.mutate {
-            $0.lossy = channel
+            switch kind {
+            case .reliable: $0.reliable = channel
+            case .lossy: $0.lossy = channel
+            }
             return $0.isOpen
         }
 
@@ -400,7 +396,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
         if isOpen {
             // Wake parked sends — pairs with `dataChannelDidChangeState`.
             openCompleter.resume(returning: ())
-            eventContinuation.yield(ChannelEvent(channelKind: .lossy, detail: .wakeup))
+            eventContinuation.yield(ChannelEvent(channelKind: kind, detail: .wakeup))
         }
     }
 
@@ -488,9 +484,9 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
     // MARK: - Sync state
 
     func infos() -> [Livekit_DataChannelInfo] {
-        _state.read { [$0.lossy, $0.reliable] }
-            .compactMap(\.self)
-            .map { $0.toLKInfoType() }
+        _state.read { state in
+            [state.lossy, state.reliable].compactMap { $0?.toLKInfoType() }
+        }
     }
 
     func receiveStates() -> [Livekit_DataChannelReceiveState] {

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -93,8 +93,6 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
 
     var isOpen: Bool { _state.isOpen }
 
-    var e2eeManager: E2EEManager?
-
     // MARK: - Private
 
     private struct State {
@@ -102,6 +100,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
         var reliable: LKRTCDataChannel?
         var reliableDataSequence: UInt32 = 1
         var reliableReceivedState: TTLDictionary<String, UInt32> = TTLDictionary(ttl: reliableReceivedStateTTL)
+        var e2eeManager: E2EEManager?
 
         var isOpen: Bool {
             guard let lossy, let reliable else { return false }
@@ -403,6 +402,10 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
         }
     }
 
+    func set(e2eeManager: E2EEManager?) {
+        _state.mutate { $0.e2eeManager = e2eeManager }
+    }
+
     func reset(throwing error: Error? = nil) {
         let (lossy, reliable) = _state.mutate {
             let result = ($0.lossy, $0.reliable)
@@ -452,7 +455,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
     }
 
     private func withEncryption(_ packet: Livekit_DataPacket) throws -> Livekit_DataPacket {
-        guard let e2eeManager, e2eeManager.isDataChannelEncryptionEnabled,
+        guard let e2eeManager = _state.e2eeManager, e2eeManager.isDataChannelEncryptionEnabled,
               let payload = Livekit_EncryptedPacketPayload(dataPacket: packet) else { return packet }
         var packet = packet
         do {
@@ -551,7 +554,7 @@ extension DataChannelPair: LKRTCDataChannelDelegate {
         }
 
         if let encryptedPacket = dataPacket.encryptedPacketOrNil,
-           let e2eeManager
+           let e2eeManager = _state.e2eeManager
         {
             do {
                 let decryptedData = try e2eeManager.handle(encryptedData: encryptedPacket.toRTCEncryptedPacket(), participantIdentity: dataPacket.participantIdentity)

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -304,7 +304,6 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
                 buffer.enqueueFront(request)
                 return
             }
-            buffer.rtcAmount += UInt64(request.data.data.count)
 
             guard channel.sendData(request.data) else {
                 request.continuation?.resume(
@@ -312,6 +311,9 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
                 )
                 return
             }
+            // Bytes are now in WebRTC's SCTP queue; account for them so the
+            // backpressure check below kicks in for subsequent iterations.
+            buffer.rtcAmount += UInt64(request.data.data.count)
             request.continuation?.resume()
 
             let event = ChannelEvent(channelKind: kind, detail: .sendDispatched(request))
@@ -492,10 +494,12 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
     }
 
     func receiveStates() -> [Livekit_DataChannelReceiveState] {
-        _state.reliableReceivedState.map { sid, seq in
-            Livekit_DataChannelReceiveState.with {
-                $0.publisherSid = sid
-                $0.lastSeq = seq
+        _state.read { state in
+            state.reliableReceivedState.map { sid, seq in
+                Livekit_DataChannelReceiveState.with {
+                    $0.publisherSid = sid
+                    $0.lastSeq = seq
+                }
             }
         }
     }
@@ -544,12 +548,18 @@ extension DataChannelPair: LKRTCDataChannelDelegate {
         }
 
         if dataChannel.kind == .reliable, dataPacket.sequence > 0, !dataPacket.participantSid.isEmpty {
-            if let lastSeq = _state.reliableReceivedState[dataPacket.participantSid], dataPacket.sequence <= lastSeq {
+            // Check and update in one locked step so two concurrent receives
+            // for the same sender can't both pass the dedup gate.
+            let isDuplicate = _state.mutate { state -> Bool in
+                if let lastSeq = state.reliableReceivedState[dataPacket.participantSid], dataPacket.sequence <= lastSeq {
+                    return true
+                }
+                state.reliableReceivedState[dataPacket.participantSid] = dataPacket.sequence
+                return false
+            }
+            if isDuplicate {
                 log("Ignoring duplicate/out-of-order reliable data message", .warning)
                 return
-            }
-            _state.mutate {
-                $0.reliableReceivedState[dataPacket.participantSid] = dataPacket.sequence
             }
         }
 

--- a/Sources/LiveKit/Core/Room+Engine.swift
+++ b/Sources/LiveKit/Core/Room+Engine.swift
@@ -82,8 +82,13 @@ extension Room {
                 try await publisherShouldNegotiate()
             }
 
-            try await publisherTransportConnectedCompleter.wait(timeout: _state.connectOptions.publisherTransportConnectTimeout)
-            try await publisherDataChannel.openCompleter.wait()
+            // Single combined gate: wait for both the publisher PC to be ICE-
+            // connected *and* the data channels to reach `.open` concurrently.
+            // Mirrors the prevailing pattern in client-sdk-js / -rust, where a
+            // single poll loop checks both conditions before any send proceeds.
+            async let transportReady: Void = publisherTransportConnectedCompleter.wait(timeout: _state.connectOptions.publisherTransportConnectTimeout)
+            async let dataChannelReady: Void = publisherDataChannel.openCompleter.wait()
+            _ = try await (transportReady, dataChannelReady)
         }
 
         try await ensurePublisherConnected()

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -399,13 +399,13 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
             e2eeManager = E2EEManager(options: encryptionOptions)
             e2eeManager!.setup(room: self)
 
-            subscriberDataChannel.e2eeManager = e2eeManager
-            publisherDataChannel.e2eeManager = e2eeManager
+            subscriberDataChannel.set(e2eeManager: e2eeManager)
+            publisherDataChannel.set(e2eeManager: e2eeManager)
         } else {
             e2eeManager = nil
 
-            subscriberDataChannel.e2eeManager = nil
-            publisherDataChannel.e2eeManager = nil
+            subscriberDataChannel.set(e2eeManager: nil)
+            publisherDataChannel.set(e2eeManager: nil)
         }
 
         _state.mutate {

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -23,7 +23,6 @@ actor IncomingStreamManager: Loggable {
         let info: StreamInfo
         let openTime: TimeInterval
         let continuation: StreamReaderSource.Continuation
-        var task: AnyTaskCancellable?
         var readLength = 0
     }
 
@@ -143,16 +142,17 @@ actor IncomingStreamManager: Loggable {
             continuation = $0
         }
 
-        let descriptor = Descriptor(
+        openStreams[info.id] = Descriptor(
             info: info,
             openTime: Date.timeIntervalSinceReferenceDate,
-            continuation: continuation,
-            task: Task {
-                try await handler(source, identity)
-            }.cancellable()
+            continuation: continuation
         )
 
-        openStreams[info.id] = descriptor
+        // Detached: handler lifetime is not tied to the descriptor — abnormal stream
+        // conditions are signalled through `source` throwing instead.
+        Task.detachedDiscarding {
+            try await handler(source, identity)
+        }
     }
 
     /// Close the stream with the given id.

--- a/Sources/LiveKit/Extensions/TimeInterval.swift
+++ b/Sources/LiveKit/Extensions/TimeInterval.swift
@@ -31,7 +31,9 @@ public extension TimeInterval {
 
     static let defaultJoinResponse: Self = 7
     static let defaultTransportState: Self = 10
-    static let defaultPublisherDataChannelOpen: Self = 7
+    // Matches client-sdk-js (`peerConnectionTimeout`) and client-sdk-rust
+    // (`ICE_CONNECT_TIMEOUT`); client-sdk-android uses 20s.
+    static let defaultPublisherDataChannelOpen: Self = 15
     static let resolveSid: Self = 7 + 5 // Join response + 5
     static let defaultPublish: Self = 10
     static let defaultCaptureStart: Self = 10

--- a/Sources/LiveKit/Protos/livekit_metrics.pb.swift
+++ b/Sources/LiveKit/Protos/livekit_metrics.pb.swift
@@ -19,13 +19,13 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// index from [0: MAX_LABEL_PREDEFINED_MAX_VALUE) are for predefined labels (`MetricLabel`)
-enum Livekit_MetricLabel: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_MetricLabel: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
 
   /// time to first token from LLM
@@ -175,7 +175,7 @@ enum Livekit_MetricLabel: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-struct Livekit_MetricsBatch: Sendable {
+nonisolated struct Livekit_MetricsBatch: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -211,7 +211,7 @@ struct Livekit_MetricsBatch: Sendable {
   fileprivate var _normalizedTimestamp: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
-struct Livekit_TimeSeriesMetric: Sendable {
+nonisolated struct Livekit_TimeSeriesMetric: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -236,7 +236,7 @@ struct Livekit_TimeSeriesMetric: Sendable {
   init() {}
 }
 
-struct Livekit_MetricSample: Sendable {
+nonisolated struct Livekit_MetricSample: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -262,7 +262,7 @@ struct Livekit_MetricSample: Sendable {
   fileprivate var _normalizedTimestamp: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
-struct Livekit_EventMetric: Sendable {
+nonisolated struct Livekit_EventMetric: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -320,7 +320,7 @@ struct Livekit_EventMetric: Sendable {
   fileprivate var _normalizedEndTimestamp: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
-struct Livekit_MetricsRecordingHeader: Sendable {
+nonisolated struct Livekit_MetricsRecordingHeader: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -362,13 +362,13 @@ struct Livekit_MetricsRecordingHeader: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "livekit"
+fileprivate nonisolated let _protobuf_package = "livekit"
 
-extension Livekit_MetricLabel: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_MetricLabel: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0AGENTS_LLM_TTFT\0\u{1}AGENTS_STT_TTFT\0\u{1}AGENTS_TTS_TTFB\0\u{1}CLIENT_VIDEO_SUBSCRIBER_FREEZE_COUNT\0\u{1}CLIENT_VIDEO_SUBSCRIBER_TOTAL_FREEZE_DURATION\0\u{1}CLIENT_VIDEO_SUBSCRIBER_PAUSE_COUNT\0\u{1}CLIENT_VIDEO_SUBSCRIBER_TOTAL_PAUSES_DURATION\0\u{1}CLIENT_AUDIO_SUBSCRIBER_CONCEALED_SAMPLES\0\u{1}CLIENT_AUDIO_SUBSCRIBER_SILENT_CONCEALED_SAMPLES\0\u{1}CLIENT_AUDIO_SUBSCRIBER_CONCEALMENT_EVENTS\0\u{1}CLIENT_AUDIO_SUBSCRIBER_INTERRUPTION_COUNT\0\u{1}CLIENT_AUDIO_SUBSCRIBER_TOTAL_INTERRUPTION_DURATION\0\u{1}CLIENT_SUBSCRIBER_JITTER_BUFFER_DELAY\0\u{1}CLIENT_SUBSCRIBER_JITTER_BUFFER_EMITTED_COUNT\0\u{1}CLIENT_VIDEO_PUBLISHER_QUALITY_LIMITATION_DURATION_BANDWIDTH\0\u{1}CLIENT_VIDEO_PUBLISHER_QUALITY_LIMITATION_DURATION_CPU\0\u{1}CLIENT_VIDEO_PUBLISHER_QUALITY_LIMITATION_DURATION_OTHER\0\u{1}PUBLISHER_RTT\0\u{1}SERVER_MESH_RTT\0\u{1}SUBSCRIBER_RTT\0\u{2}m?METRIC_LABEL_PREDEFINED_MAX_VALUE\0")
 }
 
-extension Livekit_MetricsBatch: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_MetricsBatch: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MetricsBatch"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}timestamp_ms\0\u{3}normalized_timestamp\0\u{3}str_data\0\u{3}time_series\0\u{1}events\0")
 
@@ -422,7 +422,7 @@ extension Livekit_MetricsBatch: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 }
 
-extension Livekit_TimeSeriesMetric: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_TimeSeriesMetric: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TimeSeriesMetric"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}label\0\u{3}participant_identity\0\u{3}track_sid\0\u{1}samples\0\u{1}rid\0")
 
@@ -472,7 +472,7 @@ extension Livekit_TimeSeriesMetric: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Livekit_MetricSample: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_MetricSample: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MetricSample"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}timestamp_ms\0\u{3}normalized_timestamp\0\u{1}value\0")
 
@@ -516,7 +516,7 @@ extension Livekit_MetricSample: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 }
 
-extension Livekit_EventMetric: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_EventMetric: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".EventMetric"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}label\0\u{3}participant_identity\0\u{3}track_sid\0\u{3}start_timestamp_ms\0\u{3}end_timestamp_ms\0\u{3}normalized_start_timestamp\0\u{3}normalized_end_timestamp\0\u{1}metadata\0\u{1}rid\0")
 
@@ -590,7 +590,7 @@ extension Livekit_EventMetric: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
   }
 }
 
-extension Livekit_MetricsRecordingHeader: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_MetricsRecordingHeader: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MetricsRecordingHeader"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}room_id\0\u{2}\u{2}duration\0\u{3}start_time\0\u{3}room_tags\0\u{3}room_name\0\u{3}room_start_time\0")
 

--- a/Sources/LiveKit/Protos/livekit_models.pb.swift
+++ b/Sources/LiveKit/Protos/livekit_models.pb.swift
@@ -38,12 +38,12 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-enum Livekit_AudioCodec: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_AudioCodec: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case defaultAc // = 0
   case opus // = 1
@@ -85,7 +85,7 @@ enum Livekit_AudioCodec: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Livekit_VideoCodec: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_VideoCodec: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case defaultVc // = 0
   case h264Baseline // = 1
@@ -131,7 +131,7 @@ enum Livekit_VideoCodec: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Livekit_ImageCodec: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_ImageCodec: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case icDefault // = 0
   case icJpeg // = 1
@@ -166,7 +166,7 @@ enum Livekit_ImageCodec: SwiftProtobuf.Enum, Swift.CaseIterable {
 }
 
 /// Policy for publisher to handle subscribers that are unable to support the primary codec of a track
-enum Livekit_BackupCodecPolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_BackupCodecPolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
 
   /// default behavior, the track prefer to regress to backup codec and all subscribers will receive the backup codec,
@@ -211,7 +211,7 @@ enum Livekit_BackupCodecPolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Livekit_TrackType: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_TrackType: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case audio // = 0
   case video // = 1
@@ -249,7 +249,7 @@ enum Livekit_TrackType: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Livekit_TrackSource: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_TrackSource: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unknown // = 0
   case camera // = 1
@@ -295,7 +295,7 @@ enum Livekit_TrackSource: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Livekit_DataTrackExtensionID: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_DataTrackExtensionID: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case dteiInvalid // = 0
   case dteiParticipantSid // = 1
@@ -329,7 +329,7 @@ enum Livekit_DataTrackExtensionID: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Livekit_VideoQuality: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_VideoQuality: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case low // = 0
   case medium // = 1
@@ -371,7 +371,7 @@ enum Livekit_VideoQuality: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Livekit_ConnectionQuality: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_ConnectionQuality: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case poor // = 0
   case good // = 1
@@ -413,7 +413,7 @@ enum Livekit_ConnectionQuality: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Livekit_ClientConfigSetting: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_ClientConfigSetting: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unset // = 0
   case disabled // = 1
@@ -451,7 +451,7 @@ enum Livekit_ClientConfigSetting: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Livekit_DisconnectReason: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_DisconnectReason: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unknownReason // = 0
 
@@ -577,7 +577,7 @@ enum Livekit_DisconnectReason: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Livekit_ReconnectReason: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_ReconnectReason: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case rrUnknown // = 0
   case rrSignalDisconnected // = 1
@@ -623,7 +623,7 @@ enum Livekit_ReconnectReason: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Livekit_SubscriptionError: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_SubscriptionError: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case seUnknown // = 0
   case seCodecUnsupported // = 1
@@ -661,7 +661,7 @@ enum Livekit_SubscriptionError: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Livekit_AudioTrackFeature: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_AudioTrackFeature: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case tfStereo // = 0
   case tfNoDtx // = 1
@@ -717,7 +717,7 @@ enum Livekit_AudioTrackFeature: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Livekit_PacketTrailerFeature: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_PacketTrailerFeature: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case ptfUserTimestamp // = 0
   case ptfFrameID // = 1
@@ -751,7 +751,7 @@ enum Livekit_PacketTrailerFeature: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-struct Livekit_Pagination: Sendable {
+nonisolated struct Livekit_Pagination: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -766,7 +766,7 @@ struct Livekit_Pagination: Sendable {
   init() {}
 }
 
-struct Livekit_TokenPagination: Sendable {
+nonisolated struct Livekit_TokenPagination: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -779,7 +779,7 @@ struct Livekit_TokenPagination: Sendable {
 }
 
 /// ListUpdate is used for updated APIs where 'repeated string' field is modified.
-struct Livekit_ListUpdate: Sendable {
+nonisolated struct Livekit_ListUpdate: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -801,7 +801,7 @@ struct Livekit_ListUpdate: Sendable {
   init() {}
 }
 
-struct Livekit_Room: Sendable {
+nonisolated struct Livekit_Room: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -848,7 +848,7 @@ struct Livekit_Room: Sendable {
   fileprivate var _version: Livekit_TimedVersion? = nil
 }
 
-struct Livekit_Codec: Sendable {
+nonisolated struct Livekit_Codec: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -862,7 +862,7 @@ struct Livekit_Codec: Sendable {
   init() {}
 }
 
-struct Livekit_PlayoutDelay: Sendable {
+nonisolated struct Livekit_PlayoutDelay: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -878,7 +878,7 @@ struct Livekit_PlayoutDelay: Sendable {
   init() {}
 }
 
-struct Livekit_ParticipantPermission: Sendable {
+nonisolated struct Livekit_ParticipantPermission: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -924,7 +924,7 @@ struct Livekit_ParticipantPermission: Sendable {
   init() {}
 }
 
-struct Livekit_ParticipantInfo: @unchecked Sendable {
+nonisolated struct Livekit_ParticipantInfo: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1030,7 +1030,7 @@ struct Livekit_ParticipantInfo: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum State: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum State: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
 
     /// websocket' connected, but not offered yet
@@ -1080,7 +1080,7 @@ struct Livekit_ParticipantInfo: @unchecked Sendable {
 
   }
 
-  enum Kind: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum Kind: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
 
     /// standard participants, e.g. web clients
@@ -1148,7 +1148,7 @@ struct Livekit_ParticipantInfo: @unchecked Sendable {
 
   }
 
-  enum KindDetail: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum KindDetail: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case cloudAgent // = 0
     case forwarded // = 1
@@ -1201,14 +1201,14 @@ struct Livekit_ParticipantInfo: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Livekit_Encryption: Sendable {
+nonisolated struct Livekit_Encryption: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TypeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum TypeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case none // = 0
     case gcm // = 1
@@ -1249,7 +1249,7 @@ struct Livekit_Encryption: Sendable {
   init() {}
 }
 
-struct Livekit_SimulcastCodecInfo: Sendable {
+nonisolated struct Livekit_SimulcastCodecInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1275,7 +1275,7 @@ struct Livekit_SimulcastCodecInfo: Sendable {
   init() {}
 }
 
-struct Livekit_TrackInfo: @unchecked Sendable {
+nonisolated struct Livekit_TrackInfo: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1414,7 +1414,7 @@ struct Livekit_TrackInfo: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Livekit_DataTrackInfo: Sendable {
+nonisolated struct Livekit_DataTrackInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1436,7 +1436,7 @@ struct Livekit_DataTrackInfo: Sendable {
   init() {}
 }
 
-struct Livekit_DataTrackExtensionParticipantSid: Sendable {
+nonisolated struct Livekit_DataTrackExtensionParticipantSid: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1450,7 +1450,7 @@ struct Livekit_DataTrackExtensionParticipantSid: Sendable {
   init() {}
 }
 
-struct Livekit_DataTrackSubscriptionOptions: Sendable {
+nonisolated struct Livekit_DataTrackSubscriptionOptions: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1474,7 +1474,7 @@ struct Livekit_DataTrackSubscriptionOptions: Sendable {
 }
 
 /// provide information about available spatial layers
-struct Livekit_VideoLayer: Sendable {
+nonisolated struct Livekit_VideoLayer: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1499,7 +1499,7 @@ struct Livekit_VideoLayer: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum Mode: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum Mode: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unused // = 0
     case oneSpatialLayerPerStream // = 1
@@ -1545,7 +1545,7 @@ struct Livekit_VideoLayer: Sendable {
 }
 
 /// new DataPacket API
-struct Livekit_DataPacket: @unchecked Sendable {
+nonisolated struct Livekit_DataPacket: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1692,7 +1692,7 @@ struct Livekit_DataPacket: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Value: Equatable, Sendable {
+  nonisolated enum OneOf_Value: Equatable, Sendable {
     case user(Livekit_UserPacket)
     /// NOTE: This field was marked as deprecated in the .proto file.
     case speaker(Livekit_ActiveSpeakerUpdate)
@@ -1710,7 +1710,7 @@ struct Livekit_DataPacket: @unchecked Sendable {
 
   }
 
-  enum Kind: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum Kind: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case reliable // = 0
     case lossy // = 1
@@ -1749,7 +1749,7 @@ struct Livekit_DataPacket: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Livekit_EncryptedPacket: Sendable {
+nonisolated struct Livekit_EncryptedPacket: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1768,7 +1768,7 @@ struct Livekit_EncryptedPacket: Sendable {
   init() {}
 }
 
-struct Livekit_EncryptedPacketPayload: Sendable {
+nonisolated struct Livekit_EncryptedPacketPayload: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1841,7 +1841,7 @@ struct Livekit_EncryptedPacketPayload: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Value: Equatable, Sendable {
+  nonisolated enum OneOf_Value: Equatable, Sendable {
     case user(Livekit_UserPacket)
     case chatMessage(Livekit_ChatMessage)
     case rpcRequest(Livekit_RpcRequest)
@@ -1857,7 +1857,7 @@ struct Livekit_EncryptedPacketPayload: Sendable {
 }
 
 /// NOTE: This message was marked as deprecated in the .proto file.
-struct Livekit_ActiveSpeakerUpdate: Sendable {
+nonisolated struct Livekit_ActiveSpeakerUpdate: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1869,7 +1869,7 @@ struct Livekit_ActiveSpeakerUpdate: Sendable {
   init() {}
 }
 
-struct Livekit_SpeakerInfo: Sendable {
+nonisolated struct Livekit_SpeakerInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1887,7 +1887,7 @@ struct Livekit_SpeakerInfo: Sendable {
   init() {}
 }
 
-struct Livekit_UserPacket: Sendable {
+nonisolated struct Livekit_UserPacket: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1965,7 +1965,7 @@ struct Livekit_UserPacket: Sendable {
   fileprivate var _endTime: UInt64? = nil
 }
 
-struct Livekit_SipDTMF: Sendable {
+nonisolated struct Livekit_SipDTMF: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1979,7 +1979,7 @@ struct Livekit_SipDTMF: Sendable {
   init() {}
 }
 
-struct Livekit_Transcription: Sendable {
+nonisolated struct Livekit_Transcription: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1996,7 +1996,7 @@ struct Livekit_Transcription: Sendable {
   init() {}
 }
 
-struct Livekit_TranscriptionSegment: Sendable {
+nonisolated struct Livekit_TranscriptionSegment: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2018,7 +2018,7 @@ struct Livekit_TranscriptionSegment: Sendable {
   init() {}
 }
 
-struct Livekit_ChatMessage: Sendable {
+nonisolated struct Livekit_ChatMessage: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2053,7 +2053,7 @@ struct Livekit_ChatMessage: Sendable {
   fileprivate var _editTimestamp: Int64? = nil
 }
 
-struct Livekit_RpcRequest: Sendable {
+nonisolated struct Livekit_RpcRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2076,7 +2076,7 @@ struct Livekit_RpcRequest: Sendable {
   init() {}
 }
 
-struct Livekit_RpcAck: Sendable {
+nonisolated struct Livekit_RpcAck: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2088,7 +2088,7 @@ struct Livekit_RpcAck: Sendable {
   init() {}
 }
 
-struct Livekit_RpcResponse: Sendable {
+nonisolated struct Livekit_RpcResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2124,7 +2124,7 @@ struct Livekit_RpcResponse: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Value: Equatable, Sendable {
+  nonisolated enum OneOf_Value: Equatable, Sendable {
     case payload(String)
     case error(Livekit_RpcError)
     /// Compressed payload data. When set, this field is used instead of `payload`.
@@ -2135,7 +2135,7 @@ struct Livekit_RpcResponse: Sendable {
   init() {}
 }
 
-struct Livekit_RpcError: Sendable {
+nonisolated struct Livekit_RpcError: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2151,7 +2151,7 @@ struct Livekit_RpcError: Sendable {
   init() {}
 }
 
-struct Livekit_ParticipantTracks: Sendable {
+nonisolated struct Livekit_ParticipantTracks: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2167,7 +2167,7 @@ struct Livekit_ParticipantTracks: Sendable {
 }
 
 /// details about the server
-struct Livekit_ServerInfo: Sendable {
+nonisolated struct Livekit_ServerInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2189,7 +2189,7 @@ struct Livekit_ServerInfo: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum Edition: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum Edition: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case standard // = 0
     case cloud // = 1
@@ -2227,7 +2227,7 @@ struct Livekit_ServerInfo: Sendable {
 }
 
 /// details about the client
-struct Livekit_ClientInfo: Sendable {
+nonisolated struct Livekit_ClientInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2266,7 +2266,7 @@ struct Livekit_ClientInfo: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum SDK: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum SDK: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unknown // = 0
     case js // = 1
@@ -2356,7 +2356,7 @@ struct Livekit_ClientInfo: Sendable {
   /// uses these flags to decide whether to enable features that require
   /// client-side support (e.g. passing RTP packet trailers through to the
   /// subscriber instead of stripping them).
-  enum Capability: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum Capability: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case capUnused // = 0
     case capPacketTrailer // = 1
@@ -2394,7 +2394,7 @@ struct Livekit_ClientInfo: Sendable {
 }
 
 /// server provided client configuration
-struct Livekit_ClientConfiguration: Sendable {
+nonisolated struct Livekit_ClientConfiguration: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2439,7 +2439,7 @@ struct Livekit_ClientConfiguration: Sendable {
   fileprivate var _disabledCodecs: Livekit_DisabledCodecs? = nil
 }
 
-struct Livekit_VideoConfiguration: Sendable {
+nonisolated struct Livekit_VideoConfiguration: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2451,7 +2451,7 @@ struct Livekit_VideoConfiguration: Sendable {
   init() {}
 }
 
-struct Livekit_DisabledCodecs: Sendable {
+nonisolated struct Livekit_DisabledCodecs: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2467,7 +2467,7 @@ struct Livekit_DisabledCodecs: Sendable {
   init() {}
 }
 
-struct Livekit_RTPDrift: Sendable {
+nonisolated struct Livekit_RTPDrift: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2512,7 +2512,7 @@ struct Livekit_RTPDrift: Sendable {
   fileprivate var _endTime: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
-struct Livekit_RTPStats: @unchecked Sendable {
+nonisolated struct Livekit_RTPStats: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2790,7 +2790,7 @@ struct Livekit_RTPStats: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Livekit_RTCPSenderReportState: Sendable {
+nonisolated struct Livekit_RTCPSenderReportState: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2815,7 +2815,7 @@ struct Livekit_RTCPSenderReportState: Sendable {
   init() {}
 }
 
-struct Livekit_RTPForwarderState: @unchecked Sendable {
+nonisolated struct Livekit_RTPForwarderState: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2874,7 +2874,7 @@ struct Livekit_RTPForwarderState: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_CodecMunger: Equatable, Sendable {
+  nonisolated enum OneOf_CodecMunger: Equatable, Sendable {
     case vp8Munger(Livekit_VP8MungerState)
 
   }
@@ -2884,7 +2884,7 @@ struct Livekit_RTPForwarderState: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Livekit_RTPMungerState: Sendable {
+nonisolated struct Livekit_RTPMungerState: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2906,7 +2906,7 @@ struct Livekit_RTPMungerState: Sendable {
   init() {}
 }
 
-struct Livekit_VP8MungerState: Sendable {
+nonisolated struct Livekit_VP8MungerState: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2930,7 +2930,7 @@ struct Livekit_VP8MungerState: Sendable {
   init() {}
 }
 
-struct Livekit_TimedVersion: Sendable {
+nonisolated struct Livekit_TimedVersion: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2944,7 +2944,7 @@ struct Livekit_TimedVersion: Sendable {
   init() {}
 }
 
-struct Livekit_DataStream: Sendable {
+nonisolated struct Livekit_DataStream: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2952,7 +2952,7 @@ struct Livekit_DataStream: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// enum for operation types (specific to TextHeader)
-  enum OperationType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum OperationType: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case create // = 0
     case update // = 1
@@ -2995,7 +2995,7 @@ struct Livekit_DataStream: Sendable {
   }
 
   /// header properties specific to text streams
-  struct TextHeader: Sendable {
+  nonisolated struct TextHeader: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -3020,7 +3020,7 @@ struct Livekit_DataStream: Sendable {
   }
 
   /// header properties specific to byte or file streams
-  struct ByteHeader: Sendable {
+  nonisolated struct ByteHeader: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -3033,7 +3033,7 @@ struct Livekit_DataStream: Sendable {
   }
 
   /// main DataStream.Header that contains a oneof for specific headers
-  struct Header: Sendable {
+  nonisolated struct Header: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -3088,7 +3088,7 @@ struct Livekit_DataStream: Sendable {
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// oneof to choose between specific header types
-    enum OneOf_ContentHeader: Equatable, Sendable {
+    nonisolated enum OneOf_ContentHeader: Equatable, Sendable {
       case textHeader(Livekit_DataStream.TextHeader)
       case byteHeader(Livekit_DataStream.ByteHeader)
 
@@ -3099,7 +3099,7 @@ struct Livekit_DataStream: Sendable {
     fileprivate var _totalLength: UInt64? = nil
   }
 
-  struct Chunk: Sendable {
+  nonisolated struct Chunk: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -3134,7 +3134,7 @@ struct Livekit_DataStream: Sendable {
     fileprivate var _iv: Data? = nil
   }
 
-  struct Trailer: Sendable {
+  nonisolated struct Trailer: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -3156,7 +3156,7 @@ struct Livekit_DataStream: Sendable {
   init() {}
 }
 
-struct Livekit_FilterParams: Sendable {
+nonisolated struct Livekit_FilterParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3170,7 +3170,7 @@ struct Livekit_FilterParams: Sendable {
   init() {}
 }
 
-struct Livekit_WebhookConfig: Sendable {
+nonisolated struct Livekit_WebhookConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3195,7 +3195,7 @@ struct Livekit_WebhookConfig: Sendable {
   fileprivate var _filterParams: Livekit_FilterParams? = nil
 }
 
-struct Livekit_SubscribedAudioCodec: Sendable {
+nonisolated struct Livekit_SubscribedAudioCodec: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3211,69 +3211,69 @@ struct Livekit_SubscribedAudioCodec: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "livekit"
+fileprivate nonisolated let _protobuf_package = "livekit"
 
-extension Livekit_AudioCodec: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_AudioCodec: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0DEFAULT_AC\0\u{1}OPUS\0\u{1}AAC\0\u{1}AC_MP3\0")
 }
 
-extension Livekit_VideoCodec: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_VideoCodec: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0DEFAULT_VC\0\u{1}H264_BASELINE\0\u{1}H264_MAIN\0\u{1}H264_HIGH\0\u{1}VP8\0")
 }
 
-extension Livekit_ImageCodec: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ImageCodec: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0IC_DEFAULT\0\u{1}IC_JPEG\0")
 }
 
-extension Livekit_BackupCodecPolicy: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_BackupCodecPolicy: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0PREFER_REGRESSION\0\u{1}SIMULCAST\0\u{1}REGRESSION\0")
 }
 
-extension Livekit_TrackType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_TrackType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0AUDIO\0\u{1}VIDEO\0\u{1}DATA\0")
 }
 
-extension Livekit_TrackSource: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_TrackSource: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNKNOWN\0\u{1}CAMERA\0\u{1}MICROPHONE\0\u{1}SCREEN_SHARE\0\u{1}SCREEN_SHARE_AUDIO\0")
 }
 
-extension Livekit_DataTrackExtensionID: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataTrackExtensionID: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0DTEI_INVALID\0\u{1}DTEI_PARTICIPANT_SID\0")
 }
 
-extension Livekit_VideoQuality: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_VideoQuality: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0LOW\0\u{1}MEDIUM\0\u{1}HIGH\0\u{1}OFF\0")
 }
 
-extension Livekit_ConnectionQuality: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ConnectionQuality: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0POOR\0\u{1}GOOD\0\u{1}EXCELLENT\0\u{1}LOST\0")
 }
 
-extension Livekit_ClientConfigSetting: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ClientConfigSetting: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNSET\0\u{1}DISABLED\0\u{1}ENABLED\0")
 }
 
-extension Livekit_DisconnectReason: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DisconnectReason: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNKNOWN_REASON\0\u{1}CLIENT_INITIATED\0\u{1}DUPLICATE_IDENTITY\0\u{1}SERVER_SHUTDOWN\0\u{1}PARTICIPANT_REMOVED\0\u{1}ROOM_DELETED\0\u{1}STATE_MISMATCH\0\u{1}JOIN_FAILURE\0\u{1}MIGRATION\0\u{1}SIGNAL_CLOSE\0\u{1}ROOM_CLOSED\0\u{1}USER_UNAVAILABLE\0\u{1}USER_REJECTED\0\u{1}SIP_TRUNK_FAILURE\0\u{1}CONNECTION_TIMEOUT\0\u{1}MEDIA_FAILURE\0\u{1}AGENT_ERROR\0")
 }
 
-extension Livekit_ReconnectReason: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ReconnectReason: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0RR_UNKNOWN\0\u{1}RR_SIGNAL_DISCONNECTED\0\u{1}RR_PUBLISHER_FAILED\0\u{1}RR_SUBSCRIBER_FAILED\0\u{1}RR_SWITCH_CANDIDATE\0")
 }
 
-extension Livekit_SubscriptionError: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SubscriptionError: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SE_UNKNOWN\0\u{1}SE_CODEC_UNSUPPORTED\0\u{1}SE_TRACK_NOTFOUND\0")
 }
 
-extension Livekit_AudioTrackFeature: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_AudioTrackFeature: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0TF_STEREO\0\u{1}TF_NO_DTX\0\u{1}TF_AUTO_GAIN_CONTROL\0\u{1}TF_ECHO_CANCELLATION\0\u{1}TF_NOISE_SUPPRESSION\0\u{1}TF_ENHANCED_NOISE_CANCELLATION\0\u{1}TF_PRECONNECT_BUFFER\0")
 }
 
-extension Livekit_PacketTrailerFeature: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_PacketTrailerFeature: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0PTF_USER_TIMESTAMP\0\u{1}PTF_FRAME_ID\0")
 }
 
-extension Livekit_Pagination: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_Pagination: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Pagination"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}after_id\0\u{1}limit\0")
 
@@ -3308,7 +3308,7 @@ extension Livekit_Pagination: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Livekit_TokenPagination: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_TokenPagination: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TokenPagination"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}token\0")
 
@@ -3338,7 +3338,7 @@ extension Livekit_TokenPagination: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Livekit_ListUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ListUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ListUpdate"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}set\0\u{1}add\0\u{1}remove\0\u{1}clear\0")
 
@@ -3383,7 +3383,7 @@ extension Livekit_ListUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Livekit_Room: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_Room: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Room"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sid\0\u{1}name\0\u{3}empty_timeout\0\u{3}max_participants\0\u{3}creation_time\0\u{3}turn_password\0\u{3}enabled_codecs\0\u{1}metadata\0\u{3}num_participants\0\u{3}active_recording\0\u{3}num_publishers\0\u{2}\u{2}version\0\u{3}departure_timeout\0\u{3}creation_time_ms\0")
 
@@ -3482,7 +3482,7 @@ extension Livekit_Room: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
   }
 }
 
-extension Livekit_Codec: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_Codec: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Codec"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}mime\0\u{3}fmtp_line\0")
 
@@ -3517,7 +3517,7 @@ extension Livekit_Codec: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
   }
 }
 
-extension Livekit_PlayoutDelay: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_PlayoutDelay: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PlayoutDelay"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}enabled\0\u{1}min\0\u{1}max\0")
 
@@ -3557,7 +3557,7 @@ extension Livekit_PlayoutDelay: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 }
 
-extension Livekit_ParticipantPermission: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ParticipantPermission: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ParticipantPermission"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}can_subscribe\0\u{3}can_publish\0\u{3}can_publish_data\0\u{2}\u{4}hidden\0\u{1}recorder\0\u{3}can_publish_sources\0\u{3}can_update_metadata\0\u{1}agent\0\u{3}can_subscribe_metrics\0\u{3}can_manage_agent_session\0")
 
@@ -3632,7 +3632,7 @@ extension Livekit_ParticipantPermission: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Livekit_ParticipantInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ParticipantInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ParticipantInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sid\0\u{1}identity\0\u{1}state\0\u{1}tracks\0\u{1}metadata\0\u{3}joined_at\0\u{2}\u{3}name\0\u{1}version\0\u{1}permission\0\u{1}region\0\u{3}is_publisher\0\u{1}kind\0\u{1}attributes\0\u{3}disconnect_reason\0\u{3}joined_at_ms\0\u{3}kind_details\0\u{3}data_tracks\0\u{3}client_protocol\0")
 
@@ -3821,19 +3821,19 @@ extension Livekit_ParticipantInfo: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Livekit_ParticipantInfo.State: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ParticipantInfo.State: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0JOINING\0\u{1}JOINED\0\u{1}ACTIVE\0\u{1}DISCONNECTED\0")
 }
 
-extension Livekit_ParticipantInfo.Kind: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ParticipantInfo.Kind: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0STANDARD\0\u{1}INGRESS\0\u{1}EGRESS\0\u{1}SIP\0\u{1}AGENT\0\u{2}\u{3}CONNECTOR\0\u{1}BRIDGE\0")
 }
 
-extension Livekit_ParticipantInfo.KindDetail: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ParticipantInfo.KindDetail: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CLOUD_AGENT\0\u{1}FORWARDED\0\u{1}CONNECTOR_WHATSAPP\0\u{1}CONNECTOR_TWILIO\0\u{1}BRIDGE_RTSP\0")
 }
 
-extension Livekit_Encryption: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_Encryption: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Encryption"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -3852,11 +3852,11 @@ extension Livekit_Encryption: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Livekit_Encryption.TypeEnum: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_Encryption.TypeEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0NONE\0\u{1}GCM\0\u{1}CUSTOM\0")
 }
 
-extension Livekit_SimulcastCodecInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SimulcastCodecInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SimulcastCodecInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}mime_type\0\u{1}mid\0\u{1}cid\0\u{1}layers\0\u{3}video_layer_mode\0\u{3}sdp_cid\0")
 
@@ -3911,7 +3911,7 @@ extension Livekit_SimulcastCodecInfo: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Livekit_TrackInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_TrackInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TrackInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sid\0\u{1}type\0\u{1}name\0\u{1}muted\0\u{1}width\0\u{1}height\0\u{1}simulcast\0\u{3}disable_dtx\0\u{1}source\0\u{1}layers\0\u{3}mime_type\0\u{1}mid\0\u{1}codecs\0\u{1}stereo\0\u{3}disable_red\0\u{1}encryption\0\u{1}stream\0\u{1}version\0\u{3}audio_features\0\u{3}backup_codec_policy\0\u{3}packet_trailer_features\0")
 
@@ -4121,7 +4121,7 @@ extension Livekit_TrackInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
   }
 }
 
-extension Livekit_DataTrackInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataTrackInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DataTrackInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}pub_handle\0\u{1}sid\0\u{1}name\0\u{1}encryption\0")
 
@@ -4166,7 +4166,7 @@ extension Livekit_DataTrackInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   }
 }
 
-extension Livekit_DataTrackExtensionParticipantSid: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataTrackExtensionParticipantSid: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DataTrackExtensionParticipantSid"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}participant_sid\0")
 
@@ -4201,7 +4201,7 @@ extension Livekit_DataTrackExtensionParticipantSid: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Livekit_DataTrackSubscriptionOptions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataTrackSubscriptionOptions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DataTrackSubscriptionOptions"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}target_fps\0")
 
@@ -4235,7 +4235,7 @@ extension Livekit_DataTrackSubscriptionOptions: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Livekit_VideoLayer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_VideoLayer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".VideoLayer"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}quality\0\u{1}width\0\u{1}height\0\u{1}bitrate\0\u{1}ssrc\0\u{3}spatial_layer\0\u{1}rid\0\u{3}repair_ssrc\0")
 
@@ -4300,11 +4300,11 @@ extension Livekit_VideoLayer: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Livekit_VideoLayer.Mode: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_VideoLayer.Mode: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0MODE_UNUSED\0\u{1}ONE_SPATIAL_LAYER_PER_STREAM\0\u{1}MULTIPLE_SPATIAL_LAYERS_PER_STREAM\0\u{1}ONE_SPATIAL_LAYER_PER_STREAM_INCOMPLETE_RTCP_SR\0")
 }
 
-extension Livekit_DataPacket: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataPacket: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DataPacket"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}kind\0\u{1}user\0\u{1}speaker\0\u{3}participant_identity\0\u{3}destination_identities\0\u{3}sip_dtmf\0\u{1}transcription\0\u{1}metrics\0\u{3}chat_message\0\u{3}rpc_request\0\u{3}rpc_ack\0\u{3}rpc_response\0\u{3}stream_header\0\u{3}stream_chunk\0\u{3}stream_trailer\0\u{1}sequence\0\u{3}participant_sid\0\u{3}encrypted_packet\0")
 
@@ -4631,11 +4631,11 @@ extension Livekit_DataPacket: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Livekit_DataPacket.Kind: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataPacket.Kind: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0RELIABLE\0\u{1}LOSSY\0")
 }
 
-extension Livekit_EncryptedPacket: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_EncryptedPacket: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".EncryptedPacket"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}encryption_type\0\u{1}iv\0\u{3}key_index\0\u{3}encrypted_value\0")
 
@@ -4680,7 +4680,7 @@ extension Livekit_EncryptedPacket: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Livekit_EncryptedPacketPayload: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_EncryptedPacketPayload: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".EncryptedPacketPayload"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}user\0\u{4}\u{2}chat_message\0\u{3}rpc_request\0\u{3}rpc_ack\0\u{3}rpc_response\0\u{3}stream_header\0\u{3}stream_chunk\0\u{3}stream_trailer\0")
 
@@ -4849,7 +4849,7 @@ extension Livekit_EncryptedPacketPayload: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Livekit_ActiveSpeakerUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ActiveSpeakerUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ActiveSpeakerUpdate"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}speakers\0")
 
@@ -4879,7 +4879,7 @@ extension Livekit_ActiveSpeakerUpdate: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Livekit_SpeakerInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SpeakerInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SpeakerInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sid\0\u{1}level\0\u{1}active\0")
 
@@ -4919,7 +4919,7 @@ extension Livekit_SpeakerInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
   }
 }
 
-extension Livekit_UserPacket: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_UserPacket: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UserPacket"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}participant_sid\0\u{1}payload\0\u{3}destination_sids\0\u{1}topic\0\u{3}participant_identity\0\u{3}destination_identities\0\u{2}\u{2}id\0\u{3}start_time\0\u{3}end_time\0\u{1}nonce\0")
 
@@ -4998,7 +4998,7 @@ extension Livekit_UserPacket: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Livekit_SipDTMF: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SipDTMF: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SipDTMF"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\u{3}code\0\u{1}digit\0")
 
@@ -5033,7 +5033,7 @@ extension Livekit_SipDTMF: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
   }
 }
 
-extension Livekit_Transcription: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_Transcription: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Transcription"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{2}transcribed_participant_identity\0\u{3}track_id\0\u{1}segments\0")
 
@@ -5073,7 +5073,7 @@ extension Livekit_Transcription: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   }
 }
 
-extension Livekit_TranscriptionSegment: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_TranscriptionSegment: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TranscriptionSegment"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}text\0\u{3}start_time\0\u{3}end_time\0\u{1}final\0\u{1}language\0")
 
@@ -5128,7 +5128,7 @@ extension Livekit_TranscriptionSegment: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Livekit_ChatMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ChatMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ChatMessage"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}timestamp\0\u{3}edit_timestamp\0\u{1}message\0\u{1}deleted\0\u{1}generated\0")
 
@@ -5187,7 +5187,7 @@ extension Livekit_ChatMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
   }
 }
 
-extension Livekit_RpcRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_RpcRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RpcRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}method\0\u{1}payload\0\u{3}response_timeout_ms\0\u{1}version\0\u{3}compressed_payload\0")
 
@@ -5242,7 +5242,7 @@ extension Livekit_RpcRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Livekit_RpcAck: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_RpcAck: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RpcAck"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}request_id\0")
 
@@ -5272,7 +5272,7 @@ extension Livekit_RpcAck: SwiftProtobuf.Message, SwiftProtobuf._MessageImplement
   }
 }
 
-extension Livekit_RpcResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_RpcResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RpcResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}request_id\0\u{1}payload\0\u{1}error\0\u{3}compressed_payload\0")
 
@@ -5351,7 +5351,7 @@ extension Livekit_RpcResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
   }
 }
 
-extension Livekit_RpcError: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_RpcError: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RpcError"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}code\0\u{1}message\0\u{1}data\0")
 
@@ -5391,7 +5391,7 @@ extension Livekit_RpcError: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
   }
 }
 
-extension Livekit_ParticipantTracks: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ParticipantTracks: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ParticipantTracks"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}participant_sid\0\u{3}track_sids\0")
 
@@ -5426,7 +5426,7 @@ extension Livekit_ParticipantTracks: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Livekit_ServerInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ServerInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}edition\0\u{1}version\0\u{1}protocol\0\u{1}region\0\u{3}node_id\0\u{3}debug_info\0\u{3}agent_protocol\0")
 
@@ -5486,11 +5486,11 @@ extension Livekit_ServerInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Livekit_ServerInfo.Edition: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ServerInfo.Edition: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0Standard\0\u{1}Cloud\0")
 }
 
-extension Livekit_ClientInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ClientInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sdk\0\u{1}version\0\u{1}protocol\0\u{1}os\0\u{3}os_version\0\u{3}device_model\0\u{1}browser\0\u{3}browser_version\0\u{1}address\0\u{1}network\0\u{3}other_sdks\0\u{3}client_protocol\0\u{1}capabilities\0")
 
@@ -5580,15 +5580,15 @@ extension Livekit_ClientInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Livekit_ClientInfo.SDK: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ClientInfo.SDK: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNKNOWN\0\u{1}JS\0\u{1}SWIFT\0\u{1}ANDROID\0\u{1}FLUTTER\0\u{1}GO\0\u{1}UNITY\0\u{1}REACT_NATIVE\0\u{1}RUST\0\u{1}PYTHON\0\u{1}CPP\0\u{1}UNITY_WEB\0\u{1}NODE\0\u{1}UNREAL\0\u{1}ESP32\0")
 }
 
-extension Livekit_ClientInfo.Capability: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ClientInfo.Capability: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CAP_UNUSED\0\u{1}CAP_PACKET_TRAILER\0")
 }
 
-extension Livekit_ClientConfiguration: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ClientConfiguration: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientConfiguration"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}video\0\u{1}screen\0\u{3}resume_connection\0\u{3}disabled_codecs\0\u{3}force_relay\0")
 
@@ -5642,7 +5642,7 @@ extension Livekit_ClientConfiguration: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Livekit_VideoConfiguration: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_VideoConfiguration: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".VideoConfiguration"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}hardware_encoder\0")
 
@@ -5672,7 +5672,7 @@ extension Livekit_VideoConfiguration: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Livekit_DisabledCodecs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DisabledCodecs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DisabledCodecs"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}codecs\0\u{1}publish\0")
 
@@ -5707,7 +5707,7 @@ extension Livekit_DisabledCodecs: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Livekit_RTPDrift: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_RTPDrift: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RTPDrift"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}start_time\0\u{3}end_time\0\u{1}duration\0\u{3}start_timestamp\0\u{3}end_timestamp\0\u{3}rtp_clock_ticks\0\u{3}drift_samples\0\u{3}drift_ms\0\u{3}clock_rate\0")
 
@@ -5781,7 +5781,7 @@ extension Livekit_RTPDrift: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
   }
 }
 
-extension Livekit_RTPStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_RTPStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RTPStats"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}start_time\0\u{3}end_time\0\u{1}duration\0\u{1}packets\0\u{3}packet_rate\0\u{1}bytes\0\u{1}bitrate\0\u{3}packets_lost\0\u{3}packet_loss_rate\0\u{3}packet_loss_percentage\0\u{3}packets_duplicate\0\u{3}packet_duplicate_rate\0\u{3}bytes_duplicate\0\u{3}bitrate_duplicate\0\u{3}packets_padding\0\u{3}packet_padding_rate\0\u{3}bytes_padding\0\u{3}bitrate_padding\0\u{3}packets_out_of_order\0\u{1}frames\0\u{3}frame_rate\0\u{3}jitter_current\0\u{3}jitter_max\0\u{3}gap_histogram\0\u{1}nacks\0\u{3}nack_misses\0\u{1}plis\0\u{3}last_pli\0\u{1}firs\0\u{3}last_fir\0\u{3}rtt_current\0\u{3}rtt_max\0\u{3}key_frames\0\u{3}last_key_frame\0\u{3}layer_lock_plis\0\u{3}last_layer_lock_pli\0\u{3}nack_acks\0\u{3}nack_repeated\0\u{3}header_bytes\0\u{3}header_bytes_duplicate\0\u{3}header_bytes_padding\0\u{4}\u{3}packet_drift\0\u{3}ntp_report_drift\0\u{3}rebased_report_drift\0\u{3}received_report_drift\0")
 
@@ -6159,7 +6159,7 @@ extension Livekit_RTPStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
   }
 }
 
-extension Livekit_RTCPSenderReportState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_RTCPSenderReportState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RTCPSenderReportState"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}rtp_timestamp\0\u{3}rtp_timestamp_ext\0\u{3}ntp_timestamp\0\u{1}at\0\u{3}at_adjusted\0\u{1}packets\0\u{1}octets\0")
 
@@ -6219,7 +6219,7 @@ extension Livekit_RTCPSenderReportState: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Livekit_RTPForwarderState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_RTPForwarderState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RTPForwarderState"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}started\0\u{3}reference_layer_spatial\0\u{3}pre_start_time\0\u{3}ext_first_timestamp\0\u{3}dummy_start_timestamp_offset\0\u{3}rtp_munger\0\u{3}vp8_munger\0\u{3}sender_report_state\0")
 
@@ -6350,7 +6350,7 @@ extension Livekit_RTPForwarderState: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Livekit_RTPMungerState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_RTPMungerState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RTPMungerState"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}ext_last_sequence_number\0\u{3}ext_second_last_sequence_number\0\u{3}ext_last_timestamp\0\u{3}ext_second_last_timestamp\0\u{3}last_marker\0\u{3}second_last_marker\0")
 
@@ -6405,7 +6405,7 @@ extension Livekit_RTPMungerState: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Livekit_VP8MungerState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_VP8MungerState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".VP8MungerState"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}ext_last_picture_id\0\u{3}picture_id_used\0\u{3}last_tl0_pic_idx\0\u{3}tl0_pic_idx_used\0\u{3}tid_used\0\u{3}last_key_idx\0\u{3}key_idx_used\0")
 
@@ -6465,7 +6465,7 @@ extension Livekit_VP8MungerState: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Livekit_TimedVersion: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_TimedVersion: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TimedVersion"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}unix_micro\0\u{1}ticks\0")
 
@@ -6500,7 +6500,7 @@ extension Livekit_TimedVersion: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 }
 
-extension Livekit_DataStream: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataStream: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DataStream"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -6519,11 +6519,11 @@ extension Livekit_DataStream: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Livekit_DataStream.OperationType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataStream.OperationType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CREATE\0\u{1}UPDATE\0\u{1}DELETE\0\u{1}REACTION\0")
 }
 
-extension Livekit_DataStream.TextHeader: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataStream.TextHeader: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Livekit_DataStream.protoMessageName + ".TextHeader"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}operation_type\0\u{1}version\0\u{3}reply_to_stream_id\0\u{3}attached_stream_ids\0\u{1}generated\0")
 
@@ -6573,7 +6573,7 @@ extension Livekit_DataStream.TextHeader: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Livekit_DataStream.ByteHeader: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataStream.ByteHeader: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Livekit_DataStream.protoMessageName + ".ByteHeader"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0")
 
@@ -6603,7 +6603,7 @@ extension Livekit_DataStream.ByteHeader: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Livekit_DataStream.Header: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataStream.Header: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Livekit_DataStream.protoMessageName + ".Header"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}stream_id\0\u{1}timestamp\0\u{1}topic\0\u{3}mime_type\0\u{3}total_length\0\u{4}\u{2}encryption_type\0\u{1}attributes\0\u{3}text_header\0\u{3}byte_header\0")
 
@@ -6705,7 +6705,7 @@ extension Livekit_DataStream.Header: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Livekit_DataStream.Chunk: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataStream.Chunk: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Livekit_DataStream.protoMessageName + ".Chunk"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}stream_id\0\u{3}chunk_index\0\u{1}content\0\u{1}version\0\u{1}iv\0")
 
@@ -6759,7 +6759,7 @@ extension Livekit_DataStream.Chunk: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Livekit_DataStream.Trailer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataStream.Trailer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Livekit_DataStream.protoMessageName + ".Trailer"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}stream_id\0\u{1}reason\0\u{1}attributes\0")
 
@@ -6799,7 +6799,7 @@ extension Livekit_DataStream.Trailer: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Livekit_FilterParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_FilterParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".FilterParams"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}include_events\0\u{3}exclude_events\0")
 
@@ -6834,7 +6834,7 @@ extension Livekit_FilterParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 }
 
-extension Livekit_WebhookConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_WebhookConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WebhookConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}url\0\u{3}signing_key\0\u{3}filter_params\0")
 
@@ -6878,7 +6878,7 @@ extension Livekit_WebhookConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   }
 }
 
-extension Livekit_SubscribedAudioCodec: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SubscribedAudioCodec: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubscribedAudioCodec"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}codec\0\u{1}enabled\0")
 

--- a/Sources/LiveKit/Protos/livekit_rtc.pb.swift
+++ b/Sources/LiveKit/Protos/livekit_rtc.pb.swift
@@ -38,12 +38,12 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-enum Livekit_SignalTarget: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_SignalTarget: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case publisher // = 0
   case subscriber // = 1
@@ -77,7 +77,7 @@ enum Livekit_SignalTarget: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Livekit_StreamState: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_StreamState: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case active // = 0
   case paused // = 1
@@ -111,7 +111,7 @@ enum Livekit_StreamState: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Livekit_CandidateProtocol: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Livekit_CandidateProtocol: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case udp // = 0
   case tcp // = 1
@@ -149,7 +149,7 @@ enum Livekit_CandidateProtocol: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-struct Livekit_SignalRequest: Sendable {
+nonisolated struct Livekit_SignalRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -338,7 +338,7 @@ struct Livekit_SignalRequest: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Message: Equatable, Sendable {
+  nonisolated enum OneOf_Message: Equatable, Sendable {
     /// participant offer for publisher
     case offer(Livekit_SessionDescription)
     /// participant answering subscriber offer
@@ -385,7 +385,7 @@ struct Livekit_SignalRequest: Sendable {
   init() {}
 }
 
-struct Livekit_SignalResponse: Sendable {
+nonisolated struct Livekit_SignalResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -647,7 +647,7 @@ struct Livekit_SignalResponse: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Message: Equatable, Sendable {
+  nonisolated enum OneOf_Message: Equatable, Sendable {
     /// sent when join is accepted
     case join(Livekit_JoinResponse)
     /// sent when server answers publisher
@@ -711,7 +711,7 @@ struct Livekit_SignalResponse: Sendable {
   init() {}
 }
 
-struct Livekit_SimulcastCodec: Sendable {
+nonisolated struct Livekit_SimulcastCodec: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -729,7 +729,7 @@ struct Livekit_SimulcastCodec: Sendable {
   init() {}
 }
 
-struct Livekit_AddTrackRequest: @unchecked Sendable {
+nonisolated struct Livekit_AddTrackRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -843,7 +843,7 @@ struct Livekit_AddTrackRequest: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Livekit_PublishDataTrackRequest: Sendable {
+nonisolated struct Livekit_PublishDataTrackRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -864,7 +864,7 @@ struct Livekit_PublishDataTrackRequest: Sendable {
   init() {}
 }
 
-struct Livekit_PublishDataTrackResponse: Sendable {
+nonisolated struct Livekit_PublishDataTrackResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -886,7 +886,7 @@ struct Livekit_PublishDataTrackResponse: Sendable {
   fileprivate var _info: Livekit_DataTrackInfo? = nil
 }
 
-struct Livekit_UnpublishDataTrackRequest: Sendable {
+nonisolated struct Livekit_UnpublishDataTrackRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -899,7 +899,7 @@ struct Livekit_UnpublishDataTrackRequest: Sendable {
   init() {}
 }
 
-struct Livekit_UnpublishDataTrackResponse: Sendable {
+nonisolated struct Livekit_UnpublishDataTrackResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -921,7 +921,7 @@ struct Livekit_UnpublishDataTrackResponse: Sendable {
   fileprivate var _info: Livekit_DataTrackInfo? = nil
 }
 
-struct Livekit_DataTrackSubscriberHandles: Sendable {
+nonisolated struct Livekit_DataTrackSubscriberHandles: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -931,7 +931,7 @@ struct Livekit_DataTrackSubscriberHandles: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct PublishedDataTrack: Sendable {
+  nonisolated struct PublishedDataTrack: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -950,7 +950,7 @@ struct Livekit_DataTrackSubscriberHandles: Sendable {
   init() {}
 }
 
-struct Livekit_TrickleRequest: Sendable {
+nonisolated struct Livekit_TrickleRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -966,7 +966,7 @@ struct Livekit_TrickleRequest: Sendable {
   init() {}
 }
 
-struct Livekit_MuteTrackRequest: Sendable {
+nonisolated struct Livekit_MuteTrackRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -980,7 +980,7 @@ struct Livekit_MuteTrackRequest: Sendable {
   init() {}
 }
 
-struct Livekit_JoinResponse: @unchecked Sendable {
+nonisolated struct Livekit_JoinResponse: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1090,7 +1090,7 @@ struct Livekit_JoinResponse: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Livekit_ReconnectResponse: Sendable {
+nonisolated struct Livekit_ReconnectResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1126,7 +1126,7 @@ struct Livekit_ReconnectResponse: Sendable {
   fileprivate var _serverInfo: Livekit_ServerInfo? = nil
 }
 
-struct Livekit_TrackPublishedResponse: Sendable {
+nonisolated struct Livekit_TrackPublishedResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1149,7 +1149,7 @@ struct Livekit_TrackPublishedResponse: Sendable {
   fileprivate var _track: Livekit_TrackInfo? = nil
 }
 
-struct Livekit_TrackUnpublishedResponse: Sendable {
+nonisolated struct Livekit_TrackUnpublishedResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1161,7 +1161,7 @@ struct Livekit_TrackUnpublishedResponse: Sendable {
   init() {}
 }
 
-struct Livekit_SessionDescription: Sendable {
+nonisolated struct Livekit_SessionDescription: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1180,7 +1180,7 @@ struct Livekit_SessionDescription: Sendable {
   init() {}
 }
 
-struct Livekit_ParticipantUpdate: Sendable {
+nonisolated struct Livekit_ParticipantUpdate: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1192,7 +1192,7 @@ struct Livekit_ParticipantUpdate: Sendable {
   init() {}
 }
 
-struct Livekit_UpdateSubscription: Sendable {
+nonisolated struct Livekit_UpdateSubscription: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1208,7 +1208,7 @@ struct Livekit_UpdateSubscription: Sendable {
   init() {}
 }
 
-struct Livekit_UpdateDataSubscription: Sendable {
+nonisolated struct Livekit_UpdateDataSubscription: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1217,7 +1217,7 @@ struct Livekit_UpdateDataSubscription: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Update: Sendable {
+  nonisolated struct Update: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1247,7 +1247,7 @@ struct Livekit_UpdateDataSubscription: Sendable {
   init() {}
 }
 
-struct Livekit_UpdateTrackSettings: Sendable {
+nonisolated struct Livekit_UpdateTrackSettings: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1282,7 +1282,7 @@ struct Livekit_UpdateTrackSettings: Sendable {
   init() {}
 }
 
-struct Livekit_UpdateLocalAudioTrack: Sendable {
+nonisolated struct Livekit_UpdateLocalAudioTrack: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1296,7 +1296,7 @@ struct Livekit_UpdateLocalAudioTrack: Sendable {
   init() {}
 }
 
-struct Livekit_UpdateLocalVideoTrack: Sendable {
+nonisolated struct Livekit_UpdateLocalVideoTrack: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1312,7 +1312,7 @@ struct Livekit_UpdateLocalVideoTrack: Sendable {
   init() {}
 }
 
-struct Livekit_LeaveRequest: Sendable {
+nonisolated struct Livekit_LeaveRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1338,7 +1338,7 @@ struct Livekit_LeaveRequest: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// indicates action clients should take on receiving this message
-  enum Action: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum Action: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
 
     /// should disconnect
@@ -1390,7 +1390,7 @@ struct Livekit_LeaveRequest: Sendable {
 /// message to indicate published video track dimensions are changing
 ///
 /// NOTE: This message was marked as deprecated in the .proto file.
-struct Livekit_UpdateVideoLayers: Sendable {
+nonisolated struct Livekit_UpdateVideoLayers: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1404,7 +1404,7 @@ struct Livekit_UpdateVideoLayers: Sendable {
   init() {}
 }
 
-struct Livekit_UpdateParticipantMetadata: Sendable {
+nonisolated struct Livekit_UpdateParticipantMetadata: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1424,7 +1424,7 @@ struct Livekit_UpdateParticipantMetadata: Sendable {
   init() {}
 }
 
-struct Livekit_ICEServer: Sendable {
+nonisolated struct Livekit_ICEServer: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1440,7 +1440,7 @@ struct Livekit_ICEServer: Sendable {
   init() {}
 }
 
-struct Livekit_SpeakersChanged: Sendable {
+nonisolated struct Livekit_SpeakersChanged: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1452,7 +1452,7 @@ struct Livekit_SpeakersChanged: Sendable {
   init() {}
 }
 
-struct Livekit_RoomUpdate: Sendable {
+nonisolated struct Livekit_RoomUpdate: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1473,7 +1473,7 @@ struct Livekit_RoomUpdate: Sendable {
   fileprivate var _room: Livekit_Room? = nil
 }
 
-struct Livekit_ConnectionQualityInfo: Sendable {
+nonisolated struct Livekit_ConnectionQualityInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1489,7 +1489,7 @@ struct Livekit_ConnectionQualityInfo: Sendable {
   init() {}
 }
 
-struct Livekit_ConnectionQualityUpdate: Sendable {
+nonisolated struct Livekit_ConnectionQualityUpdate: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1501,7 +1501,7 @@ struct Livekit_ConnectionQualityUpdate: Sendable {
   init() {}
 }
 
-struct Livekit_StreamStateInfo: Sendable {
+nonisolated struct Livekit_StreamStateInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1517,7 +1517,7 @@ struct Livekit_StreamStateInfo: Sendable {
   init() {}
 }
 
-struct Livekit_StreamStateUpdate: Sendable {
+nonisolated struct Livekit_StreamStateUpdate: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1529,7 +1529,7 @@ struct Livekit_StreamStateUpdate: Sendable {
   init() {}
 }
 
-struct Livekit_SubscribedQuality: Sendable {
+nonisolated struct Livekit_SubscribedQuality: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1543,7 +1543,7 @@ struct Livekit_SubscribedQuality: Sendable {
   init() {}
 }
 
-struct Livekit_SubscribedCodec: Sendable {
+nonisolated struct Livekit_SubscribedCodec: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1557,7 +1557,7 @@ struct Livekit_SubscribedCodec: Sendable {
   init() {}
 }
 
-struct Livekit_SubscribedQualityUpdate: Sendable {
+nonisolated struct Livekit_SubscribedQualityUpdate: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1574,7 +1574,7 @@ struct Livekit_SubscribedQualityUpdate: Sendable {
   init() {}
 }
 
-struct Livekit_SubscribedAudioCodecUpdate: Sendable {
+nonisolated struct Livekit_SubscribedAudioCodecUpdate: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1588,7 +1588,7 @@ struct Livekit_SubscribedAudioCodecUpdate: Sendable {
   init() {}
 }
 
-struct Livekit_TrackPermission: Sendable {
+nonisolated struct Livekit_TrackPermission: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1607,7 +1607,7 @@ struct Livekit_TrackPermission: Sendable {
   init() {}
 }
 
-struct Livekit_SubscriptionPermission: Sendable {
+nonisolated struct Livekit_SubscriptionPermission: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1621,7 +1621,7 @@ struct Livekit_SubscriptionPermission: Sendable {
   init() {}
 }
 
-struct Livekit_SubscriptionPermissionUpdate: Sendable {
+nonisolated struct Livekit_SubscriptionPermissionUpdate: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1637,7 +1637,7 @@ struct Livekit_SubscriptionPermissionUpdate: Sendable {
   init() {}
 }
 
-struct Livekit_RoomMovedResponse: @unchecked Sendable {
+nonisolated struct Livekit_RoomMovedResponse: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1679,7 +1679,7 @@ struct Livekit_RoomMovedResponse: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Livekit_SyncState: Sendable {
+nonisolated struct Livekit_SyncState: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1736,7 +1736,7 @@ struct Livekit_SyncState: Sendable {
   fileprivate var _offer: Livekit_SessionDescription? = nil
 }
 
-struct Livekit_DataChannelReceiveState: Sendable {
+nonisolated struct Livekit_DataChannelReceiveState: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1750,7 +1750,7 @@ struct Livekit_DataChannelReceiveState: Sendable {
   init() {}
 }
 
-struct Livekit_DataChannelInfo: Sendable {
+nonisolated struct Livekit_DataChannelInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1766,7 +1766,7 @@ struct Livekit_DataChannelInfo: Sendable {
   init() {}
 }
 
-struct Livekit_SimulateScenario: Sendable {
+nonisolated struct Livekit_SimulateScenario: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1857,7 +1857,7 @@ struct Livekit_SimulateScenario: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Scenario: Equatable, Sendable {
+  nonisolated enum OneOf_Scenario: Equatable, Sendable {
     /// simulate N seconds of speaker activity
     case speakerUpdate(Int32)
     /// simulate local node failure
@@ -1883,7 +1883,7 @@ struct Livekit_SimulateScenario: Sendable {
   init() {}
 }
 
-struct Livekit_Ping: Sendable {
+nonisolated struct Livekit_Ping: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1898,7 +1898,7 @@ struct Livekit_Ping: Sendable {
   init() {}
 }
 
-struct Livekit_Pong: Sendable {
+nonisolated struct Livekit_Pong: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1913,7 +1913,7 @@ struct Livekit_Pong: Sendable {
   init() {}
 }
 
-struct Livekit_RegionSettings: Sendable {
+nonisolated struct Livekit_RegionSettings: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1925,7 +1925,7 @@ struct Livekit_RegionSettings: Sendable {
   init() {}
 }
 
-struct Livekit_RegionInfo: Sendable {
+nonisolated struct Livekit_RegionInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1941,7 +1941,7 @@ struct Livekit_RegionInfo: Sendable {
   init() {}
 }
 
-struct Livekit_SubscriptionResponse: Sendable {
+nonisolated struct Livekit_SubscriptionResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1955,7 +1955,7 @@ struct Livekit_SubscriptionResponse: Sendable {
   init() {}
 }
 
-struct Livekit_RequestResponse: Sendable {
+nonisolated struct Livekit_RequestResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2034,7 +2034,7 @@ struct Livekit_RequestResponse: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Request: Equatable, Sendable {
+  nonisolated enum OneOf_Request: Equatable, Sendable {
     case trickle(Livekit_TrickleRequest)
     case addTrack(Livekit_AddTrackRequest)
     case mute(Livekit_MuteTrackRequest)
@@ -2046,7 +2046,7 @@ struct Livekit_RequestResponse: Sendable {
 
   }
 
-  enum Reason: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum Reason: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case ok // = 0
     case notFound // = 1
@@ -2119,7 +2119,7 @@ struct Livekit_RequestResponse: Sendable {
   init() {}
 }
 
-struct Livekit_TrackSubscribed: Sendable {
+nonisolated struct Livekit_TrackSubscribed: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2131,7 +2131,7 @@ struct Livekit_TrackSubscribed: Sendable {
   init() {}
 }
 
-struct Livekit_ConnectionSettings: Sendable {
+nonisolated struct Livekit_ConnectionSettings: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2168,7 +2168,7 @@ struct Livekit_ConnectionSettings: Sendable {
   fileprivate var _autoSubscribeDataTrack: Bool? = nil
 }
 
-struct Livekit_JoinRequest: @unchecked Sendable {
+nonisolated struct Livekit_JoinRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2250,7 +2250,7 @@ struct Livekit_JoinRequest: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Livekit_WrappedJoinRequest: Sendable {
+nonisolated struct Livekit_WrappedJoinRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2262,7 +2262,7 @@ struct Livekit_WrappedJoinRequest: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum Compression: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum Compression: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case none // = 0
     case gzip // = 1
@@ -2299,7 +2299,7 @@ struct Livekit_WrappedJoinRequest: Sendable {
   init() {}
 }
 
-struct Livekit_MediaSectionsRequirement: Sendable {
+nonisolated struct Livekit_MediaSectionsRequirement: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2315,21 +2315,21 @@ struct Livekit_MediaSectionsRequirement: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "livekit"
+fileprivate nonisolated let _protobuf_package = "livekit"
 
-extension Livekit_SignalTarget: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SignalTarget: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0PUBLISHER\0\u{1}SUBSCRIBER\0")
 }
 
-extension Livekit_StreamState: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_StreamState: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0ACTIVE\0\u{1}PAUSED\0")
 }
 
-extension Livekit_CandidateProtocol: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_CandidateProtocol: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UDP\0\u{1}TCP\0\u{1}TLS\0")
 }
 
-extension Livekit_SignalRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SignalRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SignalRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}offer\0\u{1}answer\0\u{1}trickle\0\u{3}add_track\0\u{1}mute\0\u{1}subscription\0\u{3}track_setting\0\u{1}leave\0\u{4}\u{2}update_layers\0\u{3}subscription_permission\0\u{3}sync_state\0\u{1}simulate\0\u{1}ping\0\u{3}update_metadata\0\u{3}ping_req\0\u{3}update_audio_track\0\u{3}update_video_track\0\u{3}publish_data_track_request\0\u{3}unpublish_data_track_request\0\u{3}update_data_subscription\0")
 
@@ -2697,7 +2697,7 @@ extension Livekit_SignalRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   }
 }
 
-extension Livekit_SignalResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SignalResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SignalResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}join\0\u{1}answer\0\u{1}offer\0\u{1}trickle\0\u{1}update\0\u{3}track_published\0\u{2}\u{2}leave\0\u{1}mute\0\u{3}speakers_changed\0\u{3}room_update\0\u{3}connection_quality\0\u{3}stream_state_update\0\u{3}subscribed_quality_update\0\u{3}subscription_permission_update\0\u{3}refresh_token\0\u{3}track_unpublished\0\u{1}pong\0\u{1}reconnect\0\u{3}pong_resp\0\u{3}subscription_response\0\u{3}request_response\0\u{3}track_subscribed\0\u{3}room_moved\0\u{3}media_sections_requirement\0\u{3}subscribed_audio_codec_update\0\u{3}publish_data_track_response\0\u{3}unpublish_data_track_response\0\u{3}data_track_subscriber_handles\0")
 
@@ -3196,7 +3196,7 @@ extension Livekit_SignalResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Livekit_SimulcastCodec: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SimulcastCodec: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SimulcastCodec"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}codec\0\u{1}cid\0\u{2}\u{2}layers\0\u{3}video_layer_mode\0")
 
@@ -3241,7 +3241,7 @@ extension Livekit_SimulcastCodec: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Livekit_AddTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_AddTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".AddTrackRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}cid\0\u{1}name\0\u{1}type\0\u{1}width\0\u{1}height\0\u{1}muted\0\u{3}disable_dtx\0\u{1}source\0\u{1}layers\0\u{3}simulcast_codecs\0\u{1}sid\0\u{1}stereo\0\u{3}disable_red\0\u{1}encryption\0\u{1}stream\0\u{3}backup_codec_policy\0\u{3}audio_features\0\u{3}packet_trailer_features\0")
 
@@ -3426,7 +3426,7 @@ extension Livekit_AddTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Livekit_PublishDataTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_PublishDataTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PublishDataTrackRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}pub_handle\0\u{1}name\0\u{1}encryption\0")
 
@@ -3466,7 +3466,7 @@ extension Livekit_PublishDataTrackRequest: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Livekit_PublishDataTrackResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_PublishDataTrackResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PublishDataTrackResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}info\0")
 
@@ -3500,7 +3500,7 @@ extension Livekit_PublishDataTrackResponse: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Livekit_UnpublishDataTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_UnpublishDataTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnpublishDataTrackRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}pub_handle\0")
 
@@ -3530,7 +3530,7 @@ extension Livekit_UnpublishDataTrackRequest: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Livekit_UnpublishDataTrackResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_UnpublishDataTrackResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnpublishDataTrackResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}info\0")
 
@@ -3564,7 +3564,7 @@ extension Livekit_UnpublishDataTrackResponse: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Livekit_DataTrackSubscriberHandles: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataTrackSubscriberHandles: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DataTrackSubscriberHandles"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}sub_handles\0")
 
@@ -3594,7 +3594,7 @@ extension Livekit_DataTrackSubscriberHandles: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Livekit_DataTrackSubscriberHandles.PublishedDataTrack: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataTrackSubscriberHandles.PublishedDataTrack: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Livekit_DataTrackSubscriberHandles.protoMessageName + ".PublishedDataTrack"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}publisher_identity\0\u{3}publisher_sid\0\u{3}track_sid\0")
 
@@ -3634,7 +3634,7 @@ extension Livekit_DataTrackSubscriberHandles.PublishedDataTrack: SwiftProtobuf.M
   }
 }
 
-extension Livekit_TrickleRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_TrickleRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TrickleRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}candidateInit\0\u{1}target\0\u{1}final\0")
 
@@ -3674,7 +3674,7 @@ extension Livekit_TrickleRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Livekit_MuteTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_MuteTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MuteTrackRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sid\0\u{1}muted\0")
 
@@ -3709,7 +3709,7 @@ extension Livekit_MuteTrackRequest: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Livekit_JoinResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_JoinResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".JoinResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}room\0\u{1}participant\0\u{3}other_participants\0\u{3}server_version\0\u{3}ice_servers\0\u{3}subscriber_primary\0\u{3}alternative_url\0\u{3}client_configuration\0\u{3}server_region\0\u{3}ping_timeout\0\u{3}ping_interval\0\u{3}server_info\0\u{3}sif_trailer\0\u{3}enabled_publish_codecs\0\u{3}fast_publish\0")
 
@@ -3877,7 +3877,7 @@ extension Livekit_JoinResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 }
 
-extension Livekit_ReconnectResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ReconnectResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ReconnectResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}ice_servers\0\u{3}client_configuration\0\u{3}server_info\0\u{3}last_message_seq\0")
 
@@ -3926,7 +3926,7 @@ extension Livekit_ReconnectResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Livekit_TrackPublishedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_TrackPublishedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TrackPublishedResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}cid\0\u{1}track\0")
 
@@ -3965,7 +3965,7 @@ extension Livekit_TrackPublishedResponse: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Livekit_TrackUnpublishedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_TrackUnpublishedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TrackUnpublishedResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0")
 
@@ -3995,7 +3995,7 @@ extension Livekit_TrackUnpublishedResponse: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Livekit_SessionDescription: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SessionDescription: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SessionDescription"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}type\0\u{1}sdp\0\u{1}id\0\u{3}mid_to_track_id\0")
 
@@ -4040,7 +4040,7 @@ extension Livekit_SessionDescription: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Livekit_ParticipantUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ParticipantUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ParticipantUpdate"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}participants\0")
 
@@ -4070,7 +4070,7 @@ extension Livekit_ParticipantUpdate: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Livekit_UpdateSubscription: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_UpdateSubscription: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UpdateSubscription"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sids\0\u{1}subscribe\0\u{3}participant_tracks\0")
 
@@ -4110,7 +4110,7 @@ extension Livekit_UpdateSubscription: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Livekit_UpdateDataSubscription: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_UpdateDataSubscription: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UpdateDataSubscription"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}updates\0")
 
@@ -4140,7 +4140,7 @@ extension Livekit_UpdateDataSubscription: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Livekit_UpdateDataSubscription.Update: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_UpdateDataSubscription.Update: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Livekit_UpdateDataSubscription.protoMessageName + ".Update"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0\u{1}subscribe\0\u{1}options\0")
 
@@ -4184,7 +4184,7 @@ extension Livekit_UpdateDataSubscription.Update: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Livekit_UpdateTrackSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_UpdateTrackSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UpdateTrackSettings"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sids\0\u{2}\u{2}disabled\0\u{1}quality\0\u{1}width\0\u{1}height\0\u{1}fps\0\u{1}priority\0")
 
@@ -4244,7 +4244,7 @@ extension Livekit_UpdateTrackSettings: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Livekit_UpdateLocalAudioTrack: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_UpdateLocalAudioTrack: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UpdateLocalAudioTrack"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0\u{1}features\0")
 
@@ -4279,7 +4279,7 @@ extension Livekit_UpdateLocalAudioTrack: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Livekit_UpdateLocalVideoTrack: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_UpdateLocalVideoTrack: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UpdateLocalVideoTrack"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0\u{1}width\0\u{1}height\0")
 
@@ -4319,7 +4319,7 @@ extension Livekit_UpdateLocalVideoTrack: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Livekit_LeaveRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_LeaveRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".LeaveRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}can_reconnect\0\u{1}reason\0\u{1}action\0\u{1}regions\0")
 
@@ -4368,11 +4368,11 @@ extension Livekit_LeaveRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 }
 
-extension Livekit_LeaveRequest.Action: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_LeaveRequest.Action: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0DISCONNECT\0\u{1}RESUME\0\u{1}RECONNECT\0")
 }
 
-extension Livekit_UpdateVideoLayers: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_UpdateVideoLayers: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UpdateVideoLayers"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0\u{1}layers\0")
 
@@ -4407,7 +4407,7 @@ extension Livekit_UpdateVideoLayers: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Livekit_UpdateParticipantMetadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_UpdateParticipantMetadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UpdateParticipantMetadata"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}metadata\0\u{1}name\0\u{1}attributes\0\u{3}request_id\0")
 
@@ -4452,7 +4452,7 @@ extension Livekit_UpdateParticipantMetadata: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Livekit_ICEServer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ICEServer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ICEServer"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}urls\0\u{1}username\0\u{1}credential\0")
 
@@ -4492,7 +4492,7 @@ extension Livekit_ICEServer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
   }
 }
 
-extension Livekit_SpeakersChanged: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SpeakersChanged: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SpeakersChanged"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}speakers\0")
 
@@ -4522,7 +4522,7 @@ extension Livekit_SpeakersChanged: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Livekit_RoomUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_RoomUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RoomUpdate"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}room\0")
 
@@ -4556,7 +4556,7 @@ extension Livekit_RoomUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Livekit_ConnectionQualityInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ConnectionQualityInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConnectionQualityInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}participant_sid\0\u{1}quality\0\u{1}score\0")
 
@@ -4596,7 +4596,7 @@ extension Livekit_ConnectionQualityInfo: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Livekit_ConnectionQualityUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ConnectionQualityUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConnectionQualityUpdate"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}updates\0")
 
@@ -4626,7 +4626,7 @@ extension Livekit_ConnectionQualityUpdate: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Livekit_StreamStateInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_StreamStateInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamStateInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}participant_sid\0\u{3}track_sid\0\u{1}state\0")
 
@@ -4666,7 +4666,7 @@ extension Livekit_StreamStateInfo: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Livekit_StreamStateUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_StreamStateUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamStateUpdate"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}stream_states\0")
 
@@ -4696,7 +4696,7 @@ extension Livekit_StreamStateUpdate: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Livekit_SubscribedQuality: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SubscribedQuality: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubscribedQuality"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}quality\0\u{1}enabled\0")
 
@@ -4731,7 +4731,7 @@ extension Livekit_SubscribedQuality: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Livekit_SubscribedCodec: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SubscribedCodec: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubscribedCodec"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}codec\0\u{1}qualities\0")
 
@@ -4766,7 +4766,7 @@ extension Livekit_SubscribedCodec: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Livekit_SubscribedQualityUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SubscribedQualityUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubscribedQualityUpdate"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0\u{3}subscribed_qualities\0\u{3}subscribed_codecs\0")
 
@@ -4806,7 +4806,7 @@ extension Livekit_SubscribedQualityUpdate: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Livekit_SubscribedAudioCodecUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SubscribedAudioCodecUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubscribedAudioCodecUpdate"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0\u{3}subscribed_audio_codecs\0")
 
@@ -4841,7 +4841,7 @@ extension Livekit_SubscribedAudioCodecUpdate: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Livekit_TrackPermission: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_TrackPermission: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TrackPermission"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}participant_sid\0\u{3}all_tracks\0\u{3}track_sids\0\u{3}participant_identity\0")
 
@@ -4886,7 +4886,7 @@ extension Livekit_TrackPermission: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Livekit_SubscriptionPermission: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SubscriptionPermission: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubscriptionPermission"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}all_participants\0\u{3}track_permissions\0")
 
@@ -4921,7 +4921,7 @@ extension Livekit_SubscriptionPermission: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Livekit_SubscriptionPermissionUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SubscriptionPermissionUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubscriptionPermissionUpdate"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}participant_sid\0\u{3}track_sid\0\u{1}allowed\0")
 
@@ -4961,7 +4961,7 @@ extension Livekit_SubscriptionPermissionUpdate: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Livekit_RoomMovedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_RoomMovedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RoomMovedResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}room\0\u{1}token\0\u{1}participant\0\u{3}other_participants\0")
 
@@ -5052,7 +5052,7 @@ extension Livekit_RoomMovedResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Livekit_SyncState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SyncState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SyncState"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}answer\0\u{1}subscription\0\u{3}publish_tracks\0\u{3}data_channels\0\u{1}offer\0\u{3}track_sids_disabled\0\u{3}datachannel_receive_states\0\u{3}publish_data_tracks\0")
 
@@ -5121,7 +5121,7 @@ extension Livekit_SyncState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
   }
 }
 
-extension Livekit_DataChannelReceiveState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataChannelReceiveState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DataChannelReceiveState"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}publisher_sid\0\u{3}last_seq\0")
 
@@ -5156,7 +5156,7 @@ extension Livekit_DataChannelReceiveState: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Livekit_DataChannelInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_DataChannelInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DataChannelInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}label\0\u{1}id\0\u{1}target\0")
 
@@ -5196,7 +5196,7 @@ extension Livekit_DataChannelInfo: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Livekit_SimulateScenario: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SimulateScenario: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SimulateScenario"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}speaker_update\0\u{3}node_failure\0\u{1}migration\0\u{3}server_leave\0\u{3}switch_candidate_protocol\0\u{3}subscriber_bandwidth\0\u{3}disconnect_signal_on_resume\0\u{3}disconnect_signal_on_resume_no_messages\0\u{3}leave_request_full_reconnect\0")
 
@@ -5337,7 +5337,7 @@ extension Livekit_SimulateScenario: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Livekit_Ping: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_Ping: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Ping"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}timestamp\0\u{1}rtt\0")
 
@@ -5372,7 +5372,7 @@ extension Livekit_Ping: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
   }
 }
 
-extension Livekit_Pong: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_Pong: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Pong"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}last_ping_timestamp\0\u{1}timestamp\0")
 
@@ -5407,7 +5407,7 @@ extension Livekit_Pong: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
   }
 }
 
-extension Livekit_RegionSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_RegionSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RegionSettings"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}regions\0")
 
@@ -5437,7 +5437,7 @@ extension Livekit_RegionSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Livekit_RegionInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_RegionInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RegionInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}region\0\u{1}url\0\u{1}distance\0")
 
@@ -5477,7 +5477,7 @@ extension Livekit_RegionInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Livekit_SubscriptionResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_SubscriptionResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubscriptionResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0\u{1}err\0")
 
@@ -5512,7 +5512,7 @@ extension Livekit_SubscriptionResponse: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Livekit_RequestResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_RequestResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RequestResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}request_id\0\u{1}reason\0\u{1}message\0\u{1}trickle\0\u{3}add_track\0\u{1}mute\0\u{3}update_metadata\0\u{3}update_audio_track\0\u{3}update_video_track\0\u{3}publish_data_track\0\u{3}unpublish_data_track\0")
 
@@ -5696,11 +5696,11 @@ extension Livekit_RequestResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Livekit_RequestResponse.Reason: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_RequestResponse.Reason: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OK\0\u{1}NOT_FOUND\0\u{1}NOT_ALLOWED\0\u{1}LIMIT_EXCEEDED\0\u{1}QUEUED\0\u{1}UNSUPPORTED_TYPE\0\u{1}UNCLASSIFIED_ERROR\0\u{1}INVALID_HANDLE\0\u{1}INVALID_NAME\0\u{1}DUPLICATE_HANDLE\0\u{1}DUPLICATE_NAME\0")
 }
 
-extension Livekit_TrackSubscribed: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_TrackSubscribed: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TrackSubscribed"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}track_sid\0")
 
@@ -5730,7 +5730,7 @@ extension Livekit_TrackSubscribed: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Livekit_ConnectionSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_ConnectionSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConnectionSettings"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}auto_subscribe\0\u{3}adaptive_stream\0\u{3}subscriber_allow_pause\0\u{3}disable_ice_lite\0\u{3}auto_subscribe_data_track\0")
 
@@ -5784,7 +5784,7 @@ extension Livekit_ConnectionSettings: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Livekit_JoinRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_JoinRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".JoinRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}client_info\0\u{3}connection_settings\0\u{1}metadata\0\u{3}participant_attributes\0\u{3}add_track_requests\0\u{3}publisher_offer\0\u{1}reconnect\0\u{3}reconnect_reason\0\u{3}participant_sid\0\u{3}sync_state\0")
 
@@ -5917,7 +5917,7 @@ extension Livekit_JoinRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
   }
 }
 
-extension Livekit_WrappedJoinRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_WrappedJoinRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WrappedJoinRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}compression\0\u{3}join_request\0")
 
@@ -5952,11 +5952,11 @@ extension Livekit_WrappedJoinRequest: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Livekit_WrappedJoinRequest.Compression: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_WrappedJoinRequest.Compression: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0NONE\0\u{1}GZIP\0")
 }
 
-extension Livekit_MediaSectionsRequirement: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Livekit_MediaSectionsRequirement: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MediaSectionsRequirement"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}num_audios\0\u{3}num_videos\0")
 

--- a/Tests/LiveKitCoreTests/CompleterTests.swift
+++ b/Tests/LiveKitCoreTests/CompleterTests.swift
@@ -144,23 +144,6 @@ struct CompleterTests {
     }
 }
 
-private func waitForRegistration(of completer: AsyncCompleter<some Any>) async {
-    while completer.waiterCount == 0 {
-        await Task.yield()
-    }
-}
-
-private func expectLiveKitError(_ expected: LiveKitErrorType, from task: Task<some Sendable, Error>) async {
-    do {
-        _ = try await task.value
-        Issue.record("Expected LiveKitError(.\(expected)) to be thrown")
-    } catch let error as LiveKitError {
-        #expect(error.type == expected)
-    } catch {
-        Issue.record("Expected LiveKitError, got \(error)")
-    }
-}
-
 @Suite(.tags(.concurrency))
 struct CompleterMapActorTests {
     @Test func resetThrowingFanOutsTypedErrorToAllCompleters() async {

--- a/Tests/LiveKitCoreTests/DataChannel/DataChannelPairTests.swift
+++ b/Tests/LiveKitCoreTests/DataChannel/DataChannelPairTests.swift
@@ -71,20 +71,3 @@ struct DataChannelPairTests {
         await expectLiveKitError(.cancelled, from: waitTask)
     }
 }
-
-private func waitForRegistration(of completer: AsyncCompleter<some Any>) async {
-    while completer.waiterCount == 0 {
-        await Task.yield()
-    }
-}
-
-private func expectLiveKitError(_ expected: LiveKitErrorType, from task: Task<some Sendable, Error>) async {
-    do {
-        _ = try await task.value
-        Issue.record("Expected LiveKitError(.\(expected)) to be thrown")
-    } catch let error as LiveKitError {
-        #expect(error.type == expected)
-    } catch {
-        Issue.record("Expected LiveKitError, got \(error)")
-    }
-}

--- a/Tests/LiveKitCoreTests/DataChannel/DataChannelPairTests.swift
+++ b/Tests/LiveKitCoreTests/DataChannel/DataChannelPairTests.swift
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+@testable import LiveKit
+import Testing
+
+/// Unit-level coverage for the parts of `DataChannelPair` that don't need a
+/// real `LKRTCDataChannel`: the pre-flight `openCompleter` semantics and the
+/// `.drain` path that fails parked sends after `reset(throwing:)`. Anything
+/// that needs real `sendData` dispatch or `bufferedAmount` drains is exercised
+/// by `RealiableDataChannelTests` / `EncryptedDataChannelTests` end-to-end.
+@Suite(.tags(.dataChannel))
+struct DataChannelPairTests {
+    @Test func openCompleterTimesOutWhenChannelsNeverArrive() async {
+        let pair = DataChannelPair()
+        do {
+            try await pair.openCompleter.wait(timeout: 0.1)
+            Issue.record("Expected openCompleter to time out")
+        } catch let error as LiveKitError {
+            #expect(error.type == .timedOut)
+        } catch {
+            Issue.record("Expected LiveKitError, got \(error)")
+        }
+    }
+
+    @Test func resetFailsParkedSendsWithProvidedError() async throws {
+        let pair = DataChannelPair()
+
+        // No channels are set, so the send enqueues and parks.
+        let sendTask = Task {
+            try await pair.send(userPacket: Livekit_UserPacket(), kind: .reliable)
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        pair.reset(throwing: LiveKitError(.invalidState, message: "custom"))
+        await expectLiveKitError(.invalidState, from: sendTask)
+    }
+
+    @Test func resetWithNilErrorFailsParkedSendsAsCancelled() async throws {
+        let pair = DataChannelPair()
+
+        let sendTask = Task {
+            try await pair.send(userPacket: Livekit_UserPacket(), kind: .reliable)
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        pair.reset(throwing: nil)
+        await expectLiveKitError(.cancelled, from: sendTask)
+    }
+
+    @Test func openCompleterWaitHonorsTaskCancellation() async {
+        let pair = DataChannelPair()
+        let waitTask = Task { try await pair.openCompleter.wait() }
+        await waitForRegistration(of: pair.openCompleter)
+
+        waitTask.cancel()
+        await expectLiveKitError(.cancelled, from: waitTask)
+    }
+}
+
+private func waitForRegistration(of completer: AsyncCompleter<some Any>) async {
+    while completer.waiterCount == 0 {
+        await Task.yield()
+    }
+}
+
+private func expectLiveKitError(_ expected: LiveKitErrorType, from task: Task<some Sendable, Error>) async {
+    do {
+        _ = try await task.value
+        Issue.record("Expected LiveKitError(.\(expected)) to be thrown")
+    } catch let error as LiveKitError {
+        #expect(error.type == expected)
+    } catch {
+        Issue.record("Expected LiveKitError, got \(error)")
+    }
+}

--- a/Tests/LiveKitCoreTests/DataChannel/RealiableDataChannelTests.swift
+++ b/Tests/LiveKitCoreTests/DataChannel/RealiableDataChannelTests.swift
@@ -22,18 +22,38 @@ import LiveKitTestSupport
 #endif
 
 @Suite(.serialized, .tags(.dataChannel, .e2e)) final class RealiableDataChannelTests: @unchecked Sendable {
-    private let _receivedData = StateSync(Data())
-    private let _receivedCount = StateSync(0)
+    enum ReconnectMode: CustomStringConvertible {
+        case none, sender, receiver, both
+
+        var description: String {
+            switch self {
+            case .none: "no reconnect"
+            case .sender: "sender reconnect"
+            case .receiver: "receiver reconnect"
+            case .both: "dual reconnect"
+            }
+        }
+
+        var reconnectsSender: Bool { self == .sender || self == .both }
+        var reconnectsReceiver: Bool { self == .receiver || self == .both }
+    }
+
+    private let _receivedIndices = StateSync<[UInt32]>([])
     var onDataReceived: (() -> Void)?
 
-    @Test func reliableRetry() async throws {
+    @Test(arguments: [ReconnectMode.none, .sender, .receiver, .both])
+    func reliableDelivery(mode: ReconnectMode) async throws {
         let iterations = 128
+        let sendInterval: TimeInterval = 0.05
+        let senderReconnectDelay: TimeInterval = 0.2
+        let receiverReconnectDelay: TimeInterval = 0.4
+        let receiveDeadline: TimeInterval = 10
 
-        let testString = "abcdefghijklmnopqrstuvwxyz🔥"
-        let testData = try #require(String(repeating: testString, count: 1024).data(using: .utf8))
+        let bodyString = "abcdefghijklmnopqrstuvwxyz🔥"
+        let bodyData = try #require(String(repeating: bodyString, count: 1024).data(using: .utf8))
 
         try await confirmation("Data received", expectedCount: iterations) { confirm in
-            self._receivedData.mutate { $0 = Data() }
+            self._receivedIndices.mutate { $0 = [] }
             self.onDataReceived = { confirm() }
 
             try await TestEnvironment.withRooms([
@@ -44,46 +64,58 @@ import LiveKitTestSupport
                 let receiving = rooms[1]
                 let remoteIdentity = try #require(sending.remoteParticipants.keys.first)
 
-                let reconnectSender = Task {
-                    try await Task.sleep(nanoseconds: 200_000_000) // 200 ms
-                    try await sending.startReconnect(reason: .debug)
-                }.cancellable()
-                let reconnectReceiver = Task {
-                    try await Task.sleep(nanoseconds: 400_000_000) // 400 ms
-                    try await receiving.startReconnect(reason: .debug)
-                }.cancellable()
-                defer {
-                    reconnectSender.cancel()
-                    reconnectReceiver.cancel()
+                var reconnectTasks: [AnyTaskCancellable] = []
+                if mode.reconnectsSender {
+                    reconnectTasks.append(Task {
+                        try await Task.sleep(nanoseconds: UInt64(senderReconnectDelay * 1_000_000_000))
+                        try await sending.startReconnect(reason: .debug)
+                    }.cancellable())
                 }
+                if mode.reconnectsReceiver {
+                    reconnectTasks.append(Task {
+                        try await Task.sleep(nanoseconds: UInt64(receiverReconnectDelay * 1_000_000_000))
+                        try await receiving.startReconnect(reason: .debug)
+                    }.cancellable())
+                }
+                defer { reconnectTasks.forEach { $0.cancel() } }
 
-                for _ in 0 ..< iterations {
+                for i in 0 ..< iterations {
+                    // 4-byte LE sequence prefix lets the receiver assert
+                    // exact ordering — a size-only check would pass even
+                    // if packets arrived reordered or with dupes.
+                    var seq = UInt32(i)
+                    let packetData = Data(bytes: &seq, count: 4) + bodyData
                     let userPacket = Livekit_UserPacket.with {
-                        $0.payload = testData
+                        $0.payload = packetData
                         $0.destinationIdentities = [remoteIdentity.stringValue]
                     }
 
                     try await sending.send(userPacket: userPacket, kind: .reliable)
-                    try await Task.sleep(nanoseconds: 50_000_000) // 50 ms
+                    try await Task.sleep(nanoseconds: UInt64(sendInterval * 1_000_000_000))
                 }
             }
 
-            // Wait for all packets to arrive (poll instead of fixed sleep)
-            let deadline = Date().addingTimeInterval(10)
-            while Date() < deadline, self._receivedCount.copy() < iterations {
+            // `withRooms` tears the rooms down once its body returns, but
+            // the last few deliveries may still be in flight. Poll until
+            // all confirms have fired (or the deadline expires) so we
+            // don't end the confirmation body prematurely.
+            let deadline = Date().addingTimeInterval(receiveDeadline)
+            while Date() < deadline, self._receivedIndices.copy().count < iterations {
                 try? await Task.sleep(nanoseconds: 100_000_000)
             }
         }
 
-        let receivedString = try #require(String(data: _receivedData.copy(), encoding: .utf8))
-        #expect(receivedString.count == testString.count * 1024 * iterations, "Corrupted or duplicated data")
+        let received = _receivedIndices.copy()
+        #expect(received == Array(0 ..< UInt32(iterations)),
+                "Reliable delivery should be exact and in send order, with no dupes or drops")
     }
 }
 
 extension RealiableDataChannelTests: RoomDelegate {
     func room(_: Room, participant _: RemoteParticipant?, didReceiveData data: Data, forTopic _: String, encryptionType _: EncryptionType) {
-        _receivedData.mutate { $0.append(data) }
-        _receivedCount.mutate { $0 += 1 }
+        guard data.count >= 4 else { return }
+        let seq = data.prefix(4).withUnsafeBytes { $0.load(as: UInt32.self) }
+        _receivedIndices.mutate { $0.append(seq) }
         onDataReceived?()
     }
 }

--- a/Tests/LiveKitCoreTests/DataChannel/RealiableDataChannelTests.swift
+++ b/Tests/LiveKitCoreTests/DataChannel/RealiableDataChannelTests.swift
@@ -23,7 +23,7 @@ import LiveKitTestSupport
 
 @Suite(.serialized, .tags(.dataChannel, .e2e)) final class RealiableDataChannelTests: @unchecked Sendable {
     enum ReconnectMode: CustomStringConvertible {
-        case none, sender, receiver, both
+        case none, sender, receiver, both, simultaneous, bothLate
 
         var description: String {
             switch self {
@@ -31,23 +31,45 @@ import LiveKitTestSupport
             case .sender: "sender reconnect"
             case .receiver: "receiver reconnect"
             case .both: "dual reconnect"
+            case .simultaneous: "simultaneous reconnect"
+            case .bothLate: "dual reconnect (late)"
             }
         }
 
-        var reconnectsSender: Bool { self == .sender || self == .both }
-        var reconnectsReceiver: Bool { self == .receiver || self == .both }
+        /// When (if at all) the sender room should call `startReconnect`.
+        /// `nil` means no sender reconnect for this mode.
+        var senderReconnectDelay: TimeInterval? {
+            switch self {
+            case .none, .receiver: nil
+            case .sender, .both: 0.2
+            case .simultaneous: 0.3
+            // Mid-burst: 2s is ~40 sends in, so the retry buffer has a
+            // non-trivial replay set vs. early reconnects that only
+            // have to replay 4–8 entries.
+            case .bothLate: 2.0
+            }
+        }
+
+        var receiverReconnectDelay: TimeInterval? {
+            switch self {
+            case .none, .sender: nil
+            case .receiver, .both: 0.4
+            case .simultaneous: 0.3
+            case .bothLate: 3.0
+            }
+        }
     }
 
     private let _receivedIndices = StateSync<[UInt32]>([])
     var onDataReceived: (() -> Void)?
 
-    @Test(arguments: [ReconnectMode.none, .sender, .receiver, .both])
+    @Test(arguments: [ReconnectMode.none, .sender, .receiver, .both, .simultaneous, .bothLate])
     func reliableDelivery(mode: ReconnectMode) async throws {
         let iterations = 128
         let sendInterval: TimeInterval = 0.05
-        let senderReconnectDelay: TimeInterval = 0.2
-        let receiverReconnectDelay: TimeInterval = 0.4
-        let receiveDeadline: TimeInterval = 10
+        // 15s tolerates the .bothLate case, where the receiver reconnect
+        // doesn't kick in until 3s and replay then has to drain.
+        let receiveDeadline: TimeInterval = 15
 
         let bodyString = "abcdefghijklmnopqrstuvwxyz🔥"
         let bodyData = try #require(String(repeating: bodyString, count: 1024).data(using: .utf8))
@@ -65,15 +87,15 @@ import LiveKitTestSupport
                 let remoteIdentity = try #require(sending.remoteParticipants.keys.first)
 
                 var reconnectTasks: [AnyTaskCancellable] = []
-                if mode.reconnectsSender {
+                if let delay = mode.senderReconnectDelay {
                     reconnectTasks.append(Task {
-                        try await Task.sleep(nanoseconds: UInt64(senderReconnectDelay * 1_000_000_000))
+                        try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
                         try await sending.startReconnect(reason: .debug)
                     }.cancellable())
                 }
-                if mode.reconnectsReceiver {
+                if let delay = mode.receiverReconnectDelay {
                     reconnectTasks.append(Task {
-                        try await Task.sleep(nanoseconds: UInt64(receiverReconnectDelay * 1_000_000_000))
+                        try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
                         try await receiving.startReconnect(reason: .debug)
                     }.cancellable())
                 }

--- a/Tests/LiveKitCoreTests/TestHelpers.swift
+++ b/Tests/LiveKitCoreTests/TestHelpers.swift
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+import Testing
+
+/// Awaits `task` and asserts it threw a `LiveKitError` with the expected
+/// `type`. Records a test issue if it succeeded or threw a different error.
+///
+/// The `sourceLocation` default forwards the caller's location so failures
+/// point at the test, not this helper.
+func expectLiveKitError(
+    _ expected: LiveKitErrorType,
+    from task: Task<some Sendable, Error>,
+    sourceLocation: SourceLocation = #_sourceLocation
+) async {
+    do {
+        _ = try await task.value
+        Issue.record("Expected LiveKitError(.\(expected)) to be thrown", sourceLocation: sourceLocation)
+    } catch let error as LiveKitError {
+        #expect(error.type == expected, sourceLocation: sourceLocation)
+    } catch {
+        Issue.record("Expected LiveKitError, got \(error)", sourceLocation: sourceLocation)
+    }
+}
+
+/// Yields until `completer` reports at least one registered waiter — used
+/// when a Task awaits on a completer and the test needs to act only after
+/// the wait has parked.
+func waitForRegistration(of completer: AsyncCompleter<some Any>) async {
+    while completer.waiterCount == 0 {
+        await Task.yield()
+    }
+}


### PR DESCRIPTION
Follow-up to #977. No public API change.

- Fix three concurrency bugs: `TTLDictionary` iterated outside its lock; check-then-mutate dedup race; `rtcAmount` over-counted on `sendData` failure
- Fold `e2eeManager` under `_state`'s lock behind `set(e2eeManager:)`
- Run publisher transport + DC pre-flight waits concurrently via `async let`
- Align DC-open timeout with client-sdk-js / -rust (7s → 15s)
- Document and rename `ChannelEvent` state-machine cases (`sendRequested` / `sendDispatched`)
- Tidy a few rough edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)