### PR TITLE
Wrap ObjC auto-async calls in explicit checked continuations

### DIFF
--- a/.changes/objc-async-checked-continuation
+++ b/.changes/objc-async-checked-continuation
@@ -1,0 +1,1 @@
+patch type="fixed" "Wrap ObjC completion-handler async calls in explicit checked continuations (fixes mixed Swift 5/6 continuation-bridge EXC_BAD_ACCESS)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,7 @@ private static let playAndRecordOptions: AVAudioSession.CategoryOptions = [.mixW
 - Only `Task.discarding` preserves caller actor isolation in its closure; other `Support/Async/` helpers (`Task.retrying`, `AsyncSerialDelegate.notifyAsync`, etc.) run their bodies nonisolated — hop explicitly with `await MainActor.run { ... }` when UI-bound work is needed
 - Use async primitives in `Support/Async` and `Support/Schedulers` when operation order matters
 - Prefer native Swift async/await over `Combine` for new code
+- Until the minimum supported compiler is Swift 6.3, wrap calls to imported Objective-C completion-handler methods made via their synthesized `async` overload in an explicit `withCheckedThrowingContinuation`, since the bare auto-bridge hits a mixed Swift 5/6 thunk-coalescing crash (swiftlang/swift#81846) fixed in 6.3
 
 ### Error Handling
 

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -68,7 +68,12 @@ actor Transport: NSObject, Loggable {
         guard let self else { return }
 
         do {
-            try await _pc.add(iceCandidate.toRTCType())
+            let rtcCandidate = iceCandidate.toRTCType()
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                _pc.add(rtcCandidate) { error in
+                    if let error { continuation.resume(throwing: error) } else { continuation.resume() }
+                }
+            }
         } catch {
             log("Failed to add(iceCandidate:) with error: \(error)", .error)
         }

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -70,7 +70,7 @@ actor Transport: NSObject, Loggable {
         do {
             let rtcCandidate = iceCandidate.toRTCType()
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                _pc.add(rtcCandidate) { error in
+                self._pc.add(rtcCandidate) { error in
                     if let error { continuation.resume(throwing: error) } else { continuation.resume() }
                 }
             }

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -309,7 +309,11 @@ public class CameraCapturer: VideoCapturer, @unchecked Sendable {
         // Already stopped
         guard didStop else { return false }
 
-        await capturer.stopCapture()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            capturer.stopCapture {
+                continuation.resume()
+            }
+        }
 
         // Update internal vars
         set(dimensions: nil)

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -285,7 +285,11 @@ public class CameraCapturer: VideoCapturer, @unchecked Sendable {
 
         log("starting camera capturer device: \(device), format: \(selectedFormat), fps: \(selectedFps)(\(fpsRange))", .info)
 
-        try await capturer.startCapture(with: device, format: selectedFormat.format, fps: selectedFps)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            capturer.startCapture(with: device, format: selectedFormat.format, fps: selectedFps) { error in
+                if let error { continuation.resume(throwing: error) } else { continuation.resume() }
+            }
+        }
 
         // Update internal vars
         _cameraCapturerState.mutate {

--- a/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
@@ -39,11 +39,15 @@ public class InAppScreenCapturer: VideoCapturer, @unchecked Sendable {
         guard didStart else { return false }
 
         // TODO: force pixel format kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
-        try await RPScreenRecorder.shared().startCapture { [weak self] sampleBuffer, type, _ in
-            guard let self else { return }
-            // Only process .video
-            if type == .video {
-                capture(sampleBuffer: sampleBuffer, capturer: capturer, options: options)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            RPScreenRecorder.shared().startCapture { [weak self] sampleBuffer, type, _ in
+                guard let self else { return }
+                // Only process .video
+                if type == .video {
+                    capture(sampleBuffer: sampleBuffer, capturer: capturer, options: options)
+                }
+            } completionHandler: { error in
+                if let error { continuation.resume(throwing: error) } else { continuation.resume() }
             }
         }
 

--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -118,7 +118,11 @@ public class MacOSScreenCapturer: VideoCapturer, @unchecked Sendable {
         if #available(macOS 13.0, *) {
             try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: nil)
         }
-        try await stream.startCapture()
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            stream.startCapture { error in
+                if let error { continuation.resume(throwing: error) } else { continuation.resume() }
+            }
+        }
 
         _screenCapturerState.mutate { $0.scStream = stream }
 
@@ -140,7 +144,11 @@ public class MacOSScreenCapturer: VideoCapturer, @unchecked Sendable {
             $0.resendTimer = nil
         }
 
-        try await stream.stopCapture()
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            stream.stopCapture { error in
+                if let error { continuation.resume(throwing: error) } else { continuation.resume() }
+            }
+        }
         try stream.removeStreamOutput(self, type: .screen)
 
         _screenCapturerState.mutate {
@@ -449,7 +457,17 @@ public extension MacOSScreenCapturer {
     /// Enumerate ``MacOSDisplay`` or ``MacOSWindow`` sources.
     @objc
     static func sources(for type: MacOSScreenShareSourceType, includeCurrentApplication: Bool = false) async throws -> [MacOSScreenCaptureSource] {
-        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+        let content = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<SCShareableContent, Error>) in
+            SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: true) { content, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let content {
+                    continuation.resume(returning: content)
+                } else {
+                    continuation.resume(throwing: LiveKitError(.invalidState, message: "SCShareableContent unavailable"))
+                }
+            }
+        }
         let displays = content.displays.map { MacOSDisplay(from: $0, content: content) }
         let windows = content.windows
             // remove windows from this app

--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -118,11 +118,7 @@ public class MacOSScreenCapturer: VideoCapturer, @unchecked Sendable {
         if #available(macOS 13.0, *) {
             try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: nil)
         }
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            stream.startCapture { error in
-                if let error { continuation.resume(throwing: error) } else { continuation.resume() }
-            }
-        }
+        try await stream.startCapture()
 
         _screenCapturerState.mutate { $0.scStream = stream }
 
@@ -144,11 +140,7 @@ public class MacOSScreenCapturer: VideoCapturer, @unchecked Sendable {
             $0.resendTimer = nil
         }
 
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            stream.stopCapture { error in
-                if let error { continuation.resume(throwing: error) } else { continuation.resume() }
-            }
-        }
+        try await stream.stopCapture()
         try stream.removeStreamOutput(self, type: .screen)
 
         _screenCapturerState.mutate {

--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -457,17 +457,7 @@ public extension MacOSScreenCapturer {
     /// Enumerate ``MacOSDisplay`` or ``MacOSWindow`` sources.
     @objc
     static func sources(for type: MacOSScreenShareSourceType, includeCurrentApplication: Bool = false) async throws -> [MacOSScreenCaptureSource] {
-        let content = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<SCShareableContent, Error>) in
-            SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: true) { content, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else if let content {
-                    continuation.resume(returning: content)
-                } else {
-                    continuation.resume(throwing: LiveKitError(.invalidState, message: "SCShareableContent unavailable"))
-                }
-            }
-        }
+        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
         let displays = content.displays.map { MacOSDisplay(from: $0, content: content) }
         let windows = content.windows
             // remove windows from this app


### PR DESCRIPTION
## Summary

Wraps two compiler-synthesized ObjC *auto-async* calls in explicit `withCheckedThrowingContinuation`:

- `Transport._iceCandidatesQueue` → `_pc.add(iceCandidate.toRTCType())` (`addIceCandidate:completionHandler:`)
- `CameraCapturer.startCapture()` → `capturer.startCapture(with:format:fps:)` (`startCaptureWithDevice:format:fps:completionHandler:`)

Both now call the completion-handler API directly inside an explicit checked continuation, matching the pattern already used in this file for `setRemoteDescription` / `setLocalDescription` / `createOffer`.

## Motivation

When an app statically links/merges modules built in **mixed Swift language modes** (some Swift 5, some Swift 6), the compiler-generated *unsafe* continuation thunk for an imported ObjC completion-handler method is a signature-keyed shared symbol. The unsafe thunk emitted by a Swift-5 module can win symbol deduplication over the checked thunk this SDK (built in Swift 6) intends to use. At runtime the affected resume paths are silently downgraded to unsafe.

Under concurrent peer-connection negotiation, the downgraded unsafe continuation corrupts the Swift task allocator, surfacing as `EXC_BAD_ACCESS (SIGSEGV)`:

```
UnsafeContinuation.resume(returning:)
  ← @objc completion handler block (NSError?) -> ()
  ← LiveKitWebRTC
... StackAllocator::getSlabForAllocation / flagAsAndEnqueueOnExecutor
```

We hit this reliably on real devices (iOS 18 and iOS 26) on `connect` (addIceCandidate) and on enabling the camera (startCapture). The two sites here were the only remaining `_pc.`/`capturer.` calls going through the auto-async overload; every other peer-connection call in `Transport` already uses an explicit continuation, which is why those were unaffected.

## Why this fix

Calling the completion-handler API explicitly means the shared auto-async thunk is **never generated or referenced**, so there is no symbol for cross-module dedup to collapse. The resume stays checked regardless of how downstream modules are built — no behavior change for callers, just a safer continuation path.

## Testing

Verified on device (iPhone 12 / iOS 18, iPhone 17 Pro / iOS 26): connect succeeds and camera enables without the crash; previously both reproduced consistently.
