### PR TITLE
Benchmarks: disable jemalloc trait to fix SIGSEGV on macOS 26

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -10,7 +10,8 @@ let package = Package(
     dependencies: [
         .package(name: "client-sdk-swift", path: "../"),
         .package(url: "https://github.com/livekit/livekit-uniffi-xcframework.git", from: "0.0.1"),
-        .package(url: "https://github.com/ordo-one/benchmark.git", from: "1.29.0"),
+        // No Jemalloc trait: jemalloc's malloc-zone hooks crash on macOS 26 (malloc metrics read 0 without it)
+        .package(url: "https://github.com/ordo-one/benchmark.git", from: "1.29.0", traits: []),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
The nightly benchmark crash (SIGSEGV in the first benchmark since Jun 10) is jemalloc's malloc-zone hooks freeing a foreign pointer during CoreFoundation's one-time locale init, triggered by the webrtc-xcframework 144.7559.08 bump (bisected: last-good SDK commit + `.07` passes, same commit with only the pin flipped to `.08` crashes). Disabling package-benchmark's Jemalloc trait removes the malloc-zone interposition entirely — malloc metrics read 0, all other metrics unaffected; full suite verified locally at main + `.08`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)