### PR TITLE
Request microphone permission in foreground before enabling recording.

### DIFF
--- a/.changes/mic-permission-foreground
+++ b/.changes/mic-permission-foreground
@@ -1,0 +1,1 @@
+patch type="fixed" "Request microphone permission in foreground before enabling recording (#815)"

--- a/Sources/LiveKit/LiveKit+DeviceHelpers.swift
+++ b/Sources/LiveKit/LiveKit+DeviceHelpers.swift
@@ -16,6 +16,10 @@
 
 import AVFoundation
 
+#if canImport(UIKit) && (os(iOS) || os(visionOS) || os(tvOS))
+import UIKit
+#endif
+
 public extension LiveKitSDK {
     /// Helper method to ensure authorization for video(camera) / audio(microphone) permissions in a single call.
     static func ensureDeviceAccess(for types: Set<AVMediaType>) async -> Bool {
@@ -39,6 +43,19 @@ public extension LiveKitSDK {
         }
 
         return true
+    }
+
+    /// Requests authorization for the given media types, but only while the app is foregrounded so
+    /// the system permission dialog can actually appear. A no-op returning `false` on non-active or
+    /// non-UIKit (extension/background) contexts. Suitable for paths that must never block, where
+    /// prompting only makes sense when the app can present UI.
+    static func ensureDeviceAccessIfForegrounded(for types: Set<AVMediaType>) async -> Bool {
+        #if canImport(UIKit) && (os(iOS) || os(visionOS) || os(tvOS))
+        guard await UIApplication.shared.applicationState == .active else { return false }
+        return await ensureDeviceAccess(for: types)
+        #else
+        return false
+        #endif
     }
 
     /// Blocking version of ensureDeviceAccess that uses DispatchGroup to wait for permissions.

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -16,6 +16,7 @@
 
 // swiftlint:disable file_length
 
+import AVFoundation
 import Combine
 import Foundation
 
@@ -387,6 +388,10 @@ public extension LocalParticipant {
                                                                        reportStatistics: room._state.roomOptions.reportRemoteTrackStatistics)
                     return try await self._publish(track: localTrack, options: publishOptions)
                 } else if source == .microphone {
+                    // Replace the WebRTC ADM's removed implicit prompt: request mic access while foregrounded (#815).
+                    if AVCaptureDevice.authorizationStatus(for: .audio) == .notDetermined {
+                        _ = await LiveKitSDK.ensureDeviceAccessIfForegrounded(for: [.audio])
+                    }
                     let localTrack = LocalAudioTrack.createTrack(options: (captureOptions as? AudioCaptureOptions) ?? room._state.roomOptions.defaultAudioCaptureOptions,
                                                                  reportStatistics: room._state.roomOptions.reportRemoteTrackStatistics)
                     return try await self._publish(track: localTrack, options: publishOptions)


### PR DESCRIPTION
This is the SDK-side follow-up to **webrtc-sdk/webrtc#204**. That change makes the WebRTC Audio Device Module (ADM) stop implicitly requesting microphone permission — the blocking request that hangs a worker thread when the app is woken in the background (#815) — and replaces it with a passive authorized-check. With the ADM no longer prompting, the SDK now does it: `LocalParticipant` proactively requests access at its async mic-enable path, but only while the app is foregrounded so the system dialog can actually appear.
  
The two are meant to land together — #204 removes the hang, this PR restores the prompt.
  
## What changed
  
- **`LiveKit+DeviceHelpers.swift`** — new `LiveKitSDK.ensureDeviceAccessIfForegrounded(for:)`: requests access only when the app is `.active`, reusing the existing non-blocking `ensureDeviceAccess(for:)`. A no-op on non-active / non-UIKit contexts.
- **`LocalParticipant.set(source:enabled:)`** — in the `.microphone` create branch, before `LocalAudioTrack.createTrack(...)`:  
    
```swift
if AVCaptureDevice.authorizationStatus(for: .audio) == .notDetermined {
    _ = await LiveKitSDK.ensureDeviceAccessIfForegrounded(for: [.audio])
}
```
 
Only .notDetermined triggers a request; backgrounded/extension contexts never prompt; muting/unmuting an existing track is untouched. No change to existing API signatures.

Refs #815 (full fix together with webrtc-sdk/webrtc#204).