### PR TITLE
Fix Xcode 27 beta build errors

### DIFF
--- a/.changes/xcode-27-beta-build
+++ b/.changes/xcode-27-beta-build
@@ -1,0 +1,1 @@
+patch type="fixed" "Fixed Xcode 27 beta build errors"

--- a/Sources/LKObjCHelpers/LKObjCHelpers.m
+++ b/Sources/LKObjCHelpers/LKObjCHelpers.m
@@ -4,6 +4,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (void)finishBroadcastWithoutError:(RPBroadcastSampleHandler *)handler API_AVAILABLE(ios(10.0), macCatalyst(13.1), macos(11.0), tvos(10.0)) {
     // Call finishBroadcastWithError with nil error, which ends the broadcast without an error popup
     // This is unsupported/undocumented but appears to work and is preferable to an error dialog with a cryptic default message
@@ -13,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
     [handler finishBroadcastWithError:nil];
     #pragma clang diagnostic pop
 }
+#pragma clang diagnostic pop
 
 + (BOOL)catchException:(void(^)(void))tryBlock error:(__autoreleasing NSError **)error {
     @try {
@@ -24,6 +27,26 @@ NS_ASSUME_NONNULL_BEGIN
         return NO;
     }
 }
+
+// MARK: - Xcode 27 availability workarounds
+
++ (AUAudioFrameCount)maximumFramesToRenderForNode:(AVAudioNode *)node {
+    return node.AUAudioUnit.maximumFramesToRender;
+}
+
++ (void)setMaximumFramesToRender:(AUAudioFrameCount)maximumFramesToRender forNode:(AVAudioNode *)node {
+    node.AUAudioUnit.maximumFramesToRender = maximumFramesToRender;
+}
+
+#if TARGET_OS_OSX
++ (void)setWidth:(size_t)width height:(size_t)height onConfiguration:(SCStreamConfiguration *)configuration {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wunguarded-availability-new"
+    configuration.width = width;
+    configuration.height = height;
+    #pragma clang diagnostic pop
+}
+#endif
 
 NS_ASSUME_NONNULL_END
 

--- a/Sources/LKObjCHelpers/include/LKObjCHelpers.h
+++ b/Sources/LKObjCHelpers/include/LKObjCHelpers.h
@@ -1,10 +1,32 @@
 #import <Foundation/Foundation.h>
 #import <ReplayKit/ReplayKit.h>
+#import <AVFAudio/AVFAudio.h>
+#import <AudioToolbox/AudioToolbox.h>
+
+#if TARGET_OS_OSX
+#import <ScreenCaptureKit/ScreenCaptureKit.h>
+#endif
 
 @interface LKObjCHelpers : NSObject
 
+#pragma clang diagnostic push
+// RPBroadcastSampleHandler is deprecated in the iOS 27 SDK; suppress so the module still builds (#1037).
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (void)finishBroadcastWithoutError:(RPBroadcastSampleHandler *)handler API_AVAILABLE(ios(10.0), macCatalyst(13.1), macos(11.0), tvos(10.0));
+#pragma clang diagnostic pop
 
 + (BOOL)catchException:(void(^)(void))tryBlock error:(__autoreleasing NSError **)error;
+
+// MARK: - Xcode 27 availability workarounds
+// The macOS 27 SDK bumped these APIs past the OS versions they actually ship in (only the Swift
+// importer enforces it). Reaching them from ObjC keeps full behavior on every SDK/OS version (#1035).
+
++ (AUAudioFrameCount)maximumFramesToRenderForNode:(AVAudioNode *)node;
+
++ (void)setMaximumFramesToRender:(AUAudioFrameCount)maximumFramesToRender forNode:(AVAudioNode *)node;
+
+#if TARGET_OS_OSX
++ (void)setWidth:(size_t)width height:(size_t)height onConfiguration:(SCStreamConfiguration *)configuration API_AVAILABLE(macos(12.3));
+#endif
 
 @end

--- a/Sources/LiveKit/Audio/MixerEngineObserver.swift
+++ b/Sources/LiveKit/Audio/MixerEngineObserver.swift
@@ -105,7 +105,6 @@ public final class MixerEngineObserver: AudioEngineObserver, Loggable {
             ($0.appNode, $0.appMixerNode, $0.micNode, $0.micMixerNode, $0.soundPlayerNodes)
         }
 
-        #if os(iOS) || os(visionOS) || os(tvOS)
         // Match the outputNode's maximumFramesToRender so our nodes can handle the same
         // buffer sizes the engine expects, preventing kAudioUnitErr_TooManyFramesToProcess (-10874).
         // Must be set before render resources are allocated (i.e. before attach/connect/start).
@@ -118,28 +117,29 @@ public final class MixerEngineObserver: AudioEngineObserver, Loggable {
         // must move into the WebRTC layer (audio_engine_device.mm).
         // See: https://developer.apple.com/documentation/audiotoolbox/auaudiounit/maximumframestorender
         // See: https://developer.apple.com/forums/thread/111968
-        let maxFrames = engine.outputNode.auAudioUnit.maximumFramesToRender
+        let maxFrames = engine.outputNode.maximumFramesToRender
 
         log("maximumFramesToRender before: " +
-            "appNode=\(appNode.auAudioUnit.maximumFramesToRender), " +
-            "appMixerNode=\(appMixerNode.auAudioUnit.maximumFramesToRender), " +
-            "micNode=\(micNode.auAudioUnit.maximumFramesToRender), " +
-            "micMixerNode=\(micMixerNode.auAudioUnit.maximumFramesToRender), " +
-            "soundPlayerMixerNode=\(soundPlayerNodes.mixerNode.auAudioUnit.maximumFramesToRender)", .debug)
+            "appNode=\(appNode.maximumFramesToRender), " +
+            "appMixerNode=\(appMixerNode.maximumFramesToRender), " +
+            "micNode=\(micNode.maximumFramesToRender), " +
+            "micMixerNode=\(micMixerNode.maximumFramesToRender), " +
+            "soundPlayerMixerNode=\(soundPlayerNodes.mixerNode.maximumFramesToRender)", .debug)
 
-        appNode.auAudioUnit.maximumFramesToRender = maxFrames
-        appMixerNode.auAudioUnit.maximumFramesToRender = maxFrames
-        micNode.auAudioUnit.maximumFramesToRender = maxFrames
-        micMixerNode.auAudioUnit.maximumFramesToRender = maxFrames
+        appNode.maximumFramesToRender = maxFrames
+        appMixerNode.maximumFramesToRender = maxFrames
+        micNode.maximumFramesToRender = maxFrames
+        micMixerNode.maximumFramesToRender = maxFrames
         soundPlayerNodes.setMaximumFramesToRender(maxFrames)
 
         log("maximumFramesToRender setting to \(maxFrames): " +
-            "appNode=\(appNode.auAudioUnit.maximumFramesToRender), " +
-            "appMixerNode=\(appMixerNode.auAudioUnit.maximumFramesToRender), " +
-            "micNode=\(micNode.auAudioUnit.maximumFramesToRender), " +
-            "micMixerNode=\(micMixerNode.auAudioUnit.maximumFramesToRender), " +
-            "soundPlayerMixerNode=\(soundPlayerNodes.mixerNode.auAudioUnit.maximumFramesToRender)", .debug)
+            "appNode=\(appNode.maximumFramesToRender), " +
+            "appMixerNode=\(appMixerNode.maximumFramesToRender), " +
+            "micNode=\(micNode.maximumFramesToRender), " +
+            "micMixerNode=\(micMixerNode.maximumFramesToRender), " +
+            "soundPlayerMixerNode=\(soundPlayerNodes.mixerNode.maximumFramesToRender)", .debug)
 
+        #if os(iOS) || os(visionOS) || os(tvOS)
         let config = LKRTCAudioSessionConfiguration.webRTC()
         log("webRTCPreferredFrames=\(AVAudioFrameCount(config.sampleRate * config.ioBufferDuration))", .debug)
         #endif

--- a/Sources/LiveKit/Audio/PlayerNodePool.swift
+++ b/Sources/LiveKit/Audio/PlayerNodePool.swift
@@ -122,9 +122,9 @@ class AVAudioPlayerNodePool: @unchecked Sendable, Loggable {
 
     func setMaximumFramesToRender(_ maxFrames: AUAudioFrameCount) {
         executionQueue.sync {
-            mixerNode.auAudioUnit.maximumFramesToRender = maxFrames
+            mixerNode.maximumFramesToRender = maxFrames
             for item in items {
-                item.node.auAudioUnit.maximumFramesToRender = maxFrames
+                item.node.maximumFramesToRender = maxFrames
             }
         }
     }

--- a/Sources/LiveKit/Audio/SoundPlayer.swift
+++ b/Sources/LiveKit/Audio/SoundPlayer.swift
@@ -172,7 +172,7 @@ extension SoundPlayer {
         playerNodePool.stop()
         engine.stop()
         engine.disconnect(playerNodePool)
-        playerNodePool.setMaximumFramesToRender(engine.outputNode.auAudioUnit.maximumFramesToRender)
+        playerNodePool.setMaximumFramesToRender(engine.outputNode.maximumFramesToRender)
         engine.connect(playerNodePool, to: engine.mainMixerNode,
                        format: outputFormat, playerNodeFormat: playerNodeFormat)
         try engine.start()

--- a/Sources/LiveKit/Broadcast/IPC/BroadcastAudioCodec.swift
+++ b/Sources/LiveKit/Broadcast/IPC/BroadcastAudioCodec.swift
@@ -93,7 +93,7 @@ struct BroadcastAudioCodec {
     }
 }
 
-extension AudioStreamBasicDescription: Codable {
+extension AudioStreamBasicDescription: Swift.Codable {
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.unkeyedContainer()
         try container.encode(mSampleRate)

--- a/Sources/LiveKit/Broadcast/IPC/BroadcastUploader.swift
+++ b/Sources/LiveKit/Broadcast/IPC/BroadcastUploader.swift
@@ -83,7 +83,7 @@ final class BroadcastUploader: Sendable, Loggable {
             let rotation = VideoRotation(sampleBuffer.replayKitOrientation ?? .up)
             do {
                 let (metadata, imageData) = try imageCodec.encode(sampleBuffer)
-                Task {
+                Task.discarding {
                     let header = BroadcastIPCHeader.image(metadata, rotation)
                     try await channel.send(header: header, payload: imageData)
                     state.mutate { $0.isUploadingImage = false }
@@ -95,7 +95,7 @@ final class BroadcastUploader: Sendable, Loggable {
         case .audioApp:
             guard state.shouldUploadAudio else { return }
             let (metadata, audioData) = try audioCodec.encode(sampleBuffer)
-            Task {
+            Task.discarding {
                 let header = BroadcastIPCHeader.audio(metadata)
                 try await channel.send(header: header, payload: audioData)
             }

--- a/Sources/LiveKit/Extensions/AVAudioNode.swift
+++ b/Sources/LiveKit/Extensions/AVAudioNode.swift
@@ -24,13 +24,16 @@ extension AVAudioNode {
     /// The underlying audio unit's `maximumFramesToRender`.
     ///
     /// The Xcode 27 SDK restricts `auAudioUnit` to macOS 13.0 and deprecates it in favor of
-    /// `withAUAudioUnit`, so that is used where available; older OSes fall back to ``LKObjCHelpers``,
-    /// which keeps the property's original Objective-C availability (macOS 10.13). See #1035.
+    /// `withAUAudioUnit`, so this prefers `withAUAudioUnit` on OS 27+, uses the `auAudioUnit` property
+    /// on macOS 13–26, and falls back to ``LKObjCHelpers`` (original ObjC availability, macOS 10.13)
+    /// below macOS 13. See #1035.
     var maximumFramesToRender: AUAudioFrameCount {
         get {
             #if compiler(>=6.4)
             if #available(macOS 27.0, iOS 27.0, tvOS 27.0, visionOS 27.0, *) {
                 return withAUAudioUnit { $0.maximumFramesToRender }
+            } else if #available(macOS 13.0, *) {
+                return auAudioUnit.maximumFramesToRender
             } else {
                 return LKObjCHelpers.maximumFramesToRender(for: self)
             }
@@ -42,6 +45,8 @@ extension AVAudioNode {
             #if compiler(>=6.4)
             if #available(macOS 27.0, iOS 27.0, tvOS 27.0, visionOS 27.0, *) {
                 withAUAudioUnit { $0.maximumFramesToRender = newValue }
+            } else if #available(macOS 13.0, *) {
+                auAudioUnit.maximumFramesToRender = newValue
             } else {
                 LKObjCHelpers.setMaximumFramesToRender(newValue, for: self)
             }

--- a/Sources/LiveKit/Extensions/AVAudioNode.swift
+++ b/Sources/LiveKit/Extensions/AVAudioNode.swift
@@ -16,17 +16,38 @@
 
 import AVFAudio
 
-#if !COCOAPODS
+#if compiler(>=6.4) && !COCOAPODS
 internal import LKObjCHelpers
 #endif
 
 extension AVAudioNode {
     /// The underlying audio unit's `maximumFramesToRender`.
     ///
-    /// Routed through ``LKObjCHelpers`` so it stays reachable across SDK versions: the macOS 27 SDK's
-    /// Swift overlay bumped `auAudioUnit` to macOS 13.0, but the Objective-C property is still macOS 10.13.
+    /// The Xcode 27 SDK restricts `auAudioUnit` to macOS 13.0 and deprecates it in favor of
+    /// `withAUAudioUnit`, so that is used where available; older OSes fall back to ``LKObjCHelpers``,
+    /// which keeps the property's original Objective-C availability (macOS 10.13). See #1035.
     var maximumFramesToRender: AUAudioFrameCount {
-        get { LKObjCHelpers.maximumFramesToRender(for: self) }
-        set { LKObjCHelpers.setMaximumFramesToRender(newValue, for: self) }
+        get {
+            #if compiler(>=6.4)
+            if #available(macOS 27.0, iOS 27.0, tvOS 27.0, visionOS 27.0, *) {
+                return withAUAudioUnit { $0.maximumFramesToRender }
+            } else {
+                return LKObjCHelpers.maximumFramesToRender(for: self)
+            }
+            #else
+            return auAudioUnit.maximumFramesToRender
+            #endif
+        }
+        set {
+            #if compiler(>=6.4)
+            if #available(macOS 27.0, iOS 27.0, tvOS 27.0, visionOS 27.0, *) {
+                withAUAudioUnit { $0.maximumFramesToRender = newValue }
+            } else {
+                LKObjCHelpers.setMaximumFramesToRender(newValue, for: self)
+            }
+            #else
+            auAudioUnit.maximumFramesToRender = newValue
+            #endif
+        }
     }
 }

--- a/Sources/LiveKit/Extensions/AVAudioNode.swift
+++ b/Sources/LiveKit/Extensions/AVAudioNode.swift
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import AVFAudio
+
+#if !COCOAPODS
+internal import LKObjCHelpers
+#endif
+
+extension AVAudioNode {
+    /// The underlying audio unit's `maximumFramesToRender`.
+    ///
+    /// Routed through ``LKObjCHelpers`` so it stays reachable across SDK versions: the macOS 27 SDK's
+    /// Swift overlay bumped `auAudioUnit` to macOS 13.0, but the Objective-C property is still macOS 10.13.
+    var maximumFramesToRender: AUAudioFrameCount {
+        get { LKObjCHelpers.maximumFramesToRender(for: self) }
+        set { LKObjCHelpers.setMaximumFramesToRender(newValue, for: self) }
+    }
+}

--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -96,7 +96,12 @@ class Utils: Loggable {
         }
         return identifier
         #elseif os(macOS)
-        let service = IOServiceGetMatchingService(kIOMasterPortDefault,
+        let mainPort: mach_port_t = if #available(macOS 12.0, *) {
+            kIOMainPortDefault
+        } else {
+            0 // kIOMainPortDefault (macOS 12+) is a synonym for the NULL default port
+        }
+        let service = IOServiceGetMatchingService(mainPort,
                                                   IOServiceMatching("IOPlatformExpertDevice"))
         defer { IOObjectRelease(service) }
 

--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -25,6 +25,10 @@ import ScreenCaptureKit
 
 internal import LiveKitWebRTC
 
+#if compiler(>=6.4) && !COCOAPODS
+internal import LKObjCHelpers
+#endif
+
 #if os(macOS)
 
 @available(macOS 12.3, *)
@@ -89,8 +93,14 @@ public class MacOSScreenCapturer: VideoCapturer, @unchecked Sendable {
 
         let mainDisplay = CGMainDisplayID()
         // try to capture in max resolution
+        #if compiler(>=6.4)
+        LKObjCHelpers.setWidth(CGDisplayPixelsWide(mainDisplay) * 2,
+                               height: CGDisplayPixelsHigh(mainDisplay) * 2,
+                               on: configuration)
+        #else
         configuration.width = CGDisplayPixelsWide(mainDisplay) * 2
         configuration.height = CGDisplayPixelsHigh(mainDisplay) * 2
+        #endif
 
         configuration.scalesToFit = false
         configuration.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(options.fps))


### PR DESCRIPTION
## Summary

Fixes the Xcode 27 beta (macOS 27 / iOS 27 SDK) build failures reported in #1035 and #1037. Behavior is preserved on every OS and toolchain — there is no macOS 12.x regression.

## Root cause

These are SDK-side annotation changes that only the Swift importer enforces as hard errors — the underlying APIs still exist on the OS versions they always shipped in:

- **#1035 — `AVAudioNode.auAudioUnit`**: gained `NS_REFINED_FOR_SWIFT`; its new Swift overlay is `introduced: macOS 13.0, deprecated: 27.0` (in favor of `withAUAudioUnit`). The Objective-C property is still `macos(10.13)`.
- **#1035 — `SCStreamConfiguration.width`/`height`**: re-annotated from the class-inherited `macos(12.3)` to an explicit `macos(13.0)` when Apple extended ScreenCaptureKit to iOS/tvOS 27.
- **#1037 — `RPBroadcastSampleHandler`**: deprecated in the iOS 27 SDK (`ios(10.0, 27.0)`). Xcode 27 builds the `LKObjCHelpers` `.pcm` with `-clang-target …ios27.0`, so the deprecation fires and `-Werror` fails the module. (Requires that clang-target + "treat warnings as errors", which is why it doesn't reproduce on a default build.)

## Changes

- **Audio (`auAudioUnit`):** new `AVAudioNode.maximumFramesToRender` extension that centralizes access; call sites (`PlayerNodePool`, `SoundPlayer`, `MixerEngineObserver`) just use `node.maximumFramesToRender`. It resolves per toolchain/OS:
  - Xcode 26 (`compiler < 6.4`): the `auAudioUnit` property directly — unchanged.
  - Xcode 27, OS 27+: `withAUAudioUnit { … }`, the non-deprecated replacement Apple points to.
  - Xcode 27, macOS 13–26: the `auAudioUnit` property (available and not yet deprecated there).
  - Xcode 27, below macOS 13: `LKObjCHelpers`, where the original ObjC availability (`macos(10.13)`) still applies — so full behavior is preserved with no regression.
- **Screen capture (`width`/`height`):** `#if compiler(>=6.4)` → `LKObjCHelpers.setWidth(…)` (Xcode 27, preserves full capture resolution on macOS 12.x); `#else` → native `configuration.width/height` (Xcode 26 stays idiomatic).
- **#1037:** `-Wdeprecated-declarations` pragma around the `finishBroadcastWithoutError:` declaration so the precompiled module emits.
- **Reverts the macOS exclusion from #1034** (ae0d2fb): `maximumFramesToRender` matching runs on macOS again via the extension, so the `#if os(iOS) || os(visionOS) || os(tvOS)` once more wraps only the iOS audio-session logging.
- **Build warnings:** silenced pre-existing warnings the newer toolchain/SDK surfaces — `BroadcastUploader`'s bare `Task { try await … }` → `Task.discarding`; the retroactive `AudioStreamBasicDescription: Codable` conformance qualified as `Swift.Codable` (matching the `Sendable.swift` convention); and `kIOMasterPortDefault` → guarded `kIOMainPortDefault` in `Utils`. The build is now warning-free apart from the unrelated `E2EEOptions` deprecation.

Note: `#if compiler(>=6.4)` (toolchain version), not `#if swift(>=6.4)` (language version) — the latter is false under CocoaPods (`swift_versions ["5.9"]`) on Xcode 27 and would take the wrong path.

## Testing

Built locally against Xcode 27 beta (27A5194q, Swift 6.4) and Xcode 26.5 (Swift 6.3.2):

- Xcode 27: macOS, iOS, tvOS, Mac Catalyst, visionOS — ✅
- Xcode 26.5: macOS, iOS — ✅
- 0 non-deprecation warnings on every platform/toolchain; swiftformat clean

Closes #1035
Closes #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)
