### PR TITLE
Exclude macOS from buffer size workaround

### DIFF
--- a/Sources/LiveKit/Audio/MixerEngineObserver.swift
+++ b/Sources/LiveKit/Audio/MixerEngineObserver.swift
@@ -105,6 +105,7 @@ public final class MixerEngineObserver: AudioEngineObserver, Loggable {
             ($0.appNode, $0.appMixerNode, $0.micNode, $0.micMixerNode, $0.soundPlayerNodes)
         }
 
+        #if os(iOS) || os(visionOS) || os(tvOS)
         // Match the outputNode's maximumFramesToRender so our nodes can handle the same
         // buffer sizes the engine expects, preventing kAudioUnitErr_TooManyFramesToProcess (-10874).
         // Must be set before render resources are allocated (i.e. before attach/connect/start).
@@ -139,7 +140,6 @@ public final class MixerEngineObserver: AudioEngineObserver, Loggable {
             "micMixerNode=\(micMixerNode.auAudioUnit.maximumFramesToRender), " +
             "soundPlayerMixerNode=\(soundPlayerNodes.mixerNode.auAudioUnit.maximumFramesToRender)", .debug)
 
-        #if os(iOS) || os(visionOS) || os(tvOS)
         let config = LKRTCAudioSessionConfiguration.webRTC()
         log("webRTCPreferredFrames=\(AVAudioFrameCount(config.sampleRate * config.ioBufferDuration))", .debug)
         #endif


### PR DESCRIPTION
The fix was primarily for iOS devices (low-end) #936 

Xcode 27 fails with the following error:

<img width="343" height="143" alt="Screenshot 2026-06-09 at 9 29 46 AM" src="https://github.com/user-attachments/assets/33827096-dfee-42eb-aacd-1a97b1417465" />

whereas:
https://developer.apple.com/documentation/avfaudio/avaudionode/auaudiounit

```
iOS 11.0+iPadOS 11.0+Mac Catalyst 13.1+macOS 10.13+tvOS 11.0+visionOS 1.0+
```
