### PR TITLE
Audio Session Defaults

### DIFF
--- a/.changes/audio-session-defaults
+++ b/.changes/audio-session-defaults
@@ -1,0 +1,1 @@
+patch type="fixed" "iOS audio session: refined `.playAndRecord` selection; dropped `.mixWithOthers` and `.allowAirPlay`"

--- a/.changes/audio-session-defaults
+++ b/.changes/audio-session-defaults
@@ -1,0 +1,1 @@
+minor type="changed" "iOS audio session: `.playAndRecord` is now kept until the audio engine stops, so muting the microphone no longer resets the category and disables Apple's echo cancellation mid-call; `.mixWithOthers` is no longer set on `.playAndRecord`, so publishing the microphone interrupts other apps' audio for the rest of the call (it remains set on `.playback`)"

--- a/Docs/audio.md
+++ b/Docs/audio.md
@@ -48,14 +48,12 @@ When set to `false`, the audio session remains active after the LiveKit call end
 
 ## Audio session category selection
 
-When `isAutomaticConfigurationEnabled` is `true`, the SDK picks the audio session category from the participant's role:
+When `isAutomaticConfigurationEnabled` is `true`, the SDK picks the audio session category based on whether the local participant is — or might be — publishing audio:
 
-- **Listener** (subscribes to remote audio, never publishes a mic):
+- **Audience** (server-issued `canPublish: false`, and the app has not enabled `isRecordingAlwaysPreparedMode`):
   `.playback` for the entire session. The iOS volume rocker stays on the media register and no microphone permission prompt is required.
-- **Publisher** (mic enabled at any point during the session):
-  `.playAndRecord` from the first publish onward. Once engaged, the category stays `.playAndRecord` even when the mic is muted — the category doesn't churn on every mute toggle.
-- **Audience-only by token** (server-issued `canPublish: false`):
-  treated as listener for the whole session; never upgrades to `.playAndRecord` even if the app calls `setRecordingAlwaysPreparedMode`.
+- **Publisher** (server-issued mic-publish permission, the app enabled `isRecordingAlwaysPreparedMode`, or the mic has been enabled at any point during the session):
+  `.playAndRecord` from then on. Once engaged, the category stays `.playAndRecord` even when the mic is muted — the category doesn't churn on every mute toggle.
 
 The category is reset to `.ambient` when both playout and recording stop (typically after `Room.disconnect()`).
 

--- a/Docs/audio.md
+++ b/Docs/audio.md
@@ -36,7 +36,7 @@ changing it while the engine is in use.
 > Note: If `isAutomaticConfigurationEnabled` is `false`, the SDK does not touch the audio
 > session, so this setting has no effect.
 
-By default, the SDK deactivates the `AVAudioSession` when both playout and recording are disabled (e.g., after disconnecting from a room). This allows other apps' audio (like Music) to resume.
+By default, the SDK deactivates the `AVAudioSession` when both playout and recording are disabled (e.g., after disconnecting from a room). Before deactivating, the category is reset to `.ambient` so the iOS volume rocker returns to the media register, and other apps' audio (like Music) can resume.
 
 However, if your app has its own audio features that could be disrupted by deactivating the audio session, you can disable automatic deactivation:
 
@@ -45,6 +45,19 @@ AudioManager.shared.audioSession.isAutomaticDeactivationEnabled = false
 ```
 
 When set to `false`, the audio session remains active after the LiveKit call ends, preserving your app's audio state.
+
+## Audio session category selection
+
+When `isAutomaticConfigurationEnabled` is `true`, the SDK picks the audio session category from the participant's role:
+
+- **Listener** (subscribes to remote audio, never publishes a mic):
+  `.playback` for the entire session. The iOS volume rocker stays on the media register and no microphone permission prompt is required.
+- **Publisher** (mic enabled at any point during the session):
+  `.playAndRecord` from the first publish onward. Once engaged, the category stays `.playAndRecord` even when the mic is muted — the category doesn't churn on every mute toggle.
+- **Audience-only by token** (server-issued `canPublish: false`):
+  treated as listener for the whole session; never upgrades to `.playAndRecord` even if the app calls `setRecordingAlwaysPreparedMode`.
+
+The category is reset to `.ambient` when both playout and recording stop (typically after `Room.disconnect()`).
 
 ## Disabling Voice Processing
 

--- a/Docs/audio.md
+++ b/Docs/audio.md
@@ -46,6 +46,21 @@ AudioManager.shared.audioSession.isAutomaticDeactivationEnabled = false
 
 When set to `false`, the audio session remains active after the LiveKit call ends, preserving your app's audio state.
 
+## Audio session category selection
+
+When `isAutomaticConfigurationEnabled` is `true`, the SDK derives the category from the audio engine:
+
+- **Playout only** (subscribing to remote audio, nothing recording): `.playback`. The volume buttons stay on the media register.
+- **Recording active**: `.playAndRecord`, and it stays there until the audio engine stops.
+
+`.playAndRecord` is sticky on purpose. Changing the category mid-session tears down Apple's Voice Processing I/O, which would leave echo cancellation off for the remainder of the call, so muting the microphone does not fall back to `.playback`. The category returns to `.playback` once the audio engine stops — typically at `Room.disconnect()` — and the next session starts fresh. Session requirements held outside the engine (a prepared `SoundPlayer` sound, for example) keep the session active but do not keep `.playAndRecord` selected.
+
+Recording is considered active whenever anything needs microphone input — a published microphone track, `AudioManager.setRecordingAlwaysPreparedMode(_:)`, `AudioManager.startLocalRecording(audioProcessingOptions:)`, or an externally acquired session requirement that includes `.recording`.
+
+> Note: iOS asks for microphone permission when a `.playAndRecord` session is activated. Apps that only ever subscribe should avoid the APIs above so the session stays on `.playback`.
+
+Because the categories differ in whether they mix with other apps, publishing the microphone interrupts audio from other apps (`.playAndRecord` does not set `.mixWithOthers`), and muting does not bring it back — the interruption lasts until the audio engine stops.
+
 ## Audio Processing Modes (software, platform, automatic)
 
 Each audio processing effect has its own mode type: `EchoCancellationMode`, `NoiseSuppressionMode`, `AutoGainControlMode`, and `HighpassFilterMode`. Echo cancellation, noise suppression, and auto gain control can use Apple's platform Voice Processing I/O or WebRTC's software processing:

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -246,12 +246,11 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
     /// will be publishing; otherwise `.playback` (pure listener):
     ///   - `isRecordingEnabled`: a track or external acquirer needs recording now.
     ///   - `hasRecorded`: sticky — keeps `.playAndRecord` across mute toggles.
-    ///   - `wantsToPublish`: the app declared publishing intent via
-    ///     `isRecordingAlwaysPreparedMode` AND the participant has permission
-    ///     to publish a microphone (`canPublishMicrophone`).
+    ///   - `wantsToPublish`: either signal of publishing intent —
+    ///     server-issued mic permission (`canPublishMicrophone`) or the
+    ///     app-declared `isRecordingAlwaysPreparedMode`.
     private func selectConfiguration(state: State) -> AudioSessionConfiguration {
-        // Purely permission-driven for now; intent gate disabled pending validation.
-        let wantsToPublish = state.canPublishMicrophone // && AudioManager.shared.isRecordingAlwaysPreparedMode
+        let wantsToPublish = state.canPublishMicrophone || AudioManager.shared.isRecordingAlwaysPreparedMode
         let needsRecord = state.isRecordingEnabled || state.hasRecorded || wantsToPublish
         let config: AudioSessionConfiguration = needsRecord
             ? (state.isSpeakerOutputPreferred ? .playAndRecordSpeaker : .playAndRecordReceiver)

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -250,7 +250,8 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
     ///     `isRecordingAlwaysPreparedMode` AND the participant has permission
     ///     to publish a microphone (`canPublishMicrophone`).
     private func selectConfiguration(state: State) -> AudioSessionConfiguration {
-        let wantsToPublish = state.canPublishMicrophone && AudioManager.shared.isRecordingAlwaysPreparedMode
+        // Purely permission-driven for now; intent gate disabled pending validation.
+        let wantsToPublish = state.canPublishMicrophone // && AudioManager.shared.isRecordingAlwaysPreparedMode
         let needsRecord = state.isRecordingEnabled || state.hasEverRecorded || wantsToPublish
         guard needsRecord else { return .playback }
         return state.isSpeakerOutputPreferred ? .playAndRecordSpeaker : .playAndRecordReceiver

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -167,7 +167,10 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         if (!newState.isPlayoutEnabled && !newState.isRecordingEnabled) && (oldState.isPlayoutEnabled || oldState.isRecordingEnabled) {
             if newState.isAutomaticDeactivationEnabled {
                 do {
-                    log("AudioSession deactivating...")
+                    log("AudioSession resetting to ambient and deactivating...")
+                    // Restore the media volume register; rocker stays on ringer/call otherwise.
+                    let idle = AudioSessionConfiguration.ambient
+                    try session.setCategory(idle.category, mode: idle.mode, options: idle.categoryOptions)
                     try session.setActive(false, options: .notifyOthersOnDeactivation)
                 } catch {
                     log("AudioSession failed to deactivate with error: \(error)", .error)

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -64,6 +64,16 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         set { _state.mutate { $0.isSpeakerOutputPreferred = newValue } }
     }
 
+    /// Whether the active local participant has permission to publish microphone
+    /// audio. Defaults to `true` (optimistic) until permissions arrive from the
+    /// server. Gates the pre-emptive `.playAndRecord` upgrade when the app sets
+    /// `isRecordingAlwaysPreparedMode`; once recording actually engages on any
+    /// path the sticky bit and `isRecordingEnabled` take over and override.
+    var canPublishMicrophone: Bool {
+        get { _state.canPublishMicrophone }
+        set { _state.mutate { $0.canPublishMicrophone = newValue } }
+    }
+
     struct State {
         var next: (any AudioEngineObserver)?
 
@@ -72,6 +82,14 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         var isSpeakerOutputPreferred: Bool = true
 
         var sessionRequirements: [UUID: SessionRequirement] = [:]
+
+        // Sticky: true once recording engaged this session, cleared on the empty edge.
+        // Keeps `.playAndRecord` across mute toggles instead of churning the category
+        // on every requirement change.
+        var hasEverRecorded: Bool = false
+
+        // Tracks the active local participant's mic publish permission. See accessor.
+        var canPublishMicrophone: Bool = true
     }
 
     let _state = StateSync(State())
@@ -132,6 +150,15 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
             let oldState = $0
             block(&$0.sessionRequirements)
             guard $0.sessionRequirements != oldState.sessionRequirements else { return }
+
+            // Maintain the sticky `hasEverRecorded` bit.
+            if $0.isRecordingEnabled {
+                $0.hasEverRecorded = true
+            } else if !$0.isPlayoutEnabled {
+                // Empty edge — reset for the next session.
+                $0.hasEverRecorded = false
+            }
+
             do {
                 try configureIfNeeded(oldState: oldState, newState: $0)
             } catch {
@@ -180,9 +207,7 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
                 log("AudioSession deactivation skipped...")
             }
         } else if newState.isRecordingEnabled || newState.isPlayoutEnabled {
-            // Configure and activate the session with the appropriate category
-            let playAndRecord: AudioSessionConfiguration = newState.isSpeakerOutputPreferred ? .playAndRecordSpeaker : .playAndRecordReceiver
-            let config: AudioSessionConfiguration = newState.isRecordingEnabled ? playAndRecord : .playback
+            let config = selectConfiguration(state: newState)
 
             do {
                 log("AudioSession configuring category to: \(config.category)")
@@ -213,6 +238,22 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
                 }
             }
         }
+    }
+
+    /// Picks the audio session configuration for the current state.
+    ///
+    /// `.playAndRecord` is selected when any signal indicates the user is or
+    /// will be publishing; otherwise `.playback` (pure listener):
+    ///   - `isRecordingEnabled`: a track or external acquirer needs recording now.
+    ///   - `hasEverRecorded`: sticky — keeps `.playAndRecord` across mute toggles.
+    ///   - `wantsToPublish`: the app declared publishing intent via
+    ///     `isRecordingAlwaysPreparedMode` AND the participant has permission
+    ///     to publish a microphone (`canPublishMicrophone`).
+    private func selectConfiguration(state: State) -> AudioSessionConfiguration {
+        let wantsToPublish = state.canPublishMicrophone && AudioManager.shared.isRecordingAlwaysPreparedMode
+        let needsRecord = state.isRecordingEnabled || state.hasEverRecorded || wantsToPublish
+        guard needsRecord else { return .playback }
+        return state.isSpeakerOutputPreferred ? .playAndRecordSpeaker : .playAndRecordReceiver
     }
 
     // MARK: - AudioEngineObserver

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -253,8 +253,11 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         // Purely permission-driven for now; intent gate disabled pending validation.
         let wantsToPublish = state.canPublishMicrophone // && AudioManager.shared.isRecordingAlwaysPreparedMode
         let needsRecord = state.isRecordingEnabled || state.hasEverRecorded || wantsToPublish
-        guard needsRecord else { return .playback }
-        return state.isSpeakerOutputPreferred ? .playAndRecordSpeaker : .playAndRecordReceiver
+        let config: AudioSessionConfiguration = needsRecord
+            ? (state.isSpeakerOutputPreferred ? .playAndRecordSpeaker : .playAndRecordReceiver)
+            : .playback
+        log("selectConfiguration: recording=\(state.isRecordingEnabled) hasEverRecorded=\(state.hasEverRecorded) canPublishMic=\(state.canPublishMicrophone) speaker=\(state.isSpeakerOutputPreferred) → \(config.category)")
+        return config
     }
 
     // MARK: - AudioEngineObserver

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -86,7 +86,7 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         // Sticky: true once recording engaged this session, cleared on the empty edge.
         // Keeps `.playAndRecord` across mute toggles instead of churning the category
         // on every requirement change.
-        var hasEverRecorded: Bool = false
+        var hasRecorded: Bool = false
 
         // Tracks the active local participant's mic publish permission. See accessor.
         var canPublishMicrophone: Bool = true
@@ -151,12 +151,12 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
             block(&$0.sessionRequirements)
             guard $0.sessionRequirements != oldState.sessionRequirements else { return }
 
-            // Maintain the sticky `hasEverRecorded` bit.
+            // Maintain the sticky `hasRecorded` bit.
             if $0.isRecordingEnabled {
-                $0.hasEverRecorded = true
+                $0.hasRecorded = true
             } else if !$0.isPlayoutEnabled {
                 // Empty edge — reset for the next session.
-                $0.hasEverRecorded = false
+                $0.hasRecorded = false
             }
 
             do {
@@ -245,18 +245,18 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
     /// `.playAndRecord` is selected when any signal indicates the user is or
     /// will be publishing; otherwise `.playback` (pure listener):
     ///   - `isRecordingEnabled`: a track or external acquirer needs recording now.
-    ///   - `hasEverRecorded`: sticky — keeps `.playAndRecord` across mute toggles.
+    ///   - `hasRecorded`: sticky — keeps `.playAndRecord` across mute toggles.
     ///   - `wantsToPublish`: the app declared publishing intent via
     ///     `isRecordingAlwaysPreparedMode` AND the participant has permission
     ///     to publish a microphone (`canPublishMicrophone`).
     private func selectConfiguration(state: State) -> AudioSessionConfiguration {
         // Purely permission-driven for now; intent gate disabled pending validation.
         let wantsToPublish = state.canPublishMicrophone // && AudioManager.shared.isRecordingAlwaysPreparedMode
-        let needsRecord = state.isRecordingEnabled || state.hasEverRecorded || wantsToPublish
+        let needsRecord = state.isRecordingEnabled || state.hasRecorded || wantsToPublish
         let config: AudioSessionConfiguration = needsRecord
             ? (state.isSpeakerOutputPreferred ? .playAndRecordSpeaker : .playAndRecordReceiver)
             : .playback
-        log("selectConfiguration: recording=\(state.isRecordingEnabled) hasEverRecorded=\(state.hasEverRecorded) canPublishMic=\(state.canPublishMicrophone) speaker=\(state.isSpeakerOutputPreferred) → \(config.category)")
+        log("selectConfiguration: recording=\(state.isRecordingEnabled) hasRecorded=\(state.hasRecorded) canPublishMic=\(state.canPublishMicrophone) speaker=\(state.isSpeakerOutputPreferred) → \(config.category)")
         return config
     }
 

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -77,6 +77,11 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         var isPlatformVoiceProcessingExpected: Bool = true
 
         var sessionRequirements: [UUID: SessionRequirement] = [:]
+
+        // Sticky: true once recording engaged, cleared when the WebRTC engine
+        // stops. Keeps `.playAndRecord` across mute toggles instead of churning
+        // the category on every requirement change.
+        var hasRecorded: Bool = false
     }
 
     let _state = StateSync(State())
@@ -144,6 +149,18 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
             let oldState = $0
             block(&$0.sessionRequirements)
             guard $0.sessionRequirements != oldState.sessionRequirements else { return }
+
+            if $0.isRecordingEnabled {
+                $0.hasRecorded = true
+            } else if $0.sessionRequirements[sessionRequirementId] == nil {
+                // The WebRTC engine stopped, so the next one starts a fresh
+                // session. Keyed on the engine's own requirement rather than on
+                // all of them: an externally held playout requirement (a
+                // prepared `SoundPlayer` sound, say) outlives the call and
+                // must not pin the category to `.playAndRecord`.
+                $0.hasRecorded = false
+            }
+
             do {
                 try configureIfNeeded(oldState: oldState, newState: $0)
             } catch {
@@ -189,20 +206,10 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
                 log("AudioSession deactivation skipped...")
             }
         } else if newState.isRecordingEnabled || newState.isPlayoutEnabled {
-            // Configure and activate the session with the appropriate category.
-            // Chat modes engage iOS's call-tuned speaker gain and are only kept
-            // when Apple voice processing provides its compensating loudness
-            // stage. With software processing, the media-tuned presets keep
-            // remote audio at media playback loudness.
-            let playAndRecord: AudioSessionConfiguration = if newState.isPlatformVoiceProcessingExpected {
-                newState.isSpeakerOutputPreferred ? .playAndRecordSpeaker : .playAndRecordReceiver
-            } else {
-                newState.isSpeakerOutputPreferred ? .playAndRecordSpeakerMedia : .playAndRecordReceiverMedia
-            }
-            let config: AudioSessionConfiguration = newState.isRecordingEnabled ? playAndRecord : .playback
+            let config = Self.selectConfiguration(state: newState)
 
             do {
-                log("AudioSession configuring category to: \(config.category)")
+                log("AudioSession configuring category to: \(config.category), mode: \(config.mode)")
                 try session.setCategory(config.category, mode: config.mode, options: config.categoryOptions)
                 // Request WebRTC's preferred IO buffer duration (0.02s / 20ms, defined as
                 // RTCAudioSessionHighPerformanceIOBufferDuration in RTCAudioSessionConfiguration.m).
@@ -229,6 +236,27 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
                     throw error
                 }
             }
+        }
+    }
+
+    /// Picks the audio session configuration for the given state.
+    ///
+    /// `.playAndRecord` is selected while recording is active and stays selected
+    /// until the audio engine stops (`hasRecorded`), so muting the microphone no
+    /// longer flips the category back to `.playback` — a mid-session category
+    /// change tears down Apple's Voice Processing I/O and leaves echo
+    /// cancellation off until the session ends.
+    ///
+    /// The chat modes engage iOS's call-tuned speaker gain and are only kept when
+    /// Apple voice processing provides its compensating loudness stage. With
+    /// software processing the media-tuned presets keep remote audio at media
+    /// playback loudness.
+    static func selectConfiguration(state: State) -> AudioSessionConfiguration {
+        guard state.isRecordingEnabled || state.hasRecorded else { return .playback }
+        return if state.isPlatformVoiceProcessingExpected {
+            state.isSpeakerOutputPreferred ? .playAndRecordSpeaker : .playAndRecordReceiver
+        } else {
+            state.isSpeakerOutputPreferred ? .playAndRecordSpeakerMedia : .playAndRecordReceiverMedia
         }
     }
 

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -235,6 +235,13 @@ public class LocalParticipant: Participant, @unchecked Sendable {
             }
         }
 
+        #if os(iOS) || os(visionOS) || os(tvOS)
+        // Mirror the mic-publish permission to the audio session so it can pick
+        // `.playback` for audience-only participants without waiting for a publish
+        // attempt to fail.
+        AudioManager.shared.audioSession.canPublishMicrophone = canPublish(source: .microphone)
+        #endif
+
         return didUpdate
     }
 
@@ -748,14 +755,21 @@ extension LocalParticipant {
         }
     }
 
-    private func checkPermissions(toPublish track: LocalTrack) throws {
-        guard permissions.canPublish else {
-            throw LiveKitError(.insufficientPermissions, message: "Participant does not have permission to publish")
-        }
-
+    /// Whether the participant currently has permission to publish a track from
+    /// the given source. Combines the top-level `canPublish` grant with the
+    /// per-source restriction in `canPublishSources` (empty = no restriction).
+    private func canPublish(source: Track.Source) -> Bool {
+        guard permissions.canPublish else { return false }
         let sources = permissions.canPublishSources
-        if !sources.isEmpty, !sources.contains(track.source.rawValue) {
-            throw LiveKitError(.insufficientPermissions, message: "Participant does not have permission to publish tracks from this source")
+        return sources.isEmpty || sources.contains(source.rawValue)
+    }
+
+    private func checkPermissions(toPublish track: LocalTrack) throws {
+        guard canPublish(source: track.source) else {
+            let message = permissions.canPublish
+                ? "Participant does not have permission to publish tracks from this source"
+                : "Participant does not have permission to publish"
+            throw LiveKitError(.insufficientPermissions, message: message)
         }
     }
 }

--- a/Sources/LiveKit/Types/AudioSessionConfiguration.swift
+++ b/Sources/LiveKit/Types/AudioSessionConfiguration.swift
@@ -36,10 +36,19 @@ public extension AudioSessionConfiguration {
                                                     categoryOptions: [.mixWithOthers],
                                                     mode: .spokenAudio)
 
+    // `.mixWithOthers` is removed from `.playAndRecord`:
+    //   - it is a known cause of echo when other apps share the audio device
+    //     during a real-time call;
+    //   - our WebRTC ADM has a retry loop working around -66637
+    //     (kAudioUnitErr_Initialized) on interruption-end recovery when this
+    //     option is active (related symptom: #1011).
+    // Intentionally kept on `.playback` (listener) where mixing is correct.
+    // `.allowAirPlay` is redundant under `.voiceChat`/`.videoChat` per QA1803:
+    // https://developer.apple.com/library/archive/qa/qa1803/_index.html
     #if swift(>=6.2)
-    private static let playAndRecordOptions: AVAudioSession.CategoryOptions = [.mixWithOthers, .allowBluetoothHFP, .allowBluetoothA2DP, .allowAirPlay]
+    private static let playAndRecordOptions: AVAudioSession.CategoryOptions = [.allowBluetoothHFP, .allowBluetoothA2DP]
     #else
-    private static let playAndRecordOptions: AVAudioSession.CategoryOptions = [.mixWithOthers, .allowBluetooth, .allowBluetoothA2DP, .allowAirPlay]
+    private static let playAndRecordOptions: AVAudioSession.CategoryOptions = [.allowBluetooth, .allowBluetoothA2DP]
     #endif
 
     static let playAndRecordSpeaker = AudioSessionConfiguration(category: .playAndRecord,

--- a/Sources/LiveKit/Types/AudioSessionConfiguration.swift
+++ b/Sources/LiveKit/Types/AudioSessionConfiguration.swift
@@ -28,6 +28,10 @@ public extension AudioSessionConfiguration {
                                                        categoryOptions: [],
                                                        mode: .default)
 
+    static let ambient = AudioSessionConfiguration(category: .ambient,
+                                                   categoryOptions: [],
+                                                   mode: .default)
+
     static let playback = AudioSessionConfiguration(category: .playback,
                                                     categoryOptions: [.mixWithOthers],
                                                     mode: .spokenAudio)

--- a/Sources/LiveKit/Types/AudioSessionConfiguration.swift
+++ b/Sources/LiveKit/Types/AudioSessionConfiguration.swift
@@ -32,10 +32,16 @@ public extension AudioSessionConfiguration {
                                                     categoryOptions: [.mixWithOthers],
                                                     mode: .spokenAudio)
 
+    // `.mixWithOthers` is deliberately absent here. On the in-call path it lets
+    // another app hold the audio device alongside the call, which is a known
+    // source of echo, and the WebRTC ADM has to work around a -66637
+    // (kAudioUnitErr_Initialized) engine-init race with a retry loop when it is
+    // set (related symptom: #1011). It is kept on `.playback` above, where
+    // mixing with other apps is the correct behavior for a listener.
     #if swift(>=6.2)
-    private static let playAndRecordOptions: AVAudioSession.CategoryOptions = [.mixWithOthers, .allowBluetoothHFP, .allowBluetoothA2DP, .allowAirPlay]
+    private static let playAndRecordOptions: AVAudioSession.CategoryOptions = [.allowBluetoothHFP, .allowBluetoothA2DP, .allowAirPlay]
     #else
-    private static let playAndRecordOptions: AVAudioSession.CategoryOptions = [.mixWithOthers, .allowBluetooth, .allowBluetoothA2DP, .allowAirPlay]
+    private static let playAndRecordOptions: AVAudioSession.CategoryOptions = [.allowBluetooth, .allowBluetoothA2DP, .allowAirPlay]
     #endif
 
     // Explicit speaker preference for the speaker presets. The chat modes

--- a/Tests/LiveKitCoreTests/AudioSessionCategorySelectionTests.swift
+++ b/Tests/LiveKitCoreTests/AudioSessionCategorySelectionTests.swift
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if os(iOS) || os(visionOS) || os(tvOS)
+
+import AVFoundation
+import Foundation
+@testable import LiveKit
+import Testing
+
+struct AudioSessionCategorySelectionTests {
+    private typealias Observer = AudioSessionEngineObserver
+
+    private func state(_ requirement: SessionRequirement,
+                       hasRecorded: Bool = false,
+                       speaker: Bool = true,
+                       platformVoiceProcessing: Bool = true) -> Observer.State
+    {
+        var state = Observer.State()
+        state.isSpeakerOutputPreferred = speaker
+        state.isPlatformVoiceProcessingExpected = platformVoiceProcessing
+        state.hasRecorded = hasRecorded
+        if requirement != .none {
+            state.sessionRequirements = [UUID(): requirement]
+        }
+        return state
+    }
+
+    @Test func playoutOnlyUsesPlayback() {
+        #expect(Observer.selectConfiguration(state: state(.playbackOnly)) == .playback)
+    }
+
+    @Test func recordingUsesPlayAndRecord() {
+        #expect(Observer.selectConfiguration(state: state(.playbackAndRecording)) == .playAndRecordSpeaker)
+        #expect(Observer.selectConfiguration(state: state(.playbackAndRecording, speaker: false)) == .playAndRecordReceiver)
+    }
+
+    /// Muting the mic drops the recording requirement; the category must not
+    /// fall back to `.playback`, which would tear down Voice Processing I/O.
+    @Test func mutingAfterRecordingKeepsPlayAndRecord() {
+        #expect(Observer.selectConfiguration(state: state(.playbackOnly, hasRecorded: true)) == .playAndRecordSpeaker)
+    }
+
+    /// Software voice processing has no compensating loudness stage, so the
+    /// media-tuned presets are used instead of the chat modes.
+    @Test func softwareVoiceProcessingUsesMediaPresets() {
+        #expect(Observer.selectConfiguration(state: state(.playbackAndRecording, platformVoiceProcessing: false)) == .playAndRecordSpeakerMedia)
+        #expect(Observer.selectConfiguration(state: state(.playbackAndRecording, speaker: false, platformVoiceProcessing: false)) == .playAndRecordReceiverMedia)
+    }
+
+    // MARK: - Sticky bit lifecycle
+
+    /// Drives the observer without touching `AVAudioSession`, so only the
+    /// bookkeeping in `updateRequirements` is exercised.
+    private func makeObserver() -> (Observer, AVAudioEngine) {
+        let observer = Observer()
+        observer.isAutomaticConfigurationEnabled = false
+        return (observer, AVAudioEngine())
+    }
+
+    @Test func stickyBitSurvivesMuting() {
+        let (observer, engine) = makeObserver()
+        _ = observer.engineWillEnable(engine, isPlayoutEnabled: true, isRecordingEnabled: true)
+        #expect(observer._state.hasRecorded)
+
+        // Mute: the engine keeps playing out but stops recording.
+        _ = observer.engineDidDisable(engine, isPlayoutEnabled: true, isRecordingEnabled: false)
+        #expect(observer._state.hasRecorded)
+    }
+
+    @Test func stickyBitClearsWhenTheEngineStops() {
+        let (observer, engine) = makeObserver()
+        _ = observer.engineWillEnable(engine, isPlayoutEnabled: true, isRecordingEnabled: true)
+        _ = observer.engineDidDisable(engine, isPlayoutEnabled: false, isRecordingEnabled: false)
+        #expect(!observer._state.hasRecorded)
+    }
+
+    /// An externally held playout requirement (a prepared `SoundPlayer` sound)
+    /// outlives the call and must not pin the category to `.playAndRecord`.
+    @Test func externalPlayoutRequirementDoesNotPinTheStickyBit() throws {
+        let (observer, engine) = makeObserver()
+        let handle = try observer.acquire(requirement: .playbackOnly)
+        defer { try? handle.release() }
+
+        _ = observer.engineWillEnable(engine, isPlayoutEnabled: true, isRecordingEnabled: true)
+        #expect(observer._state.hasRecorded)
+
+        _ = observer.engineDidDisable(engine, isPlayoutEnabled: false, isRecordingEnabled: false)
+        #expect(!observer._state.hasRecorded)
+        #expect(Observer.selectConfiguration(state: observer._state.copy()) == .playback)
+    }
+
+    /// An external `.recording` requirement (e.g. recording-always-prepared
+    /// mode) also engages the sticky bit; releasing it mid-call keeps
+    /// `.playAndRecord` until the engine stops.
+    @Test func externalRecordingRequirementSticksUntilTheEngineStops() throws {
+        let (observer, engine) = makeObserver()
+        _ = observer.engineWillEnable(engine, isPlayoutEnabled: true, isRecordingEnabled: false)
+        #expect(!observer._state.hasRecorded)
+
+        let handle = try observer.acquire(requirement: .playbackAndRecording)
+        #expect(observer._state.hasRecorded)
+
+        try handle.release()
+        #expect(observer._state.hasRecorded)
+        #expect(Observer.selectConfiguration(state: observer._state.copy()) == .playAndRecordSpeaker)
+
+        _ = observer.engineDidDisable(engine, isPlayoutEnabled: false, isRecordingEnabled: false)
+        #expect(!observer._state.hasRecorded)
+    }
+}
+
+#endif


### PR DESCRIPTION
Reworks the iOS audio session defaults. No public API changes; observable behavior changes are listed below with rationale.

- **`.playAndRecord` is sticky for the life of the engine session.** Category selection is now a pure `selectConfiguration(state:)` driven by the engine state plus a `hasRecorded` bit: `.playAndRecord` once recording engages, kept until the WebRTC engine stops, `.playback` otherwise. Muting the microphone no longer flips the category back to `.playback` — a mid-session category change tears down Apple's Voice Processing I/O and leaves echo cancellation dead for the rest of the call. The bit is keyed to the engine's own session requirement, so external requirement holders (e.g. a prepared `SoundPlayer` sound, which lives for the lifetime of the prepared sound) don't pin `.playAndRecord` after the call ends. Covered by new hermetic unit tests (`AudioSessionCategorySelectionTests`).
- **`.mixWithOthers` dropped from the `.playAndRecord` presets** (kept on the listener `.playback` preset). On the in-call path it lets another app hold the audio device alongside the call — a known echo source (see e.g. [Agora's echo troubleshooting](https://docs.agora.io/en/help/quality-issues/echo)) — and the WebRTC ADM needs a retry loop to work around a `-66637` engine-init race when it is set (related: #1011, #886). It has a turbulent history here — added in #228, removed in #260, re-entered during the AVAudioEngine ADM rewrite (#536); this is a clean revert. This matches the Flutter SDK's `communication` preset (`allowBluetooth`/`A2DP`/`allowAirPlay`, no `mixWithOthers`). Note the user-visible consequence: publishing the mic now interrupts other apps' audio for the rest of the call; muting doesn't bring it back.
- **Docs:** `Docs/audio.md` gains an "Audio session category selection" section covering the rules above, what counts as "recording", and the mic-permission implications.

Compared to earlier revisions of this PR:

- The permission-driven selection (`canPublishMicrophone` → `.playAndRecord`) is **gone**. `canPublish` defaults to true in standard tokens, so it made `.playback` unreachable — every subscriber would have activated a `.playAndRecord` session (mic prompt; TCC kill for apps without `NSMicrophoneUsageDescription`). The viewer-mic-prompt bug it targeted is native — the ADM's teardown path touched `AVAudioEngine.inputNode`, which alone instantiates the input unit — and is fixed by webrtc-sdk/webrtc#286, shipped in 150.7871.01 (#1103).
- The **`.ambient` category reset before deactivation** (volume-rocker register fix) was dropped: no other iOS SDK we checked (LiveKit Flutter/React Native, Stream Video, Agora, Twilio, upstream `RTCAudioSession`) resets or restores the category on teardown, and `.ambient` would break apps that manage their own category (no background audio, silent-switch muting). A restore-previous-configuration approach may follow separately.
- **`.allowAirPlay` is kept.** QA1803 only documents implied options for `.voiceChat`/`.videoChat` (`allowBluetooth`, `defaultToSpeaker`); it doesn't back removing AirPlay, and Flutter keeps it too.
