### PR TITLE
Fix display pixel density in adaptive stream

### DIFF
--- a/.changes/adaptive-stream-pixel-density
+++ b/.changes/adaptive-stream-pixel-density
@@ -1,0 +1,1 @@
+patch type="improved" "Account for display pixel density (retina) in adaptive stream"

--- a/.changes/adaptive-stream-pixel-density
+++ b/.changes/adaptive-stream-pixel-density
@@ -1,1 +1,1 @@
-patch type="improved" "Account for display pixel density (retina) in adaptive stream"
+patch type="fixed" "Fix adaptive stream dimensions on high-density displays"

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -67,6 +67,32 @@ public class VideoView: NativeView, Loggable {
         case flip
     }
 
+    /// Controls how the view's logical (point) size is scaled to physical pixels
+    /// when reporting the adaptive-stream size to the server. Server simulcast/SVC
+    /// layers are sized in physical pixels, so this avoids under-requesting (and
+    /// thus a soft/upscaled layer) on retina / high-density displays.
+    public enum AdaptiveStreamPixelDensity: Sendable, Equatable {
+        /// Use the view's own screen scale (`UIScreen.scale` on iOS/tvOS,
+        /// `NSScreen.backingScaleFactor` on macOS, `traitCollection.displayScale`
+        /// on visionOS). This is the default.
+        case auto
+        /// A fixed multiplier (e.g. `1.0`, `1.5`, `2.0`). Capped at ``maxDensity``.
+        case fixed(Double)
+
+        /// Upper bound applied to the resolved density to keep bandwidth in check.
+        public static let maxDensity: Double = 3.0
+
+        /// Resolves the effective multiplier, capped at ``maxDensity``. For
+        /// ``auto``, falls back to the supplied screen scale.
+        func resolve(screenScale: CGFloat) -> CGFloat {
+            let density: CGFloat = switch self {
+            case .auto: screenScale
+            case let .fixed(value): CGFloat(value)
+            }
+            return Swift.min(density, CGFloat(Self.maxDensity))
+        }
+    }
+
     /// ``LayoutMode-swift.enum`` of the ``VideoView``.
     @objc
     public nonisolated var layoutMode: LayoutMode {
@@ -91,6 +117,16 @@ public class VideoView: NativeView, Loggable {
     public nonisolated var rotationOverride: VideoRotation? {
         get { _state.rotationOverride }
         set { _state.mutate { $0.rotationOverride = newValue } }
+    }
+
+    /// Controls how this view's logical (point) size is converted to the
+    /// physical-pixel dimensions requested from the server when adaptive stream
+    /// is enabled. Defaults to ``AdaptiveStreamPixelDensity/auto`` (the view's
+    /// own screen scale), which avoids requesting an under-sized layer on
+    /// retina / high-density displays.
+    public nonisolated var adaptiveStreamPixelDensity: AdaptiveStreamPixelDensity {
+        get { _state.adaptiveStreamPixelDensity }
+        set { _state.mutate { $0.adaptiveStreamPixelDensity = newValue } }
     }
 
     /// Calls addRenderer and/or removeRenderer internally for convenience.
@@ -215,6 +251,10 @@ public class VideoView: NativeView, Loggable {
         var mirrorMode: MirrorMode = .auto
         var renderMode: RenderMode = .auto
         var rotationOverride: VideoRotation?
+        var adaptiveStreamPixelDensity: AdaptiveStreamPixelDensity = .auto
+        // Screen scale captured at layout time (main thread), so adaptiveStreamSize
+        // can resolve `.auto` density without touching main-actor view APIs.
+        var screenScale: CGFloat = 1
 
         var isDebugMode: Bool = false
 
@@ -423,6 +463,24 @@ public class VideoView: NativeView, Loggable {
         fatalError("init(coder:) has not been implemented")
     }
 
+    /// The pixel scale of the screen this view is currently on, used to convert
+    /// logical point sizes to physical pixels for adaptive stream. Must be called
+    /// on the main thread.
+    func currentScreenScale() -> CGFloat {
+        #if os(macOS)
+        return window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2.0
+        #elseif os(visionOS)
+        let scale = traitCollection.displayScale
+        return scale > 0 ? scale : 2.0
+        #elseif os(iOS) || os(tvOS)
+        let scale = traitCollection.displayScale
+        if scale > 0 { return scale }
+        return window?.screen.scale ?? UIScreen.main.scale
+        #else
+        return 1.0
+        #endif
+    }
+
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     override public func performLayout() {
         super.performLayout()
@@ -498,9 +556,13 @@ public class VideoView: NativeView, Loggable {
                                    width: size.width,
                                    height: size.height)
 
-        if state.rendererSize != rendererFrame.size {
+        let screenScale = currentScreenScale()
+        if state.rendererSize != rendererFrame.size || state.screenScale != screenScale {
             // mutate if required
-            _state.mutate { $0.rendererSize = rendererFrame.size }
+            _state.mutate {
+                $0.rendererSize = rendererFrame.size
+                $0.screenScale = screenScale
+            }
         }
 
         if let _primaryRenderer {
@@ -602,7 +664,13 @@ extension VideoView: VideoRenderer {
     }
 
     public var adaptiveStreamSize: CGSize {
-        _state.rendererSize ?? .zero
+        _state.read { state in
+            guard let size = state.rendererSize else { return .zero }
+            // Scale the logical (point) size to physical pixels so the server is
+            // asked for the resolution actually displayed on retina/HiDPI screens.
+            let density = state.adaptiveStreamPixelDensity.resolve(screenScale: state.screenScale)
+            return CGSize(width: size.width * density, height: size.height * density)
+        }
     }
 
     public func set(size: CGSize) {

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -469,14 +469,15 @@ public class VideoView: NativeView, Loggable {
     /// on the main thread.
     func currentScreenScale() -> CGFloat {
         #if os(macOS)
-        return window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2.0
+        var scale = window?.backingScaleFactor ?? 0
+        if scale <= 0 { scale = window?.screen?.backingScaleFactor ?? 0 }
+        return max(scale, 1.0)
         #elseif os(visionOS)
-        let scale = traitCollection.displayScale
-        return scale > 0 ? scale : 2.0
+        return max(traitCollection.displayScale, 1.0)
         #elseif os(iOS) || os(tvOS)
-        let scale = traitCollection.displayScale
-        if scale > 0 { return scale }
-        return window?.screen.scale ?? UIScreen.main.scale
+        var scale = traitCollection.displayScale
+        if scale <= 0 { scale = window?.windowScene?.screen.scale ?? 0 }
+        return max(scale, 1.0)
         #else
         return 1.0
         #endif

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -89,6 +89,7 @@ public class VideoView: NativeView, Loggable {
             case .auto: screenScale
             case let .fixed(value): CGFloat(value)
             }
+            guard !density.isNaN, density > 0 else { return 1 }
             return Swift.min(density, CGFloat(Self.maxDensity))
         }
     }

--- a/Tests/LiveKitCoreTests/AdaptiveStreamPixelDensityTests.swift
+++ b/Tests/LiveKitCoreTests/AdaptiveStreamPixelDensityTests.swift
@@ -35,4 +35,13 @@ struct AdaptiveStreamPixelDensityTests {
         #expect(VideoView.AdaptiveStreamPixelDensity.fixed(5).resolve(screenScale: 1) == 3)
         #expect(VideoView.AdaptiveStreamPixelDensity.maxDensity == 3)
     }
+
+    @Test func invalidDensityFallsBackToOne() {
+        #expect(VideoView.AdaptiveStreamPixelDensity.auto.resolve(screenScale: 0) == 1)
+        #expect(VideoView.AdaptiveStreamPixelDensity.auto.resolve(screenScale: -2) == 1)
+        #expect(VideoView.AdaptiveStreamPixelDensity.auto.resolve(screenScale: .nan) == 1)
+        #expect(VideoView.AdaptiveStreamPixelDensity.fixed(0).resolve(screenScale: 2) == 1)
+        #expect(VideoView.AdaptiveStreamPixelDensity.fixed(-1).resolve(screenScale: 2) == 1)
+        #expect(VideoView.AdaptiveStreamPixelDensity.fixed(.nan).resolve(screenScale: 2) == 1)
+    }
 }

--- a/Tests/LiveKitCoreTests/AdaptiveStreamPixelDensityTests.swift
+++ b/Tests/LiveKitCoreTests/AdaptiveStreamPixelDensityTests.swift
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import CoreGraphics
+@testable import LiveKit
+import Testing
+
+struct AdaptiveStreamPixelDensityTests {
+    @Test func autoUsesScreenScale() {
+        #expect(VideoView.AdaptiveStreamPixelDensity.auto.resolve(screenScale: 1) == 1)
+        #expect(VideoView.AdaptiveStreamPixelDensity.auto.resolve(screenScale: 2) == 2)
+        #expect(VideoView.AdaptiveStreamPixelDensity.auto.resolve(screenScale: 2.75) == 2.75)
+    }
+
+    @Test func fixedIgnoresScreenScale() {
+        #expect(VideoView.AdaptiveStreamPixelDensity.fixed(1).resolve(screenScale: 3) == 1)
+        #expect(VideoView.AdaptiveStreamPixelDensity.fixed(1.5).resolve(screenScale: 1) == 1.5)
+    }
+
+    @Test func capsAtMaxDensity() {
+        #expect(VideoView.AdaptiveStreamPixelDensity.auto.resolve(screenScale: 4) == 3)
+        #expect(VideoView.AdaptiveStreamPixelDensity.fixed(5).resolve(screenScale: 1) == 3)
+        #expect(VideoView.AdaptiveStreamPixelDensity.maxDensity == 3)
+    }
+}


### PR DESCRIPTION
## Summary

- scale adaptive-stream sizes from logical points to physical pixels on high-density displays
- add `VideoView.AdaptiveStreamPixelDensity` with `.auto` and `.fixed(Double)` controls
- resolve display scale per platform and guard invalid densities before capping to `maxDensity`

## Testing

- `swift test --filter AdaptiveStreamPixelDensityTests`
