### PR TITLE
DataChannel: keep reliable seq monotonic across concurrent sends

### DIFF
--- a/.changes/concurrent-dc-sends
+++ b/.changes/concurrent-dc-sends
@@ -1,0 +1,1 @@
+patch type="fixed" "Reliable data-channel sequence stays monotonic under concurrent sends"

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -33,10 +33,15 @@ protocol DataChannelDelegate: AnyObject, Sendable {
 /// and serializes all outgoing sends through a private FIFO event loop.
 ///
 /// ## Send flow
-/// `send(dataPacket:)` builds a `PublishDataRequest` and yields a `.sendRequested`
-/// event onto the internal `AsyncStream`. The event loop's single observer is the
-/// only mutator of `Buffers` (lossy / reliable send buffers + reliable retry
-/// buffer), so all bookkeeping is race-free without locks.
+/// `send(dataPacket:)` encrypts the packet and yields a `.sendPending` event onto
+/// the internal `AsyncStream` together with its waiting continuation. The event
+/// loop's single observer is the only mutator of `Buffers` (lossy / reliable
+/// send buffers + reliable retry buffer) **and** the only assigner of reliable
+/// sequence numbers — co-locating sequence assignment with the enqueue is what
+/// guarantees the sequence carried on the wire matches the FIFO order in which
+/// packets reach `channel.sendData(...)`. The retry-buffer replay path bypasses
+/// re-processing by yielding pre-serialized `PublishDataRequest`s as
+/// `.sendRequested` events.
 ///
 /// ## Live readiness vs. the open-completer
 /// `openCompleter` is a *sticky latch* that resolves the first time both channels
@@ -189,13 +194,34 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
         }
     }
 
+    /// Carries a not-yet-serialized data packet plus its waiting continuation from
+    /// `send(dataPacket:)` into the event loop. The event loop assigns the reliable
+    /// sequence number, encrypts (already done), serializes, and builds the
+    /// `PublishDataRequest` — so the on-the-wire sequence matches the FIFO order in
+    /// which packets reach `channel.sendData(...)`.
+    private struct PendingSend {
+        let packet: Livekit_DataPacket
+        let continuation: CheckedContinuation<Void, any Error>
+    }
+
     private struct ChannelEvent {
         let channelKind: ChannelKind
         let detail: Detail
 
         enum Detail {
-            /// Yielded by `send(dataPacket:)`. Consumer enqueues the request
-            /// into the matching `SendBuffer` and tries to flush.
+            /// Yielded by `send(dataPacket:)`. The event loop assigns the reliable
+            /// sequence number, serializes the packet, and enqueues the resulting
+            /// `PublishDataRequest` into the matching send buffer. Co-locating
+            /// sequence assignment and enqueue inside the single consumer of the
+            /// stream guarantees the sequence carried on the wire matches the
+            /// FIFO order in which `channel.sendData(...)` is invoked, which the
+            /// LiveKit SFU's per-publisher dedup gate requires.
+            case sendPending(PendingSend)
+
+            /// Yielded by the retry-buffer replay path in `retry(buffer:from:)`,
+            /// where the request is already encrypted, serialized, and stamped
+            /// with its (now-stale) sequence number. Consumer enqueues directly
+            /// into the matching send buffer with no re-processing.
             case sendRequested(PublishDataRequest)
 
             /// Yielded by `processSendQueue` after a successful
@@ -238,6 +264,12 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
     // swiftlint:disable:next cyclomatic_complexity
     private func processEvent(_ event: ChannelEvent, buffers: inout Buffers) {
         switch event.detail {
+        case let .sendPending(pending):
+            guard let request = makeRequest(from: pending) else { return }
+            switch event.channelKind {
+            case .lossy: buffers.lossyBuffer.enqueue(request)
+            case .reliable: buffers.reliableBuffer.enqueue(request)
+            }
         case let .sendRequested(request):
             switch event.channelKind {
             case .lossy: buffers.lossyBuffer.enqueue(request)
@@ -281,6 +313,27 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
         // one channel's kind drains both queues without extra plumbing.
         processSendQueue(threshold: Self.lossyLowThreshold, buffer: &buffers.lossyBuffer, kind: .lossy)
         processSendQueue(threshold: Self.reliableLowThreshold, buffer: &buffers.reliableBuffer, kind: .reliable)
+    }
+
+    /// Promote a `PendingSend` to a fully-prepared `PublishDataRequest`: assigns
+    /// the reliable sequence number (under the same lock that tracks the
+    /// per-publisher counter), then serializes and wraps in a `LKRTCDataBuffer`.
+    /// Returns `nil` (after failing the continuation) when serialization throws,
+    /// which keeps the event loop loop-invariant intact: every yielded
+    /// `.sendPending` resolves its continuation exactly once.
+    private func makeRequest(from pending: PendingSend) -> PublishDataRequest? {
+        let sequencedPacket = withSequence(pending.packet)
+        do {
+            let bytes = try sequencedPacket.serializedData()
+            return PublishDataRequest(
+                data: RTC.createDataBuffer(data: bytes),
+                sequence: sequencedPacket.sequence,
+                continuation: pending.continuation,
+            )
+        } catch {
+            pending.continuation.resume(throwing: error)
+            return nil
+        }
     }
 
     private func channel(for kind: ChannelKind) -> LKRTCDataChannel? {
@@ -434,19 +487,20 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
     }
 
     func send(dataPacket packet: Livekit_DataPacket) async throws {
-        let packet = try withEncryption(withSequence(packet))
-        let serializedData = try packet.serializedData()
-        let rtcData = RTC.createDataBuffer(data: serializedData)
+        // Encrypt outside the event loop (CPU work that doesn't touch ordering).
+        let encryptedPacket = try withEncryption(packet)
 
         try await withCheckedThrowingContinuation { continuation in
-            let request = PublishDataRequest(
-                data: rtcData,
-                sequence: packet.sequence,
-                continuation: continuation,
-            )
+            // Sequence assignment + serialization are deferred to the event loop's
+            // `.sendPending` handler so that the reliable sequence carried on the
+            // wire matches the FIFO order in which packets reach `channel.sendData`.
+            // Doing the assignment here would race with the AsyncStream yield: two
+            // concurrent callers could pick (seq=N, seq=N+1) but yield in the reverse
+            // order, causing the LiveKit SFU's strict per-publisher dedup gate to
+            // silently drop the lower-seq packet.
             let event = ChannelEvent(
-                channelKind: ChannelKind(packet.kind), // TODO: field is deprecated
-                detail: .sendRequested(request),
+                channelKind: ChannelKind(encryptedPacket.kind), // TODO: field is deprecated
+                detail: .sendPending(.init(packet: encryptedPacket, continuation: continuation)),
             )
             eventContinuation.yield(event)
         }

--- a/Tests/LiveKitCoreTests/DataChannel/RealiableDataChannelTests.swift
+++ b/Tests/LiveKitCoreTests/DataChannel/RealiableDataChannelTests.swift
@@ -131,6 +131,60 @@ import LiveKitTestSupport
         #expect(received == Array(0 ..< UInt32(iterations)),
                 "Reliable delivery should be exact and in send order, with no dupes or drops")
     }
+
+    @Test
+    func concurrentReliableSendsDeliverExactlyOnce() async throws {
+        let iterations = 256
+        let receiveDeadline: TimeInterval = 15
+        let bodyData = Data(repeating: 0xAB, count: 64)
+
+        try await confirmation("Data received", expectedCount: iterations) { confirm in
+            _receivedIndices.mutate { $0 = [] }
+            onDataReceived = { confirm() }
+
+            try await TestEnvironment.withRooms([
+                RoomTestingOptions(canPublishData: true),
+                RoomTestingOptions(delegate: self, canSubscribe: true),
+            ]) { rooms in
+                let sending = rooms[0]
+                let remoteIdentity = try #require(sending.remoteParticipants.keys.first)
+
+                // Fire every send into the task group at once. Without the
+                // event-loop-side sequence assignment, the AsyncStream yields
+                // would land in a different order than `withSequence` picked
+                // numbers, the SFU would drop the laggards, and the receiver
+                // would surface gaps in `_receivedIndices`.
+                try await withThrowingTaskGroup { group in
+                    for i in 0 ..< iterations {
+                        group.addTask {
+                            var seq = UInt32(i)
+                            let packetData = Data(bytes: &seq, count: 4) + bodyData
+                            let userPacket = Livekit_UserPacket.with {
+                                $0.payload = packetData
+                                $0.destinationIdentities = [remoteIdentity.stringValue]
+                            }
+                            try await sending.send(userPacket: userPacket, kind: .reliable)
+                        }
+                    }
+                    try await group.waitForAll()
+                }
+
+                // Wait for the receiver inside `withRooms` so the data channel
+                // stays open until every packet has been delivered. Polling
+                // outside `withRooms` would race the room teardown, and
+                // any still-in-flight packets would be lost when the
+                // underlying SCTP connection closes.
+                let deadline = Date().addingTimeInterval(receiveDeadline)
+                while Date() < deadline, self._receivedIndices.copy().count < iterations {
+                    try? await Task.sleep(nanoseconds: 100_000_000)
+                }
+            }
+        }
+
+        let received = _receivedIndices.copy()
+        #expect(received.sorted() == Array(0 ..< UInt32(iterations)),
+                "Reliable delivery must cover every sequence exactly once, with no drops or dupes")
+    }
 }
 
 extension RealiableDataChannelTests: RoomDelegate {


### PR DESCRIPTION
## Summary

`DataChannelPair.send(dataPacket:)` assigned the reliable sequence number under `_state.mutate` but yielded onto the AsyncStream event loop **outside** that critical section. Two concurrent callers could pick `(seq=N, seq=N+1)` and yield in the reverse order — the SFU's per-publisher dedup gate then silently dropped the lower-seq packet.

Fix: move sequence assignment and serialization **into** the event-loop subscriber via a new `.sendPending` event variant, so the sequence carried on the wire matches the FIFO order in which packets reach `channel.sendData(...)`. The retry-buffer replay path keeps using `.sendRequested(PublishDataRequest)` for already-serialized entries.

## Discovery

Pre-existing issue (predates RPC v2), but surfaced during RPC v2 stress testing with large payloads — concurrent stream chunks raced for sequence numbers and one chunk's worth (~15 KB) consistently went missing:

```
🔴 [test-2] FAIL: sent=76.38 KB received=46.38 KB
🔴 [test-4] error (53.10 KB): RpcError(code: 1501, message: "Connection timeout", data: "")
🔴 [test-1] FAIL: sent=79.75 KB received=64.75 KB
```

## Test plan

- [x] New regression test `concurrentReliableSendsDeliverExactlyOnce` fires 256 reliable user-packets concurrently and asserts exact-once delivery
  - Reverting the SDK fix on this branch: **217/256** delivered (39 dropped)
  - With the fix: **256/256** delivered
- [x] Standalone CLI stress (10 concurrent `performRpc` × 1KB–1MB × 10 rounds against `wss://blaze-playground-…livekit.cloud`): **100/100** pass; pushed to 20 × 10: **200/200** pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)