### PR TITLE
Fix SIGBUS in camera capturer on macOS 26

### DIFF
--- a/.changes/macos-26-camera-crash
+++ b/.changes/macos-26-camera-crash
@@ -1,1 +1,1 @@
-patch type="fixed" "Crash when starting the camera on macOS 26 due to the auto-bridged LKRTCCameraVideoCapturer completion handler"
+patch type="fixed" "Crash when starting the camera or microphone on macOS 26 due to the auto-bridged ObjC completion handler"

--- a/.changes/macos-26-camera-crash
+++ b/.changes/macos-26-camera-crash
@@ -1,0 +1,1 @@
+patch type="fixed" "Crash when starting the camera on macOS 26 due to the auto-bridged LKRTCCameraVideoCapturer completion handler"

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -317,7 +317,9 @@ extension LocalParticipant {
 // MARK: - Simplified API
 
 public extension LocalParticipant {
-    @objc
+    // @nonobjc on these async methods: the @objcMembers-synthesized completion
+    // handler bridge SIGBUSes on macOS 26 (see #1022).
+    @nonobjc
     @discardableResult
     func setCamera(enabled: Bool,
                    captureOptions: CameraCaptureOptions? = nil,
@@ -329,7 +331,7 @@ public extension LocalParticipant {
                       publishOptions: publishOptions)
     }
 
-    @objc
+    @nonobjc
     @discardableResult
     func setMicrophone(enabled: Bool,
                        captureOptions: AudioCaptureOptions? = nil,
@@ -350,13 +352,13 @@ public extension LocalParticipant {
     /// to capture other screens and windows. See ``MacOSScreenCapturer`` for details.
     ///
     /// For advanced usage, you can create a relevant ``LocalVideoTrack`` and call ``LocalParticipant/publishVideoTrack(track:publishOptions:)``.
-    @objc
+    @nonobjc
     @discardableResult
     func setScreenShare(enabled: Bool) async throws -> LocalTrackPublication? {
         try await set(source: .screenShareVideo, enabled: enabled)
     }
 
-    @objc
+    @nonobjc
     @discardableResult
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     func set(source: Track.Source,

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -285,7 +285,17 @@ public class CameraCapturer: VideoCapturer, @unchecked Sendable {
 
         log("starting camera capturer device: \(device), format: \(selectedFormat), fps: \(selectedFps)(\(fpsRange))", .info)
 
-        try await capturer.startCapture(with: device, format: selectedFormat.format, fps: selectedFps)
+        // Call the completion-handler form directly: the compiler-synthesized
+        // async overload SIGBUSes on macOS 26 (see #1016).
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            capturer.startCapture(with: device, format: selectedFormat.format, fps: selectedFps) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
 
         // Update internal vars
         _cameraCapturerState.mutate {
@@ -305,7 +315,12 @@ public class CameraCapturer: VideoCapturer, @unchecked Sendable {
         // Already stopped
         guard didStop else { return false }
 
-        await capturer.stopCapture()
+        // See note in `startCapture()` above.
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            capturer.stopCapture {
+                continuation.resume()
+            }
+        }
 
         // Update internal vars
         set(dimensions: nil)


### PR DESCRIPTION
On macOS 26, two crash sites in the Swift ↔ ObjC completion-handler bridge hit `EXC_BAD_ACCESS` on continuation resume:
- **Camera ([#1016](https://github.com/livekit/client-sdk-swift/issues/1016))** — the compiler-synthesized `async` overload of `LKRTCCameraVideoCapturer`'s `start`/`stopCapture` crashes; fixed by calling the completion-handler form directly through `withCheckedContinuation`.
- **Mic / `set(source:enabled:)` ([#1022](https://github.com/livekit/client-sdk-swift/issues/1022))** — the `@objcMembers`-synthesized completion-handler bridge on `LocalParticipant.set*` crashes; fixed by marking the affected `async` methods `@nonobjc` (same pattern documented on `Room.cleanUp`).

Closes #1016, #1022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)