### PR TITLE
Fix Swift snapshot build: don't reference withAUAudioUnit

### DIFF
--- a/Sources/LiveKit/Extensions/AVAudioNode.swift
+++ b/Sources/LiveKit/Extensions/AVAudioNode.swift
@@ -23,16 +23,13 @@ internal import LKObjCHelpers
 extension AVAudioNode {
     /// The underlying audio unit's `maximumFramesToRender`.
     ///
-    /// The Xcode 27 SDK restricts `auAudioUnit` to macOS 13.0 and deprecates it in favor of
-    /// `withAUAudioUnit`, so this prefers `withAUAudioUnit` on OS 27+, uses the `auAudioUnit` property
-    /// on macOS 13–26, and falls back to ``LKObjCHelpers`` (original ObjC availability, macOS 10.13)
-    /// below macOS 13. See #1035.
+    /// The macOS 27 SDK restricts `auAudioUnit` to macOS 13.0; below that it's reached through
+    /// ``LKObjCHelpers``, which keeps the property's original Objective-C availability (macOS 10.13).
+    /// See #1035.
     var maximumFramesToRender: AUAudioFrameCount {
         get {
             #if compiler(>=6.4)
-            if #available(macOS 27.0, iOS 27.0, tvOS 27.0, visionOS 27.0, *) {
-                return withAUAudioUnit { $0.maximumFramesToRender }
-            } else if #available(macOS 13.0, *) {
+            if #available(macOS 13.0, *) {
                 return auAudioUnit.maximumFramesToRender
             } else {
                 return LKObjCHelpers.maximumFramesToRender(for: self)
@@ -43,9 +40,7 @@ extension AVAudioNode {
         }
         set {
             #if compiler(>=6.4)
-            if #available(macOS 27.0, iOS 27.0, tvOS 27.0, visionOS 27.0, *) {
-                withAUAudioUnit { $0.maximumFramesToRender = newValue }
-            } else if #available(macOS 13.0, *) {
+            if #available(macOS 13.0, *) {
                 auAudioUnit.maximumFramesToRender = newValue
             } else {
                 LKObjCHelpers.setMaximumFramesToRender(newValue, for: self)


### PR DESCRIPTION
## Summary

Follow-up to #1038. The nightly **Swift Snapshot Build** (`.github/workflows/swift-snapshot.yaml`) fails on `main` after #1038:

```
Sources/LiveKit/Extensions/AVAudioNode.swift:34:24: error: cannot find 'withAUAudioUnit' in scope
```

## Root cause

That workflow runs `swift build` with the **main-snapshot** compiler (so `#if compiler(>=6.4)` is true) but against the runner's **current stable SDK** (macOS 26 — `latest` Xcode, since 27 is still beta). `withAUAudioUnit` only exists in the **macOS 27 SDK**, so the `compiler(>=6.4)` branch compiles the symbol in, but the SDK doesn't have it.

The deeper issue: `#if compiler(>=6.4)` is a *compiler* check used as an *SDK* proxy. That holds for shipping Xcode (compiler and SDK ship together) but not for the snapshot toolchain (new compiler + stable SDK). There's no reliable compile-time SDK/API-presence check in Swift — `canImport(AVFAudio, _version:)` reports the same version in both SDKs, and keying off a new-in-27 framework would be fragile.

## Fix

Drop `withAUAudioUnit` and reach `auAudioUnit` — which exists on **every** SDK (only its Swift availability annotation differs) — under `if #available(macOS 13.0)`, falling back to `LKObjCHelpers` below macOS 13. `#if compiler(>=6.4)` is kept so older toolchains (Xcode 16.4 / 26.5) use the property directly with no ObjC shim down to macOS 10.13.

This compiles on every compiler/SDK combination, including the snapshot's newer-compiler + macOS 26 SDK.

## Testing

- `swift build --build-system native` with the Xcode 27 compiler **+ macОS 26 SDK** (reproduces the snapshot combo): **Build complete** ✅ (was: `cannot find 'withAUAudioUnit'`).
- Xcode 27 (macOS/iOS) and Xcode 26.5 (macOS) builds: ✅
- swiftformat clean.

No user-facing behavior change (the `auAudioUnit` access is functionally identical), so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
