### PR TITLE
DataChannel: reject oversized data messages before they break the channel

### DIFF
--- a/.changes/dc-max-message-size
+++ b/.changes/dc-max-message-size
@@ -1,0 +1,1 @@
+patch type="fixed" "Reject oversized data messages before they break the publisher data channel"

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -107,6 +107,18 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
         var reliableReceivedState: TTLDictionary<String, UInt32> = TTLDictionary(ttl: reliableReceivedStateTTL)
         var e2eeManager: E2EEManager?
 
+        /// Negotiated SCTP max message size (bytes), parsed from the publisher
+        /// answer SDP (`a=max-message-size`, RFC 8841). `0` means "no limit".
+        /// Defaults to ``DataChannelPair/defaultMaxMessageSize`` until the
+        /// first SDP answer is received.
+        var maxMessageSize: UInt64 = DataChannelPair.defaultMaxMessageSize
+
+        /// Set by ``DataChannelPair/reset(throwing:)``; cleared when a new
+        /// channel is assigned via ``DataChannelPair/setChannel(_:kind:)``.
+        /// Distinguishes SDK-initiated teardown from an unexpected close
+        /// (e.g. libwebrtc tearing the channel down after an oversized send).
+        var wasReset: Bool = false
+
         var isOpen: Bool {
             guard let lossy, let reliable else { return false }
             return reliable.readyState == .open && lossy.readyState == .open
@@ -318,22 +330,38 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
     /// Promote a `PendingSend` to a fully-prepared `PublishDataRequest`: assigns
     /// the reliable sequence number (under the same lock that tracks the
     /// per-publisher counter), then serializes and wraps in a `LKRTCDataBuffer`.
-    /// Returns `nil` (after failing the continuation) when serialization throws,
-    /// which keeps the event loop loop-invariant intact: every yielded
-    /// `.sendPending` resolves its continuation exactly once.
+    /// Returns `nil` (after failing the continuation) when serialization throws
+    /// or the encoded packet exceeds the negotiated SCTP max-message-size —
+    /// either way the loop invariant holds: every yielded `.sendPending`
+    /// resolves its continuation exactly once.
     private func makeRequest(from pending: PendingSend) -> PublishDataRequest? {
         let sequencedPacket = withSequence(pending.packet)
+        let bytes: Data
         do {
-            let bytes = try sequencedPacket.serializedData()
-            return PublishDataRequest(
-                data: RTC.createDataBuffer(data: bytes),
-                sequence: sequencedPacket.sequence,
-                continuation: pending.continuation,
-            )
+            bytes = try sequencedPacket.serializedData()
         } catch {
             pending.continuation.resume(throwing: error)
             return nil
         }
+
+        // Encoded size is what actually goes on the wire — sending more than
+        // the negotiated max-message-size makes libwebrtc abruptly tear the
+        // data channel down (returns success from `sendData`, then closes),
+        // breaking every subsequent publish. Reject here instead.
+        let maxMessageSize = _state.maxMessageSize
+        if maxMessageSize != 0, UInt64(bytes.count) > maxMessageSize {
+            pending.continuation.resume(throwing: LiveKitError(
+                .invalidParameter,
+                message: "data packet size (\(bytes.count) bytes) exceeds the negotiated max-message-size (\(maxMessageSize) bytes)",
+            ))
+            return nil
+        }
+
+        return PublishDataRequest(
+            data: RTC.createDataBuffer(data: bytes),
+            sequence: sequencedPacket.sequence,
+            continuation: pending.continuation,
+        )
     }
 
     private func channel(for kind: ChannelKind) -> LKRTCDataChannel? {
@@ -441,6 +469,9 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
             case .reliable: $0.reliable = channel
             case .lossy: $0.lossy = channel
             }
+            // Re-arming a channel (e.g. on fast reconnect) returns the pair
+            // to a live state, so future closes are once again "unexpected".
+            if channel != nil { $0.wasReset = false }
             return $0.isOpen
         }
 
@@ -451,6 +482,13 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
             openCompleter.resume(returning: ())
             eventContinuation.yield(ChannelEvent(channelKind: kind, detail: .wakeup))
         }
+    }
+
+    /// Update the negotiated SCTP max-message-size cap. Called by the room
+    /// after parsing `a=max-message-size` from the publisher answer SDP.
+    /// `0` is honored as "no limit".
+    func set(maxMessageSize: UInt64) {
+        _state.mutate { $0.maxMessageSize = maxMessageSize }
     }
 
     func set(e2eeManager: E2EEManager?) {
@@ -464,6 +502,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
             $0.reliableDataSequence = 1
             $0.reliableReceivedState.removeAll()
             $0.lossy = nil
+            $0.wasReset = true
             return result
         }
 
@@ -564,6 +603,11 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
     private static let reliableRetryAmount: UInt64 = .init(Double(reliableLowThreshold) * 1.25)
     private static let reliableReceivedStateTTL: TimeInterval = 30
 
+    /// Default max-message-size assumed before SDP negotiation completes, and
+    /// the upper bound clamp applied to any value parsed from the SDP answer.
+    /// LiveKit/pion advertises ~64 KiB; libwebrtc's internal default is 256 KiB.
+    static let defaultMaxMessageSize: UInt64 = 64000
+
     deinit {
         eventContinuation.finish()
     }
@@ -583,6 +627,19 @@ extension DataChannelPair: LKRTCDataChannelDelegate {
     }
 
     func dataChannelDidChangeState(_ dataChannel: LKRTCDataChannel) {
+        // Single locked read so the unexpected-close check and the open-wakeup
+        // gate observe a consistent `State` snapshot.
+        let (wasReset, isOpen) = _state.read { ($0.wasReset, $0.isOpen) }
+
+        if dataChannel.readyState == .closed, !wasReset {
+            // libwebrtc closes the publisher data channel on its own when an
+            // SCTP send violates the negotiated max-message-size (and a few
+            // other conditions). `sendData` still returns true in that case,
+            // so this is the only signal we get. The send guard in
+            // `makeRequest` is the primary defense; this log surfaces any
+            // remaining cases for diagnosis.
+            log("data channel '\(dataChannel.label)' closed unexpectedly", .error)
+        }
         if isOpen {
             // Wake parked sends after the channel transitioned to `.open`
             // (e.g. on a fast-reconnect re-arming channels mid-flight).
@@ -659,4 +716,26 @@ private extension LKRTCDataChannel {
         }
         return .lossy
     }
+}
+
+// MARK: - SDP parsing
+
+/// Parses the `a=max-message-size` attribute (RFC 8841) from an SDP string,
+/// returning the value in bytes. Returns `nil` when the attribute is absent
+/// or malformed.
+///
+/// Per RFC 8841, a value of `0` indicates "no limit"; callers downstream
+/// honor that by skipping the send-side size check.
+func parseSDPMaxMessageSize(_ sdp: String) -> UInt64? {
+    // `components(separatedBy: .newlines)` splits on Unicode scalars, which is
+    // what we want here — `String.split` treats CRLF as a single grapheme and
+    // would leave a stray `\r` on every line of a typical SDP.
+    for line in sdp.components(separatedBy: .newlines) {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        let prefix = "a=max-message-size:"
+        guard trimmed.hasPrefix(prefix) else { continue }
+        let value = trimmed.dropFirst(prefix.count).trimmingCharacters(in: .whitespaces)
+        return UInt64(value)
+    }
+    return nil
 }

--- a/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
@@ -338,6 +338,14 @@ extension Room: SignalClientDelegate {
     func signalClient(_: SignalClient, didReceiveAnswer answer: LKRTCSessionDescription, offerId: UInt32) async {
         log("Received answer for offerId: \(offerId)")
 
+        // Clamp to the SDK default — libwebrtc advertises larger (~256 KiB)
+        // than LiveKit/pion can deliver end-to-end (~64 KiB), so we trust
+        // the answer no more than our compiled-in ceiling.
+        let parsed = parseSDPMaxMessageSize(answer.sdp) ?? DataChannelPair.defaultMaxMessageSize
+        let maxMessageSize = min(parsed, DataChannelPair.defaultMaxMessageSize)
+        publisherDataChannel.set(maxMessageSize: maxMessageSize)
+        log("Negotiated data channel max-message-size: \(maxMessageSize) bytes", .debug)
+
         do {
             let publisher = try requirePublisher()
             try await publisher.set(remoteDescription: answer, offerId: offerId)

--- a/Tests/LiveKitCoreTests/DataChannel/DataChannelPairTests.swift
+++ b/Tests/LiveKitCoreTests/DataChannel/DataChannelPairTests.swift
@@ -71,4 +71,89 @@ struct DataChannelPairTests {
             try await waitTask.value
         } throws: { ($0 as? LiveKitError)?.type == .cancelled }
     }
+
+    @Test func oversizedSendRejectedWithInvalidParameter() async throws {
+        let pair = DataChannelPair()
+        pair.set(maxMessageSize: 1024)
+
+        let oversizedPayload = Data(repeating: 0xAB, count: 4096)
+        await #expect {
+            try await pair.send(userPacket: .with { $0.payload = oversizedPayload }, kind: .reliable)
+        } throws: { ($0 as? LiveKitError)?.type == .invalidParameter }
+    }
+
+    @Test func zeroLimitDisablesTheSizeGuard() async throws {
+        let pair = DataChannelPair()
+        pair.set(maxMessageSize: 0)
+
+        // Without channels, the send parks indefinitely; we only want to verify
+        // that the size check does NOT short-circuit the request first.
+        let sendTask = Task {
+            try await pair.send(userPacket: .with { $0.payload = Data(repeating: 0xCD, count: 200_000) }, kind: .reliable)
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        pair.reset(throwing: LiveKitError(.cancelled, message: "test teardown"))
+        // The send fails via .drain, not via the size guard — `.cancelled`
+        // confirms the request reached the parked-send queue.
+        await #expect {
+            try await sendTask.value
+        } throws: { ($0 as? LiveKitError)?.type == .cancelled }
+    }
+}
+
+/// Pins the parser's behavior against each shape of `a=max-message-size`
+/// attribute defined by RFC 8841 §6 (SDP for SCTP-based media transport).
+@Suite(.tags(.dataChannel))
+struct SDPMaxMessageSizeParserTests {
+    enum Case: CaseIterable {
+        /// Full application section with CRLF line endings — the wire-format
+        /// servers actually emit.
+        case applicationSectionCRLF
+        /// LF-only line endings with surrounding whitespace — exercises tolerant
+        /// parsing for peers that don't follow the SDP grammar to the letter.
+        case lfOnlyWithSurroundingWhitespace
+        /// Attribute absent. Callers fall back to the SDK default cap.
+        case missingAttribute
+        /// RFC 8841: a value of `0` indicates "no limit". The send guard
+        /// downstream honors that by skipping the size check.
+        case zeroMeansNoLimit
+        /// Non-numeric value — treated as if absent (no fallback parsing).
+        case invalidNumericValue
+        /// Empty value after the colon — treated as if absent.
+        case emptyValue
+
+        var sdp: String {
+            switch self {
+            case .applicationSectionCRLF:
+                "v=0\r\nm=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\na=sctp-port:5000\r\na=max-message-size:262144\r\n"
+            case .lfOnlyWithSurroundingWhitespace:
+                "m=application 9 UDP/DTLS/SCTP webrtc-datachannel\n a=max-message-size: 65536 \n"
+            case .missingAttribute:
+                "v=0\r\nm=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\na=sctp-port:5000\r\n"
+            case .zeroMeansNoLimit:
+                "a=max-message-size:0\r\n"
+            case .invalidNumericValue:
+                "a=max-message-size:abc\r\n"
+            case .emptyValue:
+                "a=max-message-size:\r\n"
+            }
+        }
+
+        var expected: UInt64? {
+            switch self {
+            case .applicationSectionCRLF: 262_144
+            case .lfOnlyWithSurroundingWhitespace: 65536
+            case .missingAttribute: nil
+            case .zeroMeansNoLimit: 0
+            case .invalidNumericValue: nil
+            case .emptyValue: nil
+            }
+        }
+    }
+
+    @Test(arguments: Case.allCases)
+    func parses(_ testCase: Case) {
+        #expect(parseSDPMaxMessageSize(testCase.sdp) == testCase.expected)
+    }
 }


### PR DESCRIPTION
## Summary

Sending more than the negotiated SCTP max-message-size makes libwebrtc return success from `sendData` and then abruptly tear down the publisher data channel — every subsequent publish fails until a full reconnect.

- Parse `a=max-message-size` (RFC 8841) from the publisher answer SDP, clamp to a 64000-byte default.
- Reject in `DataChannelPair.makeRequest` after serialization (encoded byte count = what goes on the wire). `0` means "no limit".
- Log an error when the publisher channel transitions to `.closed` without an SDK-initiated reset.

Ports the fix from [livekit/rust-sdks#1137](https://github.com/livekit/rust-sdks/pull/1137). Android does the simpler hardcoded-constant variant at [`LocalParticipant.kt:984-986`](https://github.com/livekit/client-sdk-android/blob/46da6784bec2ac124972738764a8e18702a78ee3/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt#L984-L986).

## Test plan

- [x] Unit tests: parameterized SDP parser (6 cases) + size-guard tests (`oversizedSendRejectedWithInvalidParameter`, `zeroLimitDisablesTheSizeGuard`)
- [x] `xcodebuild build` macOS clean
- [x] SwiftLint clean
- [ ] CI matrix