### PR TITLE
feat(audio): add AudioProcessingOptions

### DIFF
--- a/.changes/audio-processing-options
+++ b/.changes/audio-processing-options
@@ -1,0 +1,1 @@
+patch type="added" "Add AudioProcessingOptions"

--- a/.swiftformat
+++ b/.swiftformat
@@ -5,4 +5,5 @@
 --disable modifiersOnSameLine
 --disable wrapPropertyBodies
 --disable wrapFunctionBodies
+--disable wrapIfStatementBodies
 --disable docComments

--- a/.swiftformat
+++ b/.swiftformat
@@ -5,5 +5,4 @@
 --disable modifiersOnSameLine
 --disable wrapPropertyBodies
 --disable wrapFunctionBodies
---disable wrapIfStatementBodies
 --disable docComments

--- a/Docs/audio.md
+++ b/Docs/audio.md
@@ -46,6 +46,68 @@ AudioManager.shared.audioSession.isAutomaticDeactivationEnabled = false
 
 When set to `false`, the audio session remains active after the LiveKit call ends, preserving your app's audio state.
 
+## Audio Processing Modes (software, platform, automatic)
+
+Each audio processing effect (echo cancellation, noise suppression, auto gain control, and high-pass filter) can run in one of two ways. It can use Apple's platform Voice Processing I/O on the device, or WebRTC's software processing. You choose per effect with an `AudioProcessingMode`:
+
+- `.automatic` (default): prefer platform voice processing when available, and fall back to WebRTC software processing otherwise.
+- `.platform`: use platform voice processing only. If the platform implementation is unavailable, the request is rejected.
+- `.software`: force WebRTC software processing and disable the matching platform effect when possible.
+
+Configure the modes when you publish the microphone:
+
+```swift
+let options = AudioCaptureOptions(
+    echoCancellation: true,
+    autoGainControl: true,
+    noiseSuppression: true,
+    highpassFilter: true,
+    echoCancellationMode: .software,
+    autoGainControlMode: .software,
+    noiseSuppressionMode: .software,
+    highPassFilterMode: .software
+)
+try await room.localParticipant.setMicrophone(enabled: true, captureOptions: options)
+```
+
+You can also set them as the room default, so they apply whenever the mic is published:
+
+```swift
+let room = Room()
+try await room.connect(url: url, token: token,
+                       roomOptions: RoomOptions(defaultAudioCaptureOptions: options))
+```
+
+To change the modes at runtime on an already-published track, use `setAudioProcessingOptions`:
+
+```swift
+let result = try localAudioTrack.setAudioProcessingOptions(
+    AudioProcessingOptions(
+        echoCancellation: true,
+        autoGainControl: true,
+        noiseSuppression: true,
+        highPassFilter: true,
+        echoCancellationMode: .software,
+        autoGainControlMode: .software,
+        noiseSuppressionMode: .software,
+        highPassFilterMode: .software
+    )
+)
+print(result.code) // .applied or .stored on success
+```
+
+To confirm which implementation each effect resolved to, read the engine-wide state:
+
+```swift
+let state = AudioManager.shared.audioProcessingState
+print(state.echoCancellation.effective) // Software
+print(state.noiseSuppression.effective)  // Software
+```
+
+> **NOTE**: There is no platform high-pass filter, so `.platform` is rejected for `highPassFilterMode`. Use `.software` instead.
+
+To guarantee Apple Voice Processing I/O is never used at all, for example to keep hardware volume consistent or to allow screen recording with audio, also disallow platform voice processing as described below.
+
 ## Disallowing Platform Voice Processing
 
 Apple's platform voice processing is allowed by default, such as echo cancellation and auto-gain control.

--- a/Docs/audio.md
+++ b/Docs/audio.md
@@ -46,25 +46,25 @@ AudioManager.shared.audioSession.isAutomaticDeactivationEnabled = false
 
 When set to `false`, the audio session remains active after the LiveKit call ends, preserving your app's audio state.
 
-## Disabling Voice Processing
+## Disallowing Platform Voice Processing
 
-Apple's voice processing is enabled by default, such as echo cancellation and auto-gain control.
+Apple's platform voice processing is allowed by default, such as echo cancellation and auto-gain control.
 
-If your app doesn't require voice processing at all, you can disable it entirely:
+If your app must not use Apple Voice Processing I/O, disable voice processing:
 
 ```swift
 try AudioManager.shared.setVoiceProcessingEnabled(false)
 ```
 
-This restarts the internal `AVAudioEngine` to apply the change. It can cause a short audio glitch, so it is recommended to set it once before connecting to a Room. Disabling voice processing also disables muted speaker detection.
+This restarts the internal `AVAudioEngine` when an Apple VPIO path is active. It is recommended to set it once before connecting to a Room. Runtime `AudioProcessingOptions` with `automatic` mode will fall back to WebRTC software processing while platform voice processing is disallowed.
 
-If your app requires toggling voice processing at run-time, it is recommended to use:
+For per-track or per-capture software processing, use `AudioProcessingOptions` with `.software` modes. The lower-level bypass API remains available when you need to directly control Apple VPIO:
 
 ```swift
 AudioManager.shared.isVoiceProcessingBypassed = true
 ```
 
-Set it back to `false` to re-enable processing. This uses `AVAudioEngine`'s [isVoiceProcessingBypassed](https://developer.apple.com/documentation/avfaudio/avaudioinputnode/isvoiceprocessingbypassed) and works seamlessly at run-time.
+Set it back to `false` to re-enable the Apple path. This uses `AVAudioEngine`'s [isVoiceProcessingBypassed](https://developer.apple.com/documentation/avfaudio/avaudioinputnode/isvoiceprocessingbypassed). Runtime `AudioProcessingOptions` can overwrite this Apple-specific state when capture starts or options are reapplied.
 
 ## Other audio ducking
 

--- a/Docs/audio.md
+++ b/Docs/audio.md
@@ -65,7 +65,7 @@ let options = AudioCaptureOptions(
     echoCancellationMode: .software,
     autoGainControlMode: .software,
     noiseSuppressionMode: .software,
-    highPassFilterMode: .software
+    highpassFilterMode: .software
 )
 try await room.localParticipant.setMicrophone(enabled: true, captureOptions: options)
 ```
@@ -86,11 +86,11 @@ let result = try localAudioTrack.setAudioProcessingOptions(
         echoCancellation: true,
         autoGainControl: true,
         noiseSuppression: true,
-        highPassFilter: true,
+        highpassFilter: true,
         echoCancellationMode: .software,
         autoGainControlMode: .software,
         noiseSuppressionMode: .software,
-        highPassFilterMode: .software
+        highpassFilterMode: .software
     )
 )
 print(result.code) // .applied or .stored on success
@@ -104,7 +104,7 @@ print(state.echoCancellation.effective) // Software
 print(state.noiseSuppression.effective)  // Software
 ```
 
-> **NOTE**: There is no platform high-pass filter, so `.platform` is rejected for `highPassFilterMode`. Use `.software` instead.
+> **NOTE**: There is no platform high-pass filter, so `.platform` is rejected for `highpassFilterMode`. Use `.software` instead.
 
 To guarantee Apple Voice Processing I/O is never used at all, for example to keep hardware volume consistent or to allow screen recording with audio, also disallow platform voice processing as described below.
 

--- a/Docs/audio.md
+++ b/Docs/audio.md
@@ -50,10 +50,10 @@ When set to `false`, the audio session remains active after the LiveKit call end
 
 Apple's platform voice processing is allowed by default, such as echo cancellation and auto-gain control.
 
-If your app must not use Apple Voice Processing I/O, disable voice processing:
+If your app must not use Apple Voice Processing I/O, disallow platform voice processing:
 
 ```swift
-try AudioManager.shared.setVoiceProcessingEnabled(false)
+try AudioManager.shared.setPlatformVoiceProcessingAllowed(false)
 ```
 
 This restarts the internal `AVAudioEngine` when an Apple VPIO path is active. It is recommended to set it once before connecting to a Room. Runtime `AudioProcessingOptions` with `automatic` mode will fall back to WebRTC software processing while platform voice processing is disallowed.

--- a/Docs/audio.md
+++ b/Docs/audio.md
@@ -48,7 +48,7 @@ When set to `false`, the audio session remains active after the LiveKit call end
 
 ## Audio Processing Modes (software, platform, automatic)
 
-Each audio processing effect (echo cancellation, noise suppression, auto gain control, and high-pass filter) can run in one of two ways. It can use Apple's platform Voice Processing I/O on the device, or WebRTC's software processing. You choose per effect with an `AudioProcessingMode`:
+Each audio processing effect has its own mode type: `EchoCancellationMode`, `NoiseSuppressionMode`, `AutoGainControlMode`, and `HighpassFilterMode`. Echo cancellation, noise suppression, and auto gain control can use Apple's platform Voice Processing I/O or WebRTC's software processing:
 
 - `.automatic` (default): prefer platform voice processing when available, and fall back to WebRTC software processing otherwise.
 - `.platform`: use platform voice processing only. If the platform implementation is unavailable, the request is rejected.
@@ -93,8 +93,10 @@ let result = try localAudioTrack.setAudioProcessingOptions(
         highpassFilterMode: .software
     )
 )
-print(result.code) // .applied or .stored on success
+print(result) // .applied, or .stored when no sender is active yet
 ```
+
+On failure this throws `AudioProcessingOptionsError`, whose `code` describes the reason — for example `.platformUnavailable` when a `.platform` mode was requested but Apple Voice Processing I/O is unavailable.
 
 To confirm which implementation each effect resolved to, read the engine-wide state:
 
@@ -104,7 +106,9 @@ print(state.echoCancellation.effective) // Software
 print(state.noiseSuppression.effective)  // Software
 ```
 
-> **NOTE**: There is no platform high-pass filter, so `.platform` is rejected for `highpassFilterMode`. Use `.software` instead.
+Each component also exposes the most recent `requested` options and per-path detail: `software` and `platform` carry resolved/active flags, with `platform` being `nil` on devices without a built-in implementation. Device-level Apple Voice Processing I/O state is available separately through `AudioManager.shared.platformVoiceProcessingState`.
+
+> **NOTE**: There is no platform high-pass filter, so `HighpassFilterMode` only provides `.automatic` and `.software`.
 
 To guarantee Apple Voice Processing I/O is never used at all, for example to keep hardware volume consistent or to allow screen recording with audio, also disallow platform voice processing as described below.
 

--- a/Sources/LiveKit/Audio/Manager/AudioManager.swift
+++ b/Sources/LiveKit/Audio/Manager/AudioManager.swift
@@ -375,7 +375,7 @@ public class AudioManager: Loggable {
     }
 
     /// Device-level platform voice-processing capability and requested/active state.
-    public var platformAudioProcessingState: PlatformAudioProcessingState {
+    public var platformVoiceProcessingState: PlatformVoiceProcessingState {
         RTC.audioDeviceModule.platformAudioProcessingState.toLKType()
     }
 

--- a/Sources/LiveKit/Audio/Manager/AudioManager.swift
+++ b/Sources/LiveKit/Audio/Manager/AudioManager.swift
@@ -329,11 +329,19 @@ public class AudioManager: Loggable {
     /// Use ``AudioProcessingOptions`` with `.software` modes for per-track or
     /// per-capture software voice processing. Use this policy when the app must
     /// guarantee Apple Voice Processing I/O is not used.
-    public var isVoiceProcessingEnabled: Bool { RTC.audioDeviceModule.isPlatformVoiceProcessingAllowed }
+    public var isPlatformVoiceProcessingAllowed: Bool { RTC.audioDeviceModule.isPlatformVoiceProcessingAllowed }
 
-    public func setVoiceProcessingEnabled(_ enabled: Bool) throws {
-        let result = RTC.audioDeviceModule.setPlatformVoiceProcessingAllowed(enabled)
+    public func setPlatformVoiceProcessingAllowed(_ allowed: Bool) throws {
+        let result = RTC.audioDeviceModule.setPlatformVoiceProcessingAllowed(allowed)
         try checkAdmResult(code: result)
+    }
+
+    @available(*, deprecated, renamed: "isPlatformVoiceProcessingAllowed")
+    public var isVoiceProcessingEnabled: Bool { isPlatformVoiceProcessingAllowed }
+
+    @available(*, deprecated, renamed: "setPlatformVoiceProcessingAllowed(_:)")
+    public func setVoiceProcessingEnabled(_ enabled: Bool) throws {
+        try setPlatformVoiceProcessingAllowed(enabled)
     }
 
     /// Bypass Voice-Processing I/O of internal AVAudioEngine.

--- a/Sources/LiveKit/Audio/Manager/AudioManager.swift
+++ b/Sources/LiveKit/Audio/Manager/AudioManager.swift
@@ -320,10 +320,15 @@ public class AudioManager: Loggable {
         set { RTC.audioDeviceModule.duckingLevel = newValue.toRTCType() }
     }
 
-    /// The main flag that determines whether to enable Voice-Processing I/O of the internal AVAudioEngine. Toggling this requires restarting the AudioEngine.
-    /// Setting this to `false` prevents any voice-processing-related initialization, and muted talker detection will not work.
-    /// Typically, it is recommended to keep this set to `true` and toggle ``isVoiceProcessingBypassed`` when possible.
-    /// Defaults to `true`.
+    /// Whether Apple's platform voice processing is allowed.
+    ///
+    /// Defaults to `true`. When set to `false`, runtime ``AudioProcessingOptions``
+    /// treat Apple Voice Processing I/O as unavailable. `automatic` mode falls
+    /// back to WebRTC software processing and `platform` mode is rejected.
+    ///
+    /// Use ``AudioProcessingOptions`` with `.software` modes for per-track or
+    /// per-capture software voice processing. Use this policy when the app must
+    /// guarantee Apple Voice Processing I/O is not used.
     public var isVoiceProcessingEnabled: Bool { RTC.audioDeviceModule.isPlatformVoiceProcessingAllowed }
 
     public func setVoiceProcessingEnabled(_ enabled: Bool) throws {
@@ -333,6 +338,8 @@ public class AudioManager: Loggable {
 
     /// Bypass Voice-Processing I/O of internal AVAudioEngine.
     /// It is valid to toggle this at runtime and AudioEngine doesn't require restart.
+    /// Runtime ``AudioProcessingOptions`` may overwrite this Apple-specific state
+    /// when capture starts or when local audio track options are reapplied.
     /// Defaults to `false`.
     public var isVoiceProcessingBypassed: Bool {
         get {
@@ -359,6 +366,21 @@ public class AudioManager: Loggable {
         set { RTC.audioDeviceModule.isVoiceProcessingAGCEnabled = newValue }
     }
 
+    /// Device-level platform voice-processing capability and requested/active state.
+    public var platformAudioProcessingState: PlatformAudioProcessingState {
+        RTC.audioDeviceModule.platformAudioProcessingState.toLKType()
+    }
+
+    /// Diagnostic snapshot of the resolved audio processing state.
+    ///
+    /// The audio processing module is owned by the peer connection factory and
+    /// shared engine-wide, so this reflects what is actually applied across the
+    /// engine rather than any single track or connection — use it to verify what
+    /// a ``LocalAudioTrack/setAudioProcessingOptions(_:)`` request resolved to.
+    public var audioProcessingState: AudioProcessingState {
+        RTC.audioProcessingState().toLKType()
+    }
+
     /// Enables manual rendering (no-device) mode of AVAudioEngine.
     /// In this mode, you can provide audio buffers by calling `AudioManager.shared.mixer.capture(appAudio:)` continuously.
     /// Remote audio will not play out automatically. Get remote mixed audio buffers with `AudioManager.shared.add(localAudioRenderer:)` or individual tracks with ``RemoteAudioTrack/add(audioRenderer:)``.
@@ -383,22 +405,31 @@ public class AudioManager: Loggable {
     /// which keeps recording initialized and pre-warms voice processing.
     ///
     /// - Parameter enabled: Pass `true` to enable always-prepared recording, or `false` to disable it.
+    /// - Parameter audioProcessingOptions: Optional voice-processing options used when prewarming mic input.
     /// - Note: If `audioSession.isAutomaticConfigurationEnabled` is `true`, the session category is configured to `.playAndRecord`.
     /// - Note: Microphone permission is required. iOS may prompt if not already granted.
     /// - Note: This persists across ``Room`` lifecycles and connections until disabled.
     /// - Throws: An error if the underlying audio device module fails to apply the setting.
-    public func setRecordingAlwaysPreparedMode(_ enabled: Bool) async throws {
-        let result = RTC.audioDeviceModule.setRecordingAlwaysPreparedMode(enabled)
+    public func setRecordingAlwaysPreparedMode(
+        _ enabled: Bool,
+        audioProcessingOptions: AudioProcessingOptions? = nil,
+    ) async throws {
+        let result = RTC.audioDeviceModule.setRecordingAlwaysPreparedMode(
+            enabled,
+            audioProcessingOptions: audioProcessingOptions?.toRTCType(),
+        )
         try checkAdmResult(code: result)
     }
 
     /// Starts mic input to the SDK even without any ``Room`` or a connection.
     /// Audio buffers will flow into ``LocalAudioTrack/add(audioRenderer:)`` and ``capturePostProcessingDelegate``.
-    public func startLocalRecording() throws {
+    public func startLocalRecording(audioProcessingOptions: AudioProcessingOptions? = nil) throws {
         // Always unmute APM if muted by last session.
         RTC.audioProcessingModule.isMuted = false // TODO: Possibly not required anymore with new libs
         // Start recording on the ADM.
-        let result = RTC.audioDeviceModule.initAndStartRecording()
+        let result = RTC.audioDeviceModule.initAndStartRecording(
+            audioProcessingOptions: audioProcessingOptions?.toRTCType(),
+        )
         try checkAdmResult(code: result)
     }
 

--- a/Sources/LiveKit/Core/RTC.swift
+++ b/Sources/LiveKit/Core/RTC.swift
@@ -83,6 +83,10 @@ actor RTC {
                                                                                 delegate: nil) }
     }
 
+    static func audioProcessingState() -> LKRTCAudioProcessingState {
+        DispatchQueue.liveKitWebRTC.sync { peerConnectionFactory.audioProcessingState }
+    }
+
     static func createVideoSource(forScreenShare: Bool) -> LKRTCVideoSource {
         DispatchQueue.liveKitWebRTC.sync { peerConnectionFactory.videoSource(forScreenCast: forScreenShare) }
     }

--- a/Sources/LiveKit/Core/RTC.swift
+++ b/Sources/LiveKit/Core/RTC.swift
@@ -83,8 +83,9 @@ actor RTC {
                                                                                 delegate: nil) }
     }
 
+    // Marshalled to the worker thread inside webrtc-sdk, safe to call directly.
     static func audioProcessingState() -> LKRTCAudioProcessingState {
-        DispatchQueue.liveKitWebRTC.sync { peerConnectionFactory.audioProcessingState }
+        peerConnectionFactory.audioProcessingState
     }
 
     static func createVideoSource(forScreenShare: Bool) -> LKRTCVideoSource {

--- a/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
@@ -99,15 +99,20 @@ public class LocalAudioTrack: Track, LocalTrackProtocol, AudioTrackProtocol, @un
     /// If this track is already published, WebRTC reapplies the updated options through
     /// the active sender. Effective APM configuration is shared by the WebRTC voice engine,
     /// so conflicting updates from multiple local audio tracks are last-writer-wins.
+    ///
+    /// - Returns: The result of applying or storing the options.
+    /// - Throws: ``AudioProcessingOptionsError`` when the options cannot be applied.
     @discardableResult
     public func setAudioProcessingOptions(_ options: AudioProcessingOptions) throws -> AudioProcessingOptionsResult {
         guard let audioTrack = mediaTrack as? LKRTCAudioTrack else {
-            throw LiveKitError(.invalidState, message: "Media track is not an audio track")
+            throw AudioProcessingOptionsError(
+                code: .applyFailed,
+                message: "Media track is not an audio track",
+            )
         }
         let result = audioTrack.setAudioProcessingOptions(options.toRTCType()).toLKType()
         guard result.isSuccess else {
-            let reason = result.message.isEmpty ? "\(result.code)" : "\(result.code): \(result.message)"
-            throw LiveKitError(.webRTC, message: "Failed to set audio processing options: \(reason)")
+            throw AudioProcessingOptionsError(result)
         }
         return result
     }

--- a/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
@@ -69,7 +69,7 @@ public class LocalAudioTrack: Track, LocalTrackProtocol, AudioTrackProtocol, @un
             "echoCancellationMode": options.echoCancellationMode.toConstraintValue(),
             "autoGainControlMode": options.autoGainControlMode.toConstraintValue(),
             "noiseSuppressionMode": options.noiseSuppressionMode.toConstraintValue(),
-            "highPassFilterMode": options.highPassFilterMode.toConstraintValue(),
+            "highPassFilterMode": options.highpassFilterMode.toConstraintValue(),
         ]
 
         let audioConstraints = DispatchQueue.liveKitWebRTC.sync { LKRTCMediaConstraints(mandatoryConstraints: nil,

--- a/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
@@ -66,6 +66,10 @@ public class LocalAudioTrack: Track, LocalTrackProtocol, AudioTrackProtocol, @un
             "googNoiseSuppression": options.noiseSuppression.toString(),
             "googTypingNoiseDetection": options.typingNoiseDetection.toString(),
             "googHighpassFilter": options.highpassFilter.toString(),
+            "echoCancellationMode": options.echoCancellationMode.toConstraintValue(),
+            "autoGainControlMode": options.autoGainControlMode.toConstraintValue(),
+            "noiseSuppressionMode": options.noiseSuppressionMode.toConstraintValue(),
+            "highPassFilterMode": options.highPassFilterMode.toConstraintValue(),
         ]
 
         let audioConstraints = DispatchQueue.liveKitWebRTC.sync { LKRTCMediaConstraints(mandatoryConstraints: nil,
@@ -90,12 +94,32 @@ public class LocalAudioTrack: Track, LocalTrackProtocol, AudioTrackProtocol, @un
         try await super._unmute()
     }
 
+    /// Updates this local track's voice processing options without restarting capture.
+    ///
+    /// If this track is already published, WebRTC reapplies the updated options through
+    /// the active sender. Effective APM configuration is shared by the WebRTC voice engine,
+    /// so conflicting updates from multiple local audio tracks are last-writer-wins.
+    @discardableResult
+    public func setAudioProcessingOptions(_ options: AudioProcessingOptions) throws -> AudioProcessingOptionsResult {
+        guard let audioTrack = mediaTrack as? LKRTCAudioTrack else {
+            throw LiveKitError(.invalidState, message: "Media track is not an audio track")
+        }
+        let result = audioTrack.setAudioProcessingOptions(options.toRTCType()).toLKType()
+        guard result.isSuccess else {
+            let reason = result.message.isEmpty ? "\(result.code)" : "\(result.code): \(result.message)"
+            throw LiveKitError(.webRTC, message: "Failed to set audio processing options: \(reason)")
+        }
+        return result
+    }
+
     // MARK: - Internal
 
     override func startCapture() async throws {
         // AudioDeviceModule's InitRecording() and StartRecording() automatically get called by WebRTC, but
         // explicitly init & start it early to detect audio engine failures (mic not accessible for some reason, etc.).
-        try AudioManager.shared.startLocalRecording()
+        try AudioManager.shared.startLocalRecording(
+            audioProcessingOptions: captureOptions.audioProcessingOptions,
+        )
     }
 
     override func stopCapture() async throws {

--- a/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
@@ -100,21 +100,17 @@ public class LocalAudioTrack: Track, LocalTrackProtocol, AudioTrackProtocol, @un
     /// the active sender. Effective APM configuration is shared by the WebRTC voice engine,
     /// so conflicting updates from multiple local audio tracks are last-writer-wins.
     ///
-    /// - Returns: The result of applying or storing the options.
+    /// - Returns: Whether the options were applied immediately or stored for reapplication.
     /// - Throws: ``AudioProcessingOptionsError`` when the options cannot be applied.
     @discardableResult
     public func setAudioProcessingOptions(_ options: AudioProcessingOptions) throws -> AudioProcessingOptionsResult {
         guard let audioTrack = mediaTrack as? LKRTCAudioTrack else {
             throw AudioProcessingOptionsError(
-                code: .applyFailed,
+                code: .invalidState,
                 message: "Media track is not an audio track",
             )
         }
-        let result = audioTrack.setAudioProcessingOptions(options.toRTCType()).toLKType()
-        guard result.isSuccess else {
-            throw AudioProcessingOptionsError(result)
-        }
-        return result
+        return try audioTrack.setAudioProcessingOptions(options.toRTCType()).toLKType()
     }
 
     // MARK: - Internal
@@ -123,7 +119,7 @@ public class LocalAudioTrack: Track, LocalTrackProtocol, AudioTrackProtocol, @un
         // AudioDeviceModule's InitRecording() and StartRecording() automatically get called by WebRTC, but
         // explicitly init & start it early to detect audio engine failures (mic not accessible for some reason, etc.).
         try AudioManager.shared.startLocalRecording(
-            audioProcessingOptions: captureOptions.audioProcessingOptions,
+            audioProcessingOptions: captureOptions.audioProcessing,
         )
     }
 

--- a/Sources/LiveKit/Types/AudioProcessingModes.swift
+++ b/Sources/LiveKit/Types/AudioProcessingModes.swift
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+internal import LiveKitWebRTC
+
+/// Selects the echo-cancellation implementation.
+public enum EchoCancellationMode: Hashable, Sendable {
+    /// Prefer platform voice processing when available and fall back to WebRTC software processing.
+    case automatic
+    /// Use platform voice processing only. If platform processing is unavailable, the request is rejected.
+    case platform
+    /// Force WebRTC software processing and disable the matching platform effect when possible.
+    case software
+}
+
+/// Selects the automatic-gain-control implementation.
+public enum AutoGainControlMode: Hashable, Sendable {
+    /// Prefer platform voice processing when available and fall back to WebRTC software processing.
+    case automatic
+    /// Use platform voice processing only. If platform processing is unavailable, the request is rejected.
+    case platform
+    /// Force WebRTC software processing and disable the matching platform effect when possible.
+    case software
+}
+
+/// Selects the noise-suppression implementation.
+public enum NoiseSuppressionMode: Hashable, Sendable {
+    /// Prefer platform voice processing when available and fall back to WebRTC software processing.
+    case automatic
+    /// Use platform voice processing only. If platform processing is unavailable, the request is rejected.
+    case platform
+    /// Force WebRTC software processing and disable the matching platform effect when possible.
+    case software
+}
+
+/// Selects the high-pass-filter implementation.
+public enum HighpassFilterMode: Hashable, Sendable {
+    /// Use WebRTC software processing when the filter is enabled.
+    case automatic
+    /// Force WebRTC software processing.
+    case software
+}
+
+protocol AudioProcessingModeConvertible: Sendable {
+    static var automatic: Self { get }
+    static var platformMode: Self? { get }
+    static var software: Self { get }
+
+    var rtcType: LKRTCAudioProcessingMode { get }
+}
+
+extension AudioProcessingModeConvertible {
+    func toRTCType() -> LKRTCAudioProcessingMode {
+        rtcType
+    }
+
+    func toConstraintValue() -> String {
+        switch toRTCType() {
+        case .automatic: "auto"
+        case .platform: "platform"
+        case .software: "software"
+        @unknown default: "auto"
+        }
+    }
+
+    static func fromRTCType(_ mode: LKRTCAudioProcessingMode) -> Self {
+        switch mode {
+        case .automatic: .automatic
+        case .platform: platformMode ?? .automatic
+        case .software: .software
+        @unknown default: .automatic
+        }
+    }
+}
+
+extension EchoCancellationMode: AudioProcessingModeConvertible {
+    static var platformMode: Self? { .platform }
+
+    var rtcType: LKRTCAudioProcessingMode {
+        switch self {
+        case .automatic: .automatic
+        case .platform: .platform
+        case .software: .software
+        }
+    }
+}
+
+extension AutoGainControlMode: AudioProcessingModeConvertible {
+    static var platformMode: Self? { .platform }
+
+    var rtcType: LKRTCAudioProcessingMode {
+        switch self {
+        case .automatic: .automatic
+        case .platform: .platform
+        case .software: .software
+        }
+    }
+}
+
+extension NoiseSuppressionMode: AudioProcessingModeConvertible {
+    static var platformMode: Self? { .platform }
+
+    var rtcType: LKRTCAudioProcessingMode {
+        switch self {
+        case .automatic: .automatic
+        case .platform: .platform
+        case .software: .software
+        }
+    }
+}
+
+extension HighpassFilterMode: AudioProcessingModeConvertible {
+    static var platformMode: Self? { nil }
+
+    var rtcType: LKRTCAudioProcessingMode {
+        switch self {
+        case .automatic: .automatic
+        case .software: .software
+        }
+    }
+}

--- a/Sources/LiveKit/Types/AudioProcessingModes.swift
+++ b/Sources/LiveKit/Types/AudioProcessingModes.swift
@@ -17,7 +17,7 @@
 internal import LiveKitWebRTC
 
 /// Selects the echo-cancellation implementation.
-public enum EchoCancellationMode: Hashable, Sendable {
+public enum EchoCancellationMode: CaseIterable, Hashable, Sendable {
     /// Prefer platform voice processing when available and fall back to WebRTC software processing.
     case automatic
     /// Use platform voice processing only. If platform processing is unavailable, the request is rejected.
@@ -27,7 +27,7 @@ public enum EchoCancellationMode: Hashable, Sendable {
 }
 
 /// Selects the automatic-gain-control implementation.
-public enum AutoGainControlMode: Hashable, Sendable {
+public enum AutoGainControlMode: CaseIterable, Hashable, Sendable {
     /// Prefer platform voice processing when available and fall back to WebRTC software processing.
     case automatic
     /// Use platform voice processing only. If platform processing is unavailable, the request is rejected.
@@ -37,7 +37,7 @@ public enum AutoGainControlMode: Hashable, Sendable {
 }
 
 /// Selects the noise-suppression implementation.
-public enum NoiseSuppressionMode: Hashable, Sendable {
+public enum NoiseSuppressionMode: CaseIterable, Hashable, Sendable {
     /// Prefer platform voice processing when available and fall back to WebRTC software processing.
     case automatic
     /// Use platform voice processing only. If platform processing is unavailable, the request is rejected.
@@ -47,7 +47,7 @@ public enum NoiseSuppressionMode: Hashable, Sendable {
 }
 
 /// Selects the high-pass-filter implementation.
-public enum HighpassFilterMode: Hashable, Sendable {
+public enum HighpassFilterMode: CaseIterable, Hashable, Sendable {
     /// Use WebRTC software processing when the filter is enabled.
     case automatic
     /// Force WebRTC software processing.

--- a/Sources/LiveKit/Types/AudioProcessingOptions.swift
+++ b/Sources/LiveKit/Types/AudioProcessingOptions.swift
@@ -1,0 +1,379 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+internal import LiveKitWebRTC
+
+@objc
+public enum AudioProcessingMode: Int, CaseIterable, Hashable, Sendable {
+    /// Prefer platform voice processing when available and fall back to WebRTC software processing.
+    case automatic
+    /// Use platform voice processing only. If platform processing is unavailable, the request is rejected.
+    case platform
+    /// Force WebRTC software processing and disable the matching platform effect when possible.
+    case software
+}
+
+public enum AudioProcessingOptionsResultCode: Int, Sendable {
+    /// Options were applied immediately by the component handling the request.
+    case applied
+    /// Options were accepted and stored. Active senders reapply them separately.
+    case stored
+    case rejectedRemoteTrack
+    case rejectedInvalidCombination
+    case rejectedPlatformUnavailable
+    case applyFailed
+}
+
+public enum AudioProcessingImplementation: Int, Sendable {
+    case unknown
+    case disabled
+    case software
+    case platform
+    case softwareAndPlatform
+}
+
+public struct AudioProcessingOptionsResult: Sendable {
+    public let code: AudioProcessingOptionsResultCode
+    public let message: String
+
+    public var isSuccess: Bool {
+        code == .applied || code == .stored
+    }
+}
+
+@objcMembers
+public final class AudioProcessingOptions: NSObject, Sendable {
+    public static let communication = AudioProcessingOptions()
+
+    public static let noProcessing = AudioProcessingOptions(
+        echoCancellation: false,
+        autoGainControl: false,
+        noiseSuppression: false,
+        highPassFilter: false,
+    )
+
+    public let echoCancellation: Bool
+    public let autoGainControl: Bool
+    public let noiseSuppression: Bool
+    public let highPassFilter: Bool
+
+    public let echoCancellationMode: AudioProcessingMode
+    public let autoGainControlMode: AudioProcessingMode
+    public let noiseSuppressionMode: AudioProcessingMode
+    public let highPassFilterMode: AudioProcessingMode
+
+    public init(
+        echoCancellation: Bool = true,
+        autoGainControl: Bool = true,
+        noiseSuppression: Bool = true,
+        highPassFilter: Bool = false,
+        echoCancellationMode: AudioProcessingMode = .automatic,
+        autoGainControlMode: AudioProcessingMode = .automatic,
+        noiseSuppressionMode: AudioProcessingMode = .automatic,
+        highPassFilterMode: AudioProcessingMode = .automatic,
+    ) {
+        self.echoCancellation = echoCancellation
+        self.autoGainControl = autoGainControl
+        self.noiseSuppression = noiseSuppression
+        self.highPassFilter = highPassFilter
+        self.echoCancellationMode = echoCancellationMode
+        self.autoGainControlMode = autoGainControlMode
+        self.noiseSuppressionMode = noiseSuppressionMode
+        self.highPassFilterMode = highPassFilterMode
+    }
+
+    override public func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return echoCancellation == other.echoCancellation &&
+            autoGainControl == other.autoGainControl &&
+            noiseSuppression == other.noiseSuppression &&
+            highPassFilter == other.highPassFilter &&
+            echoCancellationMode == other.echoCancellationMode &&
+            autoGainControlMode == other.autoGainControlMode &&
+            noiseSuppressionMode == other.noiseSuppressionMode &&
+            highPassFilterMode == other.highPassFilterMode
+    }
+
+    override public var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(echoCancellation)
+        hasher.combine(autoGainControl)
+        hasher.combine(noiseSuppression)
+        hasher.combine(highPassFilter)
+        hasher.combine(echoCancellationMode)
+        hasher.combine(autoGainControlMode)
+        hasher.combine(noiseSuppressionMode)
+        hasher.combine(highPassFilterMode)
+        return hasher.finalize()
+    }
+}
+
+/// The caller's request for one audio processing component: enabled flag plus
+/// implementation mode.
+public struct AudioProcessingComponentRequest: Sendable {
+    public let isEnabled: Bool
+    public let mode: AudioProcessingMode
+}
+
+/// Diagnostic state of one audio processing component (echo cancellation,
+/// noise suppression, auto gain control or high-pass filter), observed at
+/// three stages of one pipeline: requested (caller intent) -> resolved (the
+/// engine's per-path decision) -> active (live truth), with ``effective`` as
+/// the merged verdict.
+public struct AudioProcessingComponentState: Sendable {
+    /// What the caller most recently requested for this component. `nil` when
+    /// no audio processing options have ever been applied — "nobody asked".
+    public let requested: AudioProcessingComponentRequest?
+
+    /// Whether the resolver decided the WebRTC software (APM) implementation
+    /// should run, after weighing the requested mode against platform
+    /// availability, coupling, and policy.
+    public let isSoftwareResolved: Bool
+
+    /// Whether APM's live configuration currently has this component enabled.
+    public let isSoftwareActive: Bool
+
+    /// Whether this device/OS offers a built-in implementation at all.
+    public let isPlatformAvailable: Bool
+
+    /// Whether the engine asked the OS to run the platform implementation.
+    /// The OS owns the outcome: it can decline, defer, or couple components.
+    public let isPlatformResolved: Bool
+
+    /// Whether the device reports the platform implementation actually running.
+    public let isPlatformActive: Bool
+
+    /// The verdict: which implementation is in effect right now.
+    public let effective: AudioProcessingImplementation
+}
+
+/// Diagnostic snapshot of the resolved audio processing state for the shared
+/// audio processing module.
+///
+/// The module is owned by the peer connection factory and shared engine-wide,
+/// so this reflects what is actually applied (per-component
+/// ``AudioProcessingComponentState/effective``) versus what was requested —
+/// for the whole engine, not a single track. Device-level platform processing
+/// detail lives on ``PlatformAudioProcessingState`` instead.
+public struct AudioProcessingState: Sendable {
+    public let hasAudioProcessingModule: Bool
+    public let echoCancellation: AudioProcessingComponentState
+    public let noiseSuppression: AudioProcessingComponentState
+    public let autoGainControl: AudioProcessingComponentState
+    public let highPassFilter: AudioProcessingComponentState
+}
+
+public enum PlatformAudioProcessingTopology: Int, Sendable {
+    case independent
+    case echoCancellationAndNoiseSuppressionCoupled
+}
+
+public struct PlatformAudioProcessingComponentState: Sendable {
+    /// Whether the device offers this effect at all.
+    public let isAvailable: Bool
+    /// The last state requested from the audio device module.
+    public let isRequested: Bool
+    /// Live OS readback when the audio device module can query the effect.
+    public let isActive: Bool
+}
+
+/// Device-level snapshot of platform audio processing.
+///
+/// The `isVoiceProcessing*` properties reflect the Apple Voice Processing I/O
+/// unit: requested values are the state stored by the audio device module;
+/// active values are live readback from the platform input node and read
+/// `false` before input is configured or where the value is not observable.
+public struct PlatformAudioProcessingState: Sendable {
+    public let topology: PlatformAudioProcessingTopology
+    public let echoCancellation: PlatformAudioProcessingComponentState
+    public let noiseSuppression: PlatformAudioProcessingComponentState
+    public let autoGainControl: PlatformAudioProcessingComponentState
+    public let isVoiceProcessingEnabledRequested: Bool
+    public let isVoiceProcessingBypassedRequested: Bool
+    public let isVoiceProcessingAGCEnabledRequested: Bool
+    public let isVoiceProcessingEnabledActive: Bool
+    public let isVoiceProcessingBypassedActive: Bool
+    public let isVoiceProcessingAGCEnabledActive: Bool
+}
+
+extension AudioProcessingMode: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .automatic: "Automatic"
+        case .platform: "Platform"
+        case .software: "Software"
+        }
+    }
+}
+
+extension AudioProcessingImplementation: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .unknown: "Unknown"
+        case .disabled: "Disabled"
+        case .software: "Software"
+        case .platform: "Platform"
+        case .softwareAndPlatform: "Software + Platform"
+        }
+    }
+}
+
+extension AudioProcessingMode {
+    func toRTCType() -> LKRTCAudioProcessingMode {
+        switch self {
+        case .automatic: .automatic
+        case .platform: .platform
+        case .software: .software
+        }
+    }
+
+    func toConstraintValue() -> String {
+        switch self {
+        case .automatic: "auto"
+        case .platform: "platform"
+        case .software: "software"
+        }
+    }
+}
+
+extension LKRTCAudioProcessingMode {
+    func toLKType() -> AudioProcessingMode {
+        switch self {
+        case .automatic: .automatic
+        case .platform: .platform
+        case .software: .software
+        @unknown default: .automatic
+        }
+    }
+}
+
+extension LKRTCAudioProcessingImplementation {
+    func toLKType() -> AudioProcessingImplementation {
+        switch self {
+        case .unknown: .unknown
+        case .disabled: .disabled
+        case .software: .software
+        case .platform: .platform
+        case .softwareAndPlatform: .softwareAndPlatform
+        @unknown default: .unknown
+        }
+    }
+}
+
+extension AudioProcessingOptionsResultCode {
+    init(_ code: LKRTCAudioProcessingOptionsResultCode) {
+        self = Self(rawValue: code.rawValue) ?? .applyFailed
+    }
+}
+
+extension LKRTCAudioProcessingOptionsResult {
+    func toLKType() -> AudioProcessingOptionsResult {
+        AudioProcessingOptionsResult(
+            code: AudioProcessingOptionsResultCode(code),
+            message: message,
+        )
+    }
+}
+
+extension AudioProcessingOptions {
+    func toRTCType() -> LKRTCAudioProcessingOptions {
+        LKRTCAudioProcessingOptions(
+            echoCancellationOptions: LKRTCAudioProcessingComponentOptions(
+                enabled: echoCancellation,
+                mode: echoCancellationMode.toRTCType(),
+            ),
+            noiseSuppressionOptions: LKRTCAudioProcessingComponentOptions(
+                enabled: noiseSuppression,
+                mode: noiseSuppressionMode.toRTCType(),
+            ),
+            autoGainControlOptions: LKRTCAudioProcessingComponentOptions(
+                enabled: autoGainControl,
+                mode: autoGainControlMode.toRTCType(),
+            ),
+            highPassFilterOptions: LKRTCAudioProcessingComponentOptions(
+                enabled: highPassFilter,
+                mode: highPassFilterMode.toRTCType(),
+            ),
+        )
+    }
+}
+
+extension LKRTCAudioProcessingComponentState {
+    func toLKType() -> AudioProcessingComponentState {
+        AudioProcessingComponentState(
+            requested: requested.map {
+                AudioProcessingComponentRequest(isEnabled: $0.isEnabled, mode: $0.mode.toLKType())
+            },
+            isSoftwareResolved: isSoftwareResolved,
+            isSoftwareActive: isSoftwareActive,
+            isPlatformAvailable: isPlatformAvailable,
+            isPlatformResolved: isPlatformResolved,
+            isPlatformActive: isPlatformActive,
+            effective: effective.toLKType(),
+        )
+    }
+}
+
+extension LKRTCAudioProcessingState {
+    func toLKType() -> AudioProcessingState {
+        AudioProcessingState(
+            hasAudioProcessingModule: hasAudioProcessingModule,
+            echoCancellation: echoCancellation.toLKType(),
+            noiseSuppression: noiseSuppression.toLKType(),
+            autoGainControl: autoGainControl.toLKType(),
+            highPassFilter: highPassFilter.toLKType(),
+        )
+    }
+}
+
+extension LKRTCPlatformAudioProcessingTopology {
+    func toLKType() -> PlatformAudioProcessingTopology {
+        switch self {
+        case .independent: .independent
+        case .echoCancellationAndNoiseSuppressionCoupled: .echoCancellationAndNoiseSuppressionCoupled
+        @unknown default: .independent
+        }
+    }
+}
+
+extension LKRTCPlatformAudioProcessingComponentState {
+    func toLKType() -> PlatformAudioProcessingComponentState {
+        PlatformAudioProcessingComponentState(
+            isAvailable: isAvailable,
+            isRequested: isRequested,
+            isActive: isActive,
+        )
+    }
+}
+
+extension LKRTCPlatformAudioProcessingState {
+    func toLKType() -> PlatformAudioProcessingState {
+        PlatformAudioProcessingState(
+            topology: topology.toLKType(),
+            echoCancellation: echoCancellation.toLKType(),
+            noiseSuppression: noiseSuppression.toLKType(),
+            autoGainControl: autoGainControl.toLKType(),
+            isVoiceProcessingEnabledRequested: isVoiceProcessingEnabledRequested,
+            isVoiceProcessingBypassedRequested: isVoiceProcessingBypassedRequested,
+            isVoiceProcessingAGCEnabledRequested: isVoiceProcessingAGCEnabledRequested,
+            isVoiceProcessingEnabledActive: isVoiceProcessingEnabledActive,
+            isVoiceProcessingBypassedActive: isVoiceProcessingBypassedActive,
+            isVoiceProcessingAGCEnabledActive: isVoiceProcessingAGCEnabledActive,
+        )
+    }
+}

--- a/Sources/LiveKit/Types/AudioProcessingOptions.swift
+++ b/Sources/LiveKit/Types/AudioProcessingOptions.swift
@@ -14,30 +14,7 @@
  * limitations under the License.
  */
 
-import Foundation
-
 internal import LiveKitWebRTC
-
-@objc
-public enum AudioProcessingMode: Int, CaseIterable, Hashable, Sendable {
-    /// Prefer platform voice processing when available and fall back to WebRTC software processing.
-    case automatic
-    /// Use platform voice processing only. If platform processing is unavailable, the request is rejected.
-    case platform
-    /// Force WebRTC software processing and disable the matching platform effect when possible.
-    case software
-}
-
-public enum AudioProcessingOptionsResultCode: Int, Sendable {
-    /// Options were applied immediately by the component handling the request.
-    case applied
-    /// Options were accepted and stored. Active senders reapply them separately.
-    case stored
-    case rejectedRemoteTrack
-    case rejectedInvalidCombination
-    case rejectedPlatformUnavailable
-    case applyFailed
-}
 
 public enum AudioProcessingImplementation: Int, Sendable {
     case unknown
@@ -47,19 +24,20 @@ public enum AudioProcessingImplementation: Int, Sendable {
     case softwareAndPlatform
 }
 
-public struct AudioProcessingOptionsResult: Sendable {
-    public let code: AudioProcessingOptionsResultCode
-    public let message: String
-
-    public var isSuccess: Bool {
-        code == .applied || code == .stored
-    }
+/// A successful outcome of applying ``AudioProcessingOptions``.
+public enum AudioProcessingOptionsResult: Sendable {
+    /// Options were applied immediately by the component handling the request.
+    case applied
+    /// Options were accepted and stored. Active senders reapply them separately.
+    case stored
 }
 
-@objcMembers
-public final class AudioProcessingOptions: NSObject, Sendable {
-    public static let communication = AudioProcessingOptions()
-
+/// Immutable runtime voice-processing settings.
+///
+/// The default initializer produces the SDK's communication profile: echo
+/// cancellation, gain control and noise suppression enabled in `.automatic`
+/// mode, high-pass filter disabled.
+public struct AudioProcessingOptions: Hashable, Sendable {
     public static let noProcessing = AudioProcessingOptions(
         echoCancellation: false,
         autoGainControl: false,
@@ -72,20 +50,20 @@ public final class AudioProcessingOptions: NSObject, Sendable {
     public let noiseSuppression: Bool
     public let highpassFilter: Bool
 
-    public let echoCancellationMode: AudioProcessingMode
-    public let autoGainControlMode: AudioProcessingMode
-    public let noiseSuppressionMode: AudioProcessingMode
-    public let highpassFilterMode: AudioProcessingMode
+    public let echoCancellationMode: EchoCancellationMode
+    public let autoGainControlMode: AutoGainControlMode
+    public let noiseSuppressionMode: NoiseSuppressionMode
+    public let highpassFilterMode: HighpassFilterMode
 
     public init(
         echoCancellation: Bool = true,
         autoGainControl: Bool = true,
         noiseSuppression: Bool = true,
         highpassFilter: Bool = false,
-        echoCancellationMode: AudioProcessingMode = .automatic,
-        autoGainControlMode: AudioProcessingMode = .automatic,
-        noiseSuppressionMode: AudioProcessingMode = .automatic,
-        highpassFilterMode: AudioProcessingMode = .automatic,
+        echoCancellationMode: EchoCancellationMode = .automatic,
+        autoGainControlMode: AutoGainControlMode = .automatic,
+        noiseSuppressionMode: NoiseSuppressionMode = .automatic,
+        highpassFilterMode: HighpassFilterMode = .automatic,
     ) {
         self.echoCancellation = echoCancellation
         self.autoGainControl = autoGainControl
@@ -96,38 +74,27 @@ public final class AudioProcessingOptions: NSObject, Sendable {
         self.noiseSuppressionMode = noiseSuppressionMode
         self.highpassFilterMode = highpassFilterMode
     }
-
-    override public func isEqual(_ object: Any?) -> Bool {
-        guard let other = object as? Self else { return false }
-        return echoCancellation == other.echoCancellation &&
-            autoGainControl == other.autoGainControl &&
-            noiseSuppression == other.noiseSuppression &&
-            highpassFilter == other.highpassFilter &&
-            echoCancellationMode == other.echoCancellationMode &&
-            autoGainControlMode == other.autoGainControlMode &&
-            noiseSuppressionMode == other.noiseSuppressionMode &&
-            highpassFilterMode == other.highpassFilterMode
-    }
-
-    override public var hash: Int {
-        var hasher = Hasher()
-        hasher.combine(echoCancellation)
-        hasher.combine(autoGainControl)
-        hasher.combine(noiseSuppression)
-        hasher.combine(highpassFilter)
-        hasher.combine(echoCancellationMode)
-        hasher.combine(autoGainControlMode)
-        hasher.combine(noiseSuppressionMode)
-        hasher.combine(highpassFilterMode)
-        return hasher.finalize()
-    }
 }
 
 /// The caller's request for one audio processing component: enabled flag plus
 /// implementation mode.
-public struct AudioProcessingComponentRequest: Sendable {
+public struct AudioProcessingComponentRequest<Mode: Sendable>: Sendable {
+    /// Whether the component was requested to be enabled.
     public let isEnabled: Bool
-    public let mode: AudioProcessingMode
+
+    /// The requested implementation mode.
+    public let mode: Mode
+}
+
+/// Resolved and live state of one processing path (WebRTC software APM or the
+/// platform implementation) for an audio processing component.
+public struct AudioProcessingPathState: Sendable {
+    /// Whether the resolver decided this path should run, after weighing the
+    /// requested mode against platform availability, coupling, and policy.
+    public let isResolved: Bool
+
+    /// Whether this path reports the component as currently running.
+    public let isActive: Bool
 }
 
 /// Diagnostic state of one audio processing component (echo cancellation,
@@ -135,28 +102,18 @@ public struct AudioProcessingComponentRequest: Sendable {
 /// three stages of one pipeline: requested (caller intent) -> resolved (the
 /// engine's per-path decision) -> active (live truth), with ``effective`` as
 /// the merged verdict.
-public struct AudioProcessingComponentState: Sendable {
+public struct AudioProcessingComponentState<Mode: Sendable>: Sendable {
     /// What the caller most recently requested for this component. `nil` when
     /// no audio processing options have ever been applied — "nobody asked".
-    public let requested: AudioProcessingComponentRequest?
+    public let requested: AudioProcessingComponentRequest<Mode>?
 
-    /// Whether the resolver decided the WebRTC software (APM) implementation
-    /// should run, after weighing the requested mode against platform
-    /// availability, coupling, and policy.
-    public let isSoftwareResolved: Bool
+    /// The WebRTC software (APM) path.
+    public let software: AudioProcessingPathState
 
-    /// Whether APM's live configuration currently has this component enabled.
-    public let isSoftwareActive: Bool
-
-    /// Whether this device/OS offers a built-in implementation at all.
-    public let isPlatformAvailable: Bool
-
-    /// Whether the engine asked the OS to run the platform implementation.
-    /// The OS owns the outcome: it can decline, defer, or couple components.
-    public let isPlatformResolved: Bool
-
-    /// Whether the device reports the platform implementation actually running.
-    public let isPlatformActive: Bool
+    /// The platform path, or `nil` when this device/OS offers no built-in
+    /// implementation. The OS owns this path's outcome: it can decline, defer,
+    /// or couple components even after the engine requests it.
+    public let platform: AudioProcessingPathState?
 
     /// The verdict: which implementation is in effect right now.
     public let effective: AudioProcessingImplementation
@@ -169,21 +126,30 @@ public struct AudioProcessingComponentState: Sendable {
 /// so this reflects what is actually applied (per-component
 /// ``AudioProcessingComponentState/effective``) versus what was requested —
 /// for the whole engine, not a single track. Device-level platform processing
-/// detail lives on ``PlatformAudioProcessingState`` instead.
+/// detail lives on ``PlatformVoiceProcessingState`` instead.
 public struct AudioProcessingState: Sendable {
+    /// Whether the shared engine includes a WebRTC audio processing module.
     public let hasAudioProcessingModule: Bool
-    public let echoCancellation: AudioProcessingComponentState
-    public let noiseSuppression: AudioProcessingComponentState
-    public let autoGainControl: AudioProcessingComponentState
-    public let highpassFilter: AudioProcessingComponentState
+
+    /// Echo-cancellation state and its most recent typed request.
+    public let echoCancellation: AudioProcessingComponentState<EchoCancellationMode>
+
+    /// Noise-suppression state and its most recent typed request.
+    public let noiseSuppression: AudioProcessingComponentState<NoiseSuppressionMode>
+
+    /// Automatic-gain-control state and its most recent typed request.
+    public let autoGainControl: AudioProcessingComponentState<AutoGainControlMode>
+
+    /// High-pass-filter state and its most recent typed request.
+    public let highpassFilter: AudioProcessingComponentState<HighpassFilterMode>
 }
 
-public enum PlatformAudioProcessingTopology: Int, Sendable {
+public enum PlatformVoiceProcessingTopology: Int, Sendable {
     case independent
     case echoCancellationAndNoiseSuppressionCoupled
 }
 
-public struct PlatformAudioProcessingComponentState: Sendable {
+public struct PlatformVoiceProcessingComponentState: Sendable {
     /// Whether the device offers this effect at all.
     public let isAvailable: Bool
     /// The last state requested from the audio device module.
@@ -192,33 +158,27 @@ public struct PlatformAudioProcessingComponentState: Sendable {
     public let isActive: Bool
 }
 
-/// Device-level snapshot of platform audio processing.
-///
-/// The `isVoiceProcessing*` properties reflect the Apple Voice Processing I/O
-/// unit: requested values are the state stored by the audio device module;
-/// active values are live readback from the platform input node and read
-/// `false` before input is configured or where the value is not observable.
-public struct PlatformAudioProcessingState: Sendable {
-    public let topology: PlatformAudioProcessingTopology
-    public let echoCancellation: PlatformAudioProcessingComponentState
-    public let noiseSuppression: PlatformAudioProcessingComponentState
-    public let autoGainControl: PlatformAudioProcessingComponentState
-    public let isVoiceProcessingEnabledRequested: Bool
-    public let isVoiceProcessingBypassedRequested: Bool
-    public let isVoiceProcessingAGCEnabledRequested: Bool
-    public let isVoiceProcessingEnabledActive: Bool
-    public let isVoiceProcessingBypassedActive: Bool
-    public let isVoiceProcessingAGCEnabledActive: Bool
+/// Requested and live state of one Apple Voice Processing I/O unit flag.
+public struct PlatformVoiceProcessingFlagState: Sendable {
+    /// The last state requested from the audio device module.
+    public let isRequested: Bool
+    /// Live readback from the platform input node. Reads `false` before input
+    /// is configured or where the value is not observable.
+    public let isActive: Bool
 }
 
-extension AudioProcessingMode: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case .automatic: "Automatic"
-        case .platform: "Platform"
-        case .software: "Software"
-        }
-    }
+/// Device-level snapshot of Apple's platform Voice Processing I/O.
+public struct PlatformVoiceProcessingState: Sendable {
+    public let topology: PlatformVoiceProcessingTopology
+    public let echoCancellation: PlatformVoiceProcessingComponentState
+    public let noiseSuppression: PlatformVoiceProcessingComponentState
+    public let autoGainControl: PlatformVoiceProcessingComponentState
+    /// Whether the Voice Processing I/O unit is enabled.
+    public let voiceProcessingEnabled: PlatformVoiceProcessingFlagState
+    /// Whether the Voice Processing I/O unit is bypassed.
+    public let voiceProcessingBypassed: PlatformVoiceProcessingFlagState
+    /// Whether the Voice Processing I/O unit's automatic gain control is enabled.
+    public let voiceProcessingAGCEnabled: PlatformVoiceProcessingFlagState
 }
 
 extension AudioProcessingImplementation: CustomStringConvertible {
@@ -229,35 +189,6 @@ extension AudioProcessingImplementation: CustomStringConvertible {
         case .software: "Software"
         case .platform: "Platform"
         case .softwareAndPlatform: "Software + Platform"
-        }
-    }
-}
-
-extension AudioProcessingMode {
-    func toRTCType() -> LKRTCAudioProcessingMode {
-        switch self {
-        case .automatic: .automatic
-        case .platform: .platform
-        case .software: .software
-        }
-    }
-
-    func toConstraintValue() -> String {
-        switch self {
-        case .automatic: "auto"
-        case .platform: "platform"
-        case .software: "software"
-        }
-    }
-}
-
-extension LKRTCAudioProcessingMode {
-    func toLKType() -> AudioProcessingMode {
-        switch self {
-        case .automatic: .automatic
-        case .platform: .platform
-        case .software: .software
-        @unknown default: .automatic
         }
     }
 }
@@ -275,26 +206,18 @@ extension LKRTCAudioProcessingImplementation {
     }
 }
 
-extension AudioProcessingOptionsResultCode {
-    init(_ code: LKRTCAudioProcessingOptionsResultCode) {
-        switch code {
-        case .applied: self = .applied
-        case .stored: self = .stored
-        case .rejectedRemoteTrack: self = .rejectedRemoteTrack
-        case .rejectedInvalidCombination: self = .rejectedInvalidCombination
-        case .rejectedPlatformUnavailable: self = .rejectedPlatformUnavailable
-        case .applyFailed: self = .applyFailed
-        @unknown default: self = .applyFailed
-        }
-    }
-}
-
 extension LKRTCAudioProcessingOptionsResult {
-    func toLKType() -> AudioProcessingOptionsResult {
-        AudioProcessingOptionsResult(
-            code: AudioProcessingOptionsResultCode(code),
-            message: message,
-        )
+    /// Partitions the upstream result: successes are returned, rejections are thrown.
+    func toLKType() throws -> AudioProcessingOptionsResult {
+        switch code {
+        case .applied: return .applied
+        case .stored: return .stored
+        case .rejectedRemoteTrack: throw AudioProcessingOptionsError(code: .remoteTrack, message: message)
+        case .rejectedInvalidCombination: throw AudioProcessingOptionsError(code: .invalidCombination, message: message)
+        case .rejectedPlatformUnavailable: throw AudioProcessingOptionsError(code: .platformUnavailable, message: message)
+        case .applyFailed: throw AudioProcessingOptionsError(code: .applyFailed, message: message)
+        @unknown default: throw AudioProcessingOptionsError(code: .applyFailed, message: message)
+        }
     }
 }
 
@@ -322,16 +245,19 @@ extension AudioProcessingOptions {
 }
 
 extension LKRTCAudioProcessingComponentState {
-    func toLKType() -> AudioProcessingComponentState {
+    func toLKType<Mode: AudioProcessingModeConvertible>(modeType _: Mode.Type) -> AudioProcessingComponentState<Mode> {
         AudioProcessingComponentState(
             requested: requested.map {
-                AudioProcessingComponentRequest(isEnabled: $0.isEnabled, mode: $0.mode.toLKType())
+                AudioProcessingComponentRequest(isEnabled: $0.isEnabled, mode: Mode.fromRTCType($0.mode))
             },
-            isSoftwareResolved: isSoftwareResolved,
-            isSoftwareActive: isSoftwareActive,
-            isPlatformAvailable: isPlatformAvailable,
-            isPlatformResolved: isPlatformResolved,
-            isPlatformActive: isPlatformActive,
+            software: AudioProcessingPathState(
+                isResolved: isSoftwareResolved,
+                isActive: isSoftwareActive,
+            ),
+            platform: isPlatformAvailable ? AudioProcessingPathState(
+                isResolved: isPlatformResolved,
+                isActive: isPlatformActive,
+            ) : nil,
             effective: effective.toLKType(),
         )
     }
@@ -341,16 +267,16 @@ extension LKRTCAudioProcessingState {
     func toLKType() -> AudioProcessingState {
         AudioProcessingState(
             hasAudioProcessingModule: hasAudioProcessingModule,
-            echoCancellation: echoCancellation.toLKType(),
-            noiseSuppression: noiseSuppression.toLKType(),
-            autoGainControl: autoGainControl.toLKType(),
-            highpassFilter: highPassFilter.toLKType(),
+            echoCancellation: echoCancellation.toLKType(modeType: EchoCancellationMode.self),
+            noiseSuppression: noiseSuppression.toLKType(modeType: NoiseSuppressionMode.self),
+            autoGainControl: autoGainControl.toLKType(modeType: AutoGainControlMode.self),
+            highpassFilter: highPassFilter.toLKType(modeType: HighpassFilterMode.self),
         )
     }
 }
 
 extension LKRTCPlatformAudioProcessingTopology {
-    func toLKType() -> PlatformAudioProcessingTopology {
+    func toLKType() -> PlatformVoiceProcessingTopology {
         switch self {
         case .independent: .independent
         case .echoCancellationAndNoiseSuppressionCoupled: .echoCancellationAndNoiseSuppressionCoupled
@@ -360,8 +286,8 @@ extension LKRTCPlatformAudioProcessingTopology {
 }
 
 extension LKRTCPlatformAudioProcessingComponentState {
-    func toLKType() -> PlatformAudioProcessingComponentState {
-        PlatformAudioProcessingComponentState(
+    func toLKType() -> PlatformVoiceProcessingComponentState {
+        PlatformVoiceProcessingComponentState(
             isAvailable: isAvailable,
             isRequested: isRequested,
             isActive: isActive,
@@ -370,18 +296,24 @@ extension LKRTCPlatformAudioProcessingComponentState {
 }
 
 extension LKRTCPlatformAudioProcessingState {
-    func toLKType() -> PlatformAudioProcessingState {
-        PlatformAudioProcessingState(
+    func toLKType() -> PlatformVoiceProcessingState {
+        PlatformVoiceProcessingState(
             topology: topology.toLKType(),
             echoCancellation: echoCancellation.toLKType(),
             noiseSuppression: noiseSuppression.toLKType(),
             autoGainControl: autoGainControl.toLKType(),
-            isVoiceProcessingEnabledRequested: isVoiceProcessingEnabledRequested,
-            isVoiceProcessingBypassedRequested: isVoiceProcessingBypassedRequested,
-            isVoiceProcessingAGCEnabledRequested: isVoiceProcessingAGCEnabledRequested,
-            isVoiceProcessingEnabledActive: isVoiceProcessingEnabledActive,
-            isVoiceProcessingBypassedActive: isVoiceProcessingBypassedActive,
-            isVoiceProcessingAGCEnabledActive: isVoiceProcessingAGCEnabledActive,
+            voiceProcessingEnabled: PlatformVoiceProcessingFlagState(
+                isRequested: isVoiceProcessingEnabledRequested,
+                isActive: isVoiceProcessingEnabledActive,
+            ),
+            voiceProcessingBypassed: PlatformVoiceProcessingFlagState(
+                isRequested: isVoiceProcessingBypassedRequested,
+                isActive: isVoiceProcessingBypassedActive,
+            ),
+            voiceProcessingAGCEnabled: PlatformVoiceProcessingFlagState(
+                isRequested: isVoiceProcessingAGCEnabledRequested,
+                isActive: isVoiceProcessingAGCEnabledActive,
+            ),
         )
     }
 }

--- a/Sources/LiveKit/Types/AudioProcessingOptions.swift
+++ b/Sources/LiveKit/Types/AudioProcessingOptions.swift
@@ -212,7 +212,7 @@ extension LKRTCAudioProcessingOptionsResult {
         switch code {
         case .applied: return .applied
         case .stored: return .stored
-        case .rejectedRemoteTrack: throw AudioProcessingOptionsError(code: .remoteTrack, message: message)
+        case .rejectedRemoteTrack: throw AudioProcessingOptionsError(code: .invalidState, message: message)
         case .rejectedInvalidCombination: throw AudioProcessingOptionsError(code: .invalidCombination, message: message)
         case .rejectedPlatformUnavailable: throw AudioProcessingOptionsError(code: .platformUnavailable, message: message)
         case .applyFailed: throw AudioProcessingOptionsError(code: .applyFailed, message: message)

--- a/Sources/LiveKit/Types/AudioProcessingOptions.swift
+++ b/Sources/LiveKit/Types/AudioProcessingOptions.swift
@@ -128,9 +128,6 @@ public struct AudioProcessingComponentState<Mode: Sendable>: Sendable {
 /// for the whole engine, not a single track. Device-level platform processing
 /// detail lives on ``PlatformVoiceProcessingState`` instead.
 public struct AudioProcessingState: Sendable {
-    /// Whether the shared engine includes a WebRTC audio processing module.
-    public let hasAudioProcessingModule: Bool
-
     /// Echo-cancellation state and its most recent typed request.
     public let echoCancellation: AudioProcessingComponentState<EchoCancellationMode>
 
@@ -266,7 +263,6 @@ extension LKRTCAudioProcessingComponentState {
 extension LKRTCAudioProcessingState {
     func toLKType() -> AudioProcessingState {
         AudioProcessingState(
-            hasAudioProcessingModule: hasAudioProcessingModule,
             echoCancellation: echoCancellation.toLKType(modeType: EchoCancellationMode.self),
             noiseSuppression: noiseSuppression.toLKType(modeType: NoiseSuppressionMode.self),
             autoGainControl: autoGainControl.toLKType(modeType: AutoGainControlMode.self),

--- a/Sources/LiveKit/Types/AudioProcessingOptions.swift
+++ b/Sources/LiveKit/Types/AudioProcessingOptions.swift
@@ -277,7 +277,15 @@ extension LKRTCAudioProcessingImplementation {
 
 extension AudioProcessingOptionsResultCode {
     init(_ code: LKRTCAudioProcessingOptionsResultCode) {
-        self = Self(rawValue: code.rawValue) ?? .applyFailed
+        switch code {
+        case .applied: self = .applied
+        case .stored: self = .stored
+        case .rejectedRemoteTrack: self = .rejectedRemoteTrack
+        case .rejectedInvalidCombination: self = .rejectedInvalidCombination
+        case .rejectedPlatformUnavailable: self = .rejectedPlatformUnavailable
+        case .applyFailed: self = .applyFailed
+        @unknown default: self = .applyFailed
+        }
     }
 }
 

--- a/Sources/LiveKit/Types/AudioProcessingOptions.swift
+++ b/Sources/LiveKit/Types/AudioProcessingOptions.swift
@@ -64,37 +64,37 @@ public final class AudioProcessingOptions: NSObject, Sendable {
         echoCancellation: false,
         autoGainControl: false,
         noiseSuppression: false,
-        highPassFilter: false,
+        highpassFilter: false,
     )
 
     public let echoCancellation: Bool
     public let autoGainControl: Bool
     public let noiseSuppression: Bool
-    public let highPassFilter: Bool
+    public let highpassFilter: Bool
 
     public let echoCancellationMode: AudioProcessingMode
     public let autoGainControlMode: AudioProcessingMode
     public let noiseSuppressionMode: AudioProcessingMode
-    public let highPassFilterMode: AudioProcessingMode
+    public let highpassFilterMode: AudioProcessingMode
 
     public init(
         echoCancellation: Bool = true,
         autoGainControl: Bool = true,
         noiseSuppression: Bool = true,
-        highPassFilter: Bool = false,
+        highpassFilter: Bool = false,
         echoCancellationMode: AudioProcessingMode = .automatic,
         autoGainControlMode: AudioProcessingMode = .automatic,
         noiseSuppressionMode: AudioProcessingMode = .automatic,
-        highPassFilterMode: AudioProcessingMode = .automatic,
+        highpassFilterMode: AudioProcessingMode = .automatic,
     ) {
         self.echoCancellation = echoCancellation
         self.autoGainControl = autoGainControl
         self.noiseSuppression = noiseSuppression
-        self.highPassFilter = highPassFilter
+        self.highpassFilter = highpassFilter
         self.echoCancellationMode = echoCancellationMode
         self.autoGainControlMode = autoGainControlMode
         self.noiseSuppressionMode = noiseSuppressionMode
-        self.highPassFilterMode = highPassFilterMode
+        self.highpassFilterMode = highpassFilterMode
     }
 
     override public func isEqual(_ object: Any?) -> Bool {
@@ -102,11 +102,11 @@ public final class AudioProcessingOptions: NSObject, Sendable {
         return echoCancellation == other.echoCancellation &&
             autoGainControl == other.autoGainControl &&
             noiseSuppression == other.noiseSuppression &&
-            highPassFilter == other.highPassFilter &&
+            highpassFilter == other.highpassFilter &&
             echoCancellationMode == other.echoCancellationMode &&
             autoGainControlMode == other.autoGainControlMode &&
             noiseSuppressionMode == other.noiseSuppressionMode &&
-            highPassFilterMode == other.highPassFilterMode
+            highpassFilterMode == other.highpassFilterMode
     }
 
     override public var hash: Int {
@@ -114,11 +114,11 @@ public final class AudioProcessingOptions: NSObject, Sendable {
         hasher.combine(echoCancellation)
         hasher.combine(autoGainControl)
         hasher.combine(noiseSuppression)
-        hasher.combine(highPassFilter)
+        hasher.combine(highpassFilter)
         hasher.combine(echoCancellationMode)
         hasher.combine(autoGainControlMode)
         hasher.combine(noiseSuppressionMode)
-        hasher.combine(highPassFilterMode)
+        hasher.combine(highpassFilterMode)
         return hasher.finalize()
     }
 }
@@ -175,7 +175,7 @@ public struct AudioProcessingState: Sendable {
     public let echoCancellation: AudioProcessingComponentState
     public let noiseSuppression: AudioProcessingComponentState
     public let autoGainControl: AudioProcessingComponentState
-    public let highPassFilter: AudioProcessingComponentState
+    public let highpassFilter: AudioProcessingComponentState
 }
 
 public enum PlatformAudioProcessingTopology: Int, Sendable {
@@ -306,8 +306,8 @@ extension AudioProcessingOptions {
                 mode: autoGainControlMode.toRTCType(),
             ),
             highPassFilterOptions: LKRTCAudioProcessingComponentOptions(
-                enabled: highPassFilter,
-                mode: highPassFilterMode.toRTCType(),
+                enabled: highpassFilter,
+                mode: highpassFilterMode.toRTCType(),
             ),
         )
     }
@@ -336,7 +336,7 @@ extension LKRTCAudioProcessingState {
             echoCancellation: echoCancellation.toLKType(),
             noiseSuppression: noiseSuppression.toLKType(),
             autoGainControl: autoGainControl.toLKType(),
-            highPassFilter: highPassFilter.toLKType(),
+            highpassFilter: highPassFilter.toLKType(),
         )
     }
 }

--- a/Sources/LiveKit/Types/AudioProcessingOptionsError.swift
+++ b/Sources/LiveKit/Types/AudioProcessingOptionsError.swift
@@ -22,8 +22,6 @@ public struct AudioProcessingOptionsError: LocalizedError, Sendable {
     public enum Code: Sendable {
         /// The receiving track is not in a state that accepts processing options.
         case invalidState
-        /// Processing options cannot be applied to a remote track.
-        case remoteTrack
         /// The requested per-effect combination is not supported.
         case invalidCombination
         /// A platform implementation was required but is unavailable.

--- a/Sources/LiveKit/Types/AudioProcessingOptionsError.swift
+++ b/Sources/LiveKit/Types/AudioProcessingOptionsError.swift
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// An error returned when audio processing options cannot be applied.
+public struct AudioProcessingOptionsError: LocalizedError, Sendable {
+    /// The machine-readable reason the request failed.
+    public let code: AudioProcessingOptionsResultCode
+
+    /// Details supplied by the audio processing implementation, if available.
+    public let message: String
+
+    /// A localized description containing the failure code and available details.
+    public var errorDescription: String? {
+        let reason = message.isEmpty ? "\(code)" : "\(code): \(message)"
+        return "Failed to set audio processing options: \(reason)"
+    }
+
+    init(_ result: AudioProcessingOptionsResult) {
+        code = result.code
+        message = result.message
+    }
+
+    init(code: AudioProcessingOptionsResultCode, message: String) {
+        self.code = code
+        self.message = message
+    }
+}

--- a/Sources/LiveKit/Types/AudioProcessingOptionsError.swift
+++ b/Sources/LiveKit/Types/AudioProcessingOptionsError.swift
@@ -16,10 +16,24 @@
 
 import Foundation
 
-/// An error returned when audio processing options cannot be applied.
+/// An error thrown when audio processing options cannot be applied.
 public struct AudioProcessingOptionsError: LocalizedError, Sendable {
     /// The machine-readable reason the request failed.
-    public let code: AudioProcessingOptionsResultCode
+    public enum Code: Sendable {
+        /// The receiving track is not in a state that accepts processing options.
+        case invalidState
+        /// Processing options cannot be applied to a remote track.
+        case remoteTrack
+        /// The requested per-effect combination is not supported.
+        case invalidCombination
+        /// A platform implementation was required but is unavailable.
+        case platformUnavailable
+        /// The engine failed to apply the options.
+        case applyFailed
+    }
+
+    /// The machine-readable reason the request failed.
+    public let code: Code
 
     /// Details supplied by the audio processing implementation, if available.
     public let message: String
@@ -28,15 +42,5 @@ public struct AudioProcessingOptionsError: LocalizedError, Sendable {
     public var errorDescription: String? {
         let reason = message.isEmpty ? "\(code)" : "\(code): \(message)"
         return "Failed to set audio processing options: \(reason)"
-    }
-
-    init(_ result: AudioProcessingOptionsResult) {
-        code = result.code
-        message = result.message
-    }
-
-    init(code: AudioProcessingOptionsResultCode, message: String) {
-        self.code = code
-        self.message = message
     }
 }

--- a/Sources/LiveKit/Types/Options/AudioCaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/AudioCaptureOptions.swift
@@ -20,20 +20,9 @@ internal import LiveKitWebRTC
 
 @objcMembers
 public final class AudioCaptureOptions: NSObject, CaptureOptions, Sendable {
-    // Defaults are `true` on all platforms. In practice these options only affect
-    // software (WebRTC) APM on iOS Simulator. On iOS device or macOS, Apple's VPIO
-    // handles AEC/AGC/NS and software APM is always off regardless of these flags.
-    //
-    // Platform behavior:
-    // - iOS device or macOS: VPIO is active. Software APM is always off. These
-    //   flags are effectively ignored for runtime processing, but still reported
-    //   to the server as audio track features for telemetry.
-    // - iOS Simulator: VPIO is not reliably available. Software APM is used and
-    //   these flags are respected.
-    //
-    // To control VPIO on device, see ``AudioManager/isVoiceProcessingEnabled``,
-    // ``AudioManager/isVoiceProcessingBypassed``, and
-    // ``AudioManager/isVoiceProcessingAGCEnabled``.
+    // Defaults preserve the historical communication profile. Each component is
+    // enabled with `.automatic` mode, which prefers platform processing when
+    // available and falls back to WebRTC software processing otherwise.
     public static let defaultEchoCancellation = true
     public static let defaultAutoGainControl = true
     public static let defaultNoiseSuppression = true
@@ -46,26 +35,31 @@ public final class AudioCaptureOptions: NSObject, CaptureOptions, Sendable {
         typingNoiseDetection: false,
     )
 
-    /// Whether to enable software (WebRTC's) echo cancellation.
-    /// Only takes effect on iOS Simulator. On iOS device or macOS, Apple's VPIO
-    /// handles AEC and this flag is ignored for runtime processing.
-    /// See ``AudioManager/isVoiceProcessingBypassed`` for device-side VPIO controls.
+    /// Whether to enable echo cancellation.
     public let echoCancellation: Bool
 
-    /// Whether to enable software (WebRTC's) gain control.
-    /// Only takes effect on iOS Simulator. On iOS device or macOS, Apple's VPIO
-    /// handles AGC and this flag is ignored for runtime processing.
-    /// See ``AudioManager/isVoiceProcessingAGCEnabled`` for device-side VPIO controls.
+    /// Whether to enable gain control.
     public let autoGainControl: Bool
 
-    /// Whether to enable software (WebRTC's) noise suppression.
-    /// Only takes effect on iOS Simulator. On iOS device or macOS, Apple's VPIO
-    /// handles NS and this flag is ignored for runtime processing.
+    /// Whether to enable noise suppression.
     public let noiseSuppression: Bool
 
     public let highpassFilter: Bool
 
     public let typingNoiseDetection: Bool
+
+    /// Selects platform versus WebRTC software echo cancellation.
+    public let echoCancellationMode: AudioProcessingMode
+
+    /// Selects platform versus WebRTC software gain control.
+    public let autoGainControlMode: AudioProcessingMode
+
+    /// Selects platform versus WebRTC software noise suppression.
+    public let noiseSuppressionMode: AudioProcessingMode
+
+    /// Selects platform versus WebRTC software high-pass filtering.
+    /// No platform HPF exists today, so `platform` is rejected.
+    public let highPassFilterMode: AudioProcessingMode
 
     public init(
         echoCancellation: Bool = AudioCaptureOptions.defaultEchoCancellation,
@@ -73,12 +67,49 @@ public final class AudioCaptureOptions: NSObject, CaptureOptions, Sendable {
         noiseSuppression: Bool = AudioCaptureOptions.defaultNoiseSuppression,
         highpassFilter: Bool = false,
         typingNoiseDetection: Bool = false,
+        echoCancellationMode: AudioProcessingMode = .automatic,
+        autoGainControlMode: AudioProcessingMode = .automatic,
+        noiseSuppressionMode: AudioProcessingMode = .automatic,
+        highPassFilterMode: AudioProcessingMode = .automatic,
     ) {
         self.echoCancellation = echoCancellation
         self.noiseSuppression = noiseSuppression
         self.autoGainControl = autoGainControl
         self.typingNoiseDetection = typingNoiseDetection
         self.highpassFilter = highpassFilter
+        self.echoCancellationMode = echoCancellationMode
+        self.autoGainControlMode = autoGainControlMode
+        self.noiseSuppressionMode = noiseSuppressionMode
+        self.highPassFilterMode = highPassFilterMode
+    }
+
+    public convenience init(audioProcessingOptions: AudioProcessingOptions,
+                            typingNoiseDetection: Bool = false)
+    {
+        self.init(
+            echoCancellation: audioProcessingOptions.echoCancellation,
+            autoGainControl: audioProcessingOptions.autoGainControl,
+            noiseSuppression: audioProcessingOptions.noiseSuppression,
+            highpassFilter: audioProcessingOptions.highPassFilter,
+            typingNoiseDetection: typingNoiseDetection,
+            echoCancellationMode: audioProcessingOptions.echoCancellationMode,
+            autoGainControlMode: audioProcessingOptions.autoGainControlMode,
+            noiseSuppressionMode: audioProcessingOptions.noiseSuppressionMode,
+            highPassFilterMode: audioProcessingOptions.highPassFilterMode,
+        )
+    }
+
+    public var audioProcessingOptions: AudioProcessingOptions {
+        AudioProcessingOptions(
+            echoCancellation: echoCancellation,
+            autoGainControl: autoGainControl,
+            noiseSuppression: noiseSuppression,
+            highPassFilter: highpassFilter,
+            echoCancellationMode: echoCancellationMode,
+            autoGainControlMode: autoGainControlMode,
+            noiseSuppressionMode: noiseSuppressionMode,
+            highPassFilterMode: highPassFilterMode,
+        )
     }
 
     // MARK: - Equatable
@@ -89,7 +120,11 @@ public final class AudioCaptureOptions: NSObject, CaptureOptions, Sendable {
             noiseSuppression == other.noiseSuppression &&
             autoGainControl == other.autoGainControl &&
             typingNoiseDetection == other.typingNoiseDetection &&
-            highpassFilter == other.highpassFilter
+            highpassFilter == other.highpassFilter &&
+            echoCancellationMode == other.echoCancellationMode &&
+            autoGainControlMode == other.autoGainControlMode &&
+            noiseSuppressionMode == other.noiseSuppressionMode &&
+            highPassFilterMode == other.highPassFilterMode
     }
 
     override public var hash: Int {
@@ -99,6 +134,10 @@ public final class AudioCaptureOptions: NSObject, CaptureOptions, Sendable {
         hasher.combine(autoGainControl)
         hasher.combine(typingNoiseDetection)
         hasher.combine(highpassFilter)
+        hasher.combine(echoCancellationMode)
+        hasher.combine(autoGainControlMode)
+        hasher.combine(noiseSuppressionMode)
+        hasher.combine(highPassFilterMode)
         return hasher.finalize()
     }
 }

--- a/Sources/LiveKit/Types/Options/AudioCaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/AudioCaptureOptions.swift
@@ -59,7 +59,7 @@ public final class AudioCaptureOptions: NSObject, CaptureOptions, Sendable {
 
     /// Selects platform versus WebRTC software high-pass filtering.
     /// No platform HPF exists today, so `platform` is rejected.
-    public let highPassFilterMode: AudioProcessingMode
+    public let highpassFilterMode: AudioProcessingMode
 
     public init(
         echoCancellation: Bool = AudioCaptureOptions.defaultEchoCancellation,
@@ -70,7 +70,7 @@ public final class AudioCaptureOptions: NSObject, CaptureOptions, Sendable {
         echoCancellationMode: AudioProcessingMode = .automatic,
         autoGainControlMode: AudioProcessingMode = .automatic,
         noiseSuppressionMode: AudioProcessingMode = .automatic,
-        highPassFilterMode: AudioProcessingMode = .automatic,
+        highpassFilterMode: AudioProcessingMode = .automatic,
     ) {
         self.echoCancellation = echoCancellation
         self.noiseSuppression = noiseSuppression
@@ -80,7 +80,7 @@ public final class AudioCaptureOptions: NSObject, CaptureOptions, Sendable {
         self.echoCancellationMode = echoCancellationMode
         self.autoGainControlMode = autoGainControlMode
         self.noiseSuppressionMode = noiseSuppressionMode
-        self.highPassFilterMode = highPassFilterMode
+        self.highpassFilterMode = highpassFilterMode
     }
 
     public convenience init(audioProcessingOptions: AudioProcessingOptions,
@@ -90,12 +90,12 @@ public final class AudioCaptureOptions: NSObject, CaptureOptions, Sendable {
             echoCancellation: audioProcessingOptions.echoCancellation,
             autoGainControl: audioProcessingOptions.autoGainControl,
             noiseSuppression: audioProcessingOptions.noiseSuppression,
-            highpassFilter: audioProcessingOptions.highPassFilter,
+            highpassFilter: audioProcessingOptions.highpassFilter,
             typingNoiseDetection: typingNoiseDetection,
             echoCancellationMode: audioProcessingOptions.echoCancellationMode,
             autoGainControlMode: audioProcessingOptions.autoGainControlMode,
             noiseSuppressionMode: audioProcessingOptions.noiseSuppressionMode,
-            highPassFilterMode: audioProcessingOptions.highPassFilterMode,
+            highpassFilterMode: audioProcessingOptions.highpassFilterMode,
         )
     }
 
@@ -104,11 +104,11 @@ public final class AudioCaptureOptions: NSObject, CaptureOptions, Sendable {
             echoCancellation: echoCancellation,
             autoGainControl: autoGainControl,
             noiseSuppression: noiseSuppression,
-            highPassFilter: highpassFilter,
+            highpassFilter: highpassFilter,
             echoCancellationMode: echoCancellationMode,
             autoGainControlMode: autoGainControlMode,
             noiseSuppressionMode: noiseSuppressionMode,
-            highPassFilterMode: highPassFilterMode,
+            highpassFilterMode: highpassFilterMode,
         )
     }
 
@@ -124,7 +124,7 @@ public final class AudioCaptureOptions: NSObject, CaptureOptions, Sendable {
             echoCancellationMode == other.echoCancellationMode &&
             autoGainControlMode == other.autoGainControlMode &&
             noiseSuppressionMode == other.noiseSuppressionMode &&
-            highPassFilterMode == other.highPassFilterMode
+            highpassFilterMode == other.highpassFilterMode
     }
 
     override public var hash: Int {
@@ -137,7 +137,7 @@ public final class AudioCaptureOptions: NSObject, CaptureOptions, Sendable {
         hasher.combine(echoCancellationMode)
         hasher.combine(autoGainControlMode)
         hasher.combine(noiseSuppressionMode)
-        hasher.combine(highPassFilterMode)
+        hasher.combine(highpassFilterMode)
         return hasher.finalize()
     }
 }

--- a/Sources/LiveKit/Types/Options/AudioCaptureOptions.swift
+++ b/Sources/LiveKit/Types/Options/AudioCaptureOptions.swift
@@ -44,22 +44,22 @@ public final class AudioCaptureOptions: NSObject, CaptureOptions, Sendable {
     /// Whether to enable noise suppression.
     public let noiseSuppression: Bool
 
+    /// Whether to enable the high-pass filter.
     public let highpassFilter: Bool
 
     public let typingNoiseDetection: Bool
 
     /// Selects platform versus WebRTC software echo cancellation.
-    public let echoCancellationMode: AudioProcessingMode
+    public let echoCancellationMode: EchoCancellationMode
 
     /// Selects platform versus WebRTC software gain control.
-    public let autoGainControlMode: AudioProcessingMode
+    public let autoGainControlMode: AutoGainControlMode
 
     /// Selects platform versus WebRTC software noise suppression.
-    public let noiseSuppressionMode: AudioProcessingMode
+    public let noiseSuppressionMode: NoiseSuppressionMode
 
-    /// Selects platform versus WebRTC software high-pass filtering.
-    /// No platform HPF exists today, so `platform` is rejected.
-    public let highpassFilterMode: AudioProcessingMode
+    /// Selects WebRTC software high-pass filtering behavior.
+    public let highpassFilterMode: HighpassFilterMode
 
     public init(
         echoCancellation: Bool = AudioCaptureOptions.defaultEchoCancellation,
@@ -67,39 +67,64 @@ public final class AudioCaptureOptions: NSObject, CaptureOptions, Sendable {
         noiseSuppression: Bool = AudioCaptureOptions.defaultNoiseSuppression,
         highpassFilter: Bool = false,
         typingNoiseDetection: Bool = false,
-        echoCancellationMode: AudioProcessingMode = .automatic,
-        autoGainControlMode: AudioProcessingMode = .automatic,
-        noiseSuppressionMode: AudioProcessingMode = .automatic,
-        highpassFilterMode: AudioProcessingMode = .automatic,
+        echoCancellationMode: EchoCancellationMode = .automatic,
+        autoGainControlMode: AutoGainControlMode = .automatic,
+        noiseSuppressionMode: NoiseSuppressionMode = .automatic,
+        highpassFilterMode: HighpassFilterMode = .automatic,
     ) {
         self.echoCancellation = echoCancellation
-        self.noiseSuppression = noiseSuppression
         self.autoGainControl = autoGainControl
-        self.typingNoiseDetection = typingNoiseDetection
+        self.noiseSuppression = noiseSuppression
         self.highpassFilter = highpassFilter
+        self.typingNoiseDetection = typingNoiseDetection
         self.echoCancellationMode = echoCancellationMode
         self.autoGainControlMode = autoGainControlMode
         self.noiseSuppressionMode = noiseSuppressionMode
         self.highpassFilterMode = highpassFilterMode
     }
 
-    public convenience init(audioProcessingOptions: AudioProcessingOptions,
-                            typingNoiseDetection: Bool = false)
-    {
+    /// Preserves the Objective-C initializer available before per-effect modes were added.
+    @objc(initWithEchoCancellation:autoGainControl:noiseSuppression:highpassFilter:typingNoiseDetection:)
+    public convenience init(
+        echoCancellation: Bool,
+        autoGainControl: Bool,
+        noiseSuppression: Bool,
+        highpassFilter: Bool,
+        typingNoiseDetection: Bool,
+    ) {
         self.init(
-            echoCancellation: audioProcessingOptions.echoCancellation,
-            autoGainControl: audioProcessingOptions.autoGainControl,
-            noiseSuppression: audioProcessingOptions.noiseSuppression,
-            highpassFilter: audioProcessingOptions.highpassFilter,
+            echoCancellation: echoCancellation,
+            autoGainControl: autoGainControl,
+            noiseSuppression: noiseSuppression,
+            highpassFilter: highpassFilter,
             typingNoiseDetection: typingNoiseDetection,
-            echoCancellationMode: audioProcessingOptions.echoCancellationMode,
-            autoGainControlMode: audioProcessingOptions.autoGainControlMode,
-            noiseSuppressionMode: audioProcessingOptions.noiseSuppressionMode,
-            highpassFilterMode: audioProcessingOptions.highpassFilterMode,
+            echoCancellationMode: .automatic,
+            autoGainControlMode: .automatic,
+            noiseSuppressionMode: .automatic,
+            highpassFilterMode: .automatic,
         )
     }
 
-    public var audioProcessingOptions: AudioProcessingOptions {
+    // MARK: - Equatable
+
+    override public func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return audioProcessing == other.audioProcessing &&
+            typingNoiseDetection == other.typingNoiseDetection
+    }
+
+    override public var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(audioProcessing)
+        hasher.combine(typingNoiseDetection)
+        return hasher.finalize()
+    }
+}
+
+// Internal
+extension AudioCaptureOptions {
+    /// The per-effect voice-processing configuration as runtime options.
+    var audioProcessing: AudioProcessingOptions {
         AudioProcessingOptions(
             echoCancellation: echoCancellation,
             autoGainControl: autoGainControl,
@@ -112,38 +137,6 @@ public final class AudioCaptureOptions: NSObject, CaptureOptions, Sendable {
         )
     }
 
-    // MARK: - Equatable
-
-    override public func isEqual(_ object: Any?) -> Bool {
-        guard let other = object as? Self else { return false }
-        return echoCancellation == other.echoCancellation &&
-            noiseSuppression == other.noiseSuppression &&
-            autoGainControl == other.autoGainControl &&
-            typingNoiseDetection == other.typingNoiseDetection &&
-            highpassFilter == other.highpassFilter &&
-            echoCancellationMode == other.echoCancellationMode &&
-            autoGainControlMode == other.autoGainControlMode &&
-            noiseSuppressionMode == other.noiseSuppressionMode &&
-            highpassFilterMode == other.highpassFilterMode
-    }
-
-    override public var hash: Int {
-        var hasher = Hasher()
-        hasher.combine(echoCancellation)
-        hasher.combine(noiseSuppression)
-        hasher.combine(autoGainControl)
-        hasher.combine(typingNoiseDetection)
-        hasher.combine(highpassFilter)
-        hasher.combine(echoCancellationMode)
-        hasher.combine(autoGainControlMode)
-        hasher.combine(noiseSuppressionMode)
-        hasher.combine(highpassFilterMode)
-        return hasher.finalize()
-    }
-}
-
-// Internal
-extension AudioCaptureOptions {
     func toFeatures() -> Set<Livekit_AudioTrackFeature> {
         Set([
             echoCancellation ? .tfEchoCancellation : nil,

--- a/Tests/LiveKitAudioTests/AudioEngineAvailability.swift
+++ b/Tests/LiveKitAudioTests/AudioEngineAvailability.swift
@@ -26,7 +26,7 @@ import LiveKitTestSupport
     // then resume (restart) when availability is set back to .default.
     @Test func recording() throws {
         // Test without enabling VP
-        try AudioManager.shared.setVoiceProcessingEnabled(false)
+        try AudioManager.shared.setPlatformVoiceProcessingAllowed(false)
 
         // First check
         #expect(!AudioManager.shared.isEngineRunning)

--- a/Tests/LiveKitAudioTests/AudioEngineObserver.swift
+++ b/Tests/LiveKitAudioTests/AudioEngineObserver.swift
@@ -44,7 +44,7 @@ final class TestEngineObserver: AudioEngineObserver, @unchecked Sendable {
         AudioManager.shared.set(engineObservers: [testObserver])
 
         // Test without enabling VP
-        try AudioManager.shared.setVoiceProcessingEnabled(false)
+        try AudioManager.shared.setPlatformVoiceProcessingAllowed(false)
 
         // First check
         #expect(!AudioManager.shared.isEngineRunning)

--- a/Tests/LiveKitAudioTests/AudioEnginePermission.swift
+++ b/Tests/LiveKitAudioTests/AudioEnginePermission.swift
@@ -27,7 +27,7 @@ import LiveKitTestSupport
     // configured correctly. Only for non-macOS platforms.
     @Test func audioSessionPermission() throws {
         // Test without enabling VP
-        try AudioManager.shared.setVoiceProcessingEnabled(false)
+        try AudioManager.shared.setPlatformVoiceProcessingAllowed(false)
 
         // First check
         #expect(!AudioManager.shared.isEngineRunning)

--- a/Tests/LiveKitAudioTests/PublishDeviceOptimization.swift
+++ b/Tests/LiveKitAudioTests/PublishDeviceOptimization.swift
@@ -46,7 +46,7 @@ import LiveKitTestSupport
     // No-VP publish flow
     @Test func noVpMicPublish() async throws {
         // Turn off Apple's VP
-        try AudioManager.shared.setVoiceProcessingEnabled(false)
+        try AudioManager.shared.setPlatformVoiceProcessingAllowed(false)
 
         let span = Span(label: "Test: No-VP publish sequence")
 

--- a/Tests/LiveKitCoreTests/AudioProcessingOptionsTests.swift
+++ b/Tests/LiveKitCoreTests/AudioProcessingOptionsTests.swift
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+import Testing
+
+struct AudioProcessingOptionsTests {
+    @Test func captureOptionsProjectToProcessingOptions() {
+        let options = AudioCaptureOptions(
+            echoCancellation: true,
+            autoGainControl: false,
+            noiseSuppression: true,
+            highpassFilter: false,
+            echoCancellationMode: .software,
+            autoGainControlMode: .platform,
+            noiseSuppressionMode: .automatic,
+            highpassFilterMode: .software,
+        )
+
+        let expected = AudioProcessingOptions(
+            echoCancellation: true,
+            autoGainControl: false,
+            noiseSuppression: true,
+            highpassFilter: false,
+            echoCancellationMode: .software,
+            autoGainControlMode: .platform,
+            noiseSuppressionMode: .automatic,
+            highpassFilterMode: .software,
+        )
+        #expect(options.audioProcessing == expected)
+    }
+
+    @Test func noProcessingPresetsAgree() {
+        #expect(AudioCaptureOptions.noProcessing.audioProcessing == AudioProcessingOptions.noProcessing)
+    }
+
+    @Test func legacyCaptureInitializerDefaultsToAutomaticModes() {
+        let options = AudioCaptureOptions(
+            echoCancellation: false,
+            autoGainControl: true,
+            noiseSuppression: false,
+            highpassFilter: true,
+            typingNoiseDetection: true,
+        )
+
+        #expect(options.echoCancellation == false)
+        #expect(options.autoGainControl == true)
+        #expect(options.noiseSuppression == false)
+        #expect(options.highpassFilter == true)
+        #expect(options.echoCancellationMode == .automatic)
+        #expect(options.autoGainControlMode == .automatic)
+        #expect(options.noiseSuppressionMode == .automatic)
+        #expect(options.highpassFilterMode == .automatic)
+        #expect(options.typingNoiseDetection == true)
+    }
+
+    @Test func effectSpecificModesMapToConstraints() {
+        #expect(EchoCancellationMode.platform.toConstraintValue() == "platform")
+        #expect(AutoGainControlMode.software.toConstraintValue() == "software")
+        #expect(NoiseSuppressionMode.automatic.toConstraintValue() == "auto")
+        #expect(HighpassFilterMode.software.toConstraintValue() == "software")
+        #expect(HighpassFilterMode.automatic.toConstraintValue() == "auto")
+    }
+
+    @Test func componentRequestsPreserveEffectSpecificModeTypes() {
+        let echoCancellation = AudioProcessingComponentRequest(
+            isEnabled: true,
+            mode: EchoCancellationMode.platform,
+        )
+        let highpassFilter = AudioProcessingComponentRequest(
+            isEnabled: true,
+            mode: HighpassFilterMode.software,
+        )
+
+        #expect(echoCancellation.mode == .platform)
+        #expect(highpassFilter.mode == .software)
+    }
+}

--- a/Tests/LiveKitObjCTests/Basic.m
+++ b/Tests/LiveKitObjCTests/Basic.m
@@ -27,4 +27,17 @@
     NSLog(@"%@", LiveKitSDK.sdkVersion);
 }
 
+- (void)testAudioCaptureOptionsInitializer {
+    AudioCaptureOptions *options = [[AudioCaptureOptions alloc] initWithEchoCancellation:NO
+                                                                         autoGainControl:YES
+                                                                        noiseSuppression:NO
+                                                                           highpassFilter:YES
+                                                                    typingNoiseDetection:NO];
+    XCTAssertFalse(options.echoCancellation);
+    XCTAssertTrue(options.autoGainControl);
+    XCTAssertFalse(options.noiseSuppression);
+    XCTAssertTrue(options.highpassFilter);
+    XCTAssertFalse(options.typingNoiseDetection);
+}
+
 @end


### PR DESCRIPTION
## Summary

Adds an explicit, per-effect audio processing API so apps can choose how each effect runs, either Apple's platform Voice Processing I/O on the device or WebRTC's software processing, instead of relying on implicit toggles. This also adopts the webrtc-sdk audio processing state v2 contract for accurate, engine-wide diagnostics.

### Motivation

Until now, software voice processing was reached indirectly by disabling platform voice processing, and the exact behavior changed across releases. Some apps deliberately avoid Apple VPIO (for consistent hardware volume, faster call start, screen recording with audio, and no system mute sounds) while still wanting echo cancellation and noise suppression in software. This PR makes that an explicit, stable choice.

## New API

The new surface is Swift-only. The shipped Objective-C surface of `AudioCaptureOptions` (its `Bool` properties and `initWithEchoCancellation:...` initializer) is unchanged.

### Per-effect mode types

Each effect has its own mode type: `EchoCancellationMode`, `NoiseSuppressionMode`, `AutoGainControlMode`, and `HighpassFilterMode`, selecting the implementation:

- `.automatic` (default): prefer platform processing when available, fall back to WebRTC software otherwise.
- `.platform`: use platform processing only. Rejected if the platform implementation is unavailable.
- `.software`: force WebRTC software processing and disable the matching platform effect when possible.

There is no platform high-pass filter, so `HighpassFilterMode` offers only `.automatic` and `.software` — requesting a platform HPF is unrepresentable at compile time.

### `AudioProcessingOptions`

An immutable `Hashable`, `Sendable` struct describing all four effects (echo cancellation, noise suppression, auto gain control, high-pass filter) with an enabled flag and a mode each. The default initializer produces the communication profile (EC/AGC/NS enabled, HPF disabled, all modes `.automatic`); an `AudioProcessingOptions.noProcessing` preset disables everything.

### `AudioCaptureOptions`

Gains matching `*Mode` fields (`echoCancellationMode`, `autoGainControlMode`, `noiseSuppressionMode`, `highpassFilterMode`, following the existing Swift `highpassFilter` spelling). Existing call sites keep working since modes default to `.automatic`.

### Runtime control

`LocalAudioTrack.setAudioProcessingOptions(_:)` applies options to an already-published track. On success it returns `AudioProcessingOptionsResult` (`.applied`, or `.stored` when no sender is active yet); on failure it throws `AudioProcessingOptionsError`, whose `code` carries the reason (`.invalidState`, `.invalidCombination`, `.platformUnavailable`, `.applyFailed`). Success and failure states are separate types, so neither can express the other.

### Diagnostics

`AudioManager.audioProcessingState` exposes the v2 state, following the `requested -> resolved -> active -> effective` vocabulary, read from the factory-owned, engine-wide module rather than a single peer connection. Each component reports its last typed request, per-path detail (`software` and `platform` resolved/active flags, with `platform` being `nil` on devices without a built-in implementation), and the `effective` implementation.

`AudioManager.platformVoiceProcessingState` separately exposes device-level Apple Voice Processing I/O state: per-effect availability/requested/active, coupling topology, and the VPIO unit's enabled/bypassed/AGC flags as requested/active pairs.

### Renamed API

`AudioManager.setVoiceProcessingEnabled(_:)` and `isVoiceProcessingEnabled` are renamed to `setPlatformVoiceProcessingAllowed(_:)` and `isPlatformVoiceProcessingAllowed`, matching the underlying ADM accessors and the "allowed" policy meaning. The old names remain as deprecated, renamed forwarders, so existing code keeps compiling with a fix-it.

## Usage

Publish the microphone with all effects forced to software:

```swift
let options = AudioCaptureOptions(
    echoCancellation: true,
    autoGainControl: true,
    noiseSuppression: true,
    highpassFilter: true,
    echoCancellationMode: .software,
    autoGainControlMode: .software,
    noiseSuppressionMode: .software,
    highpassFilterMode: .software
)
try await room.localParticipant.setMicrophone(enabled: true, captureOptions: options)
```

Set it as the room default so it applies whenever the mic track is published:

```swift
try await room.connect(url: url, token: token,
                       roomOptions: RoomOptions(defaultAudioCaptureOptions: options))
```

Guarantee Apple VPIO is never used, then rely on software processing:

```swift
try AudioManager.shared.setPlatformVoiceProcessingAllowed(false)
```

Verify what each effect resolved to:

```swift
let state = AudioManager.shared.audioProcessingState
print(state.echoCancellation.effective) // Software
print(state.noiseSuppression.effective)  // Software
```

## Documentation

`Docs/audio.md` gains a new section, "Audio Processing Modes (software, platform, automatic)", covering publish-time, room-default, and runtime configuration, plus how to verify the resolved implementation. The "Disallowing Platform Voice Processing" section is updated to the renamed API.

## Example app

A companion example demonstrates the full surface, including a live "Voice Processing" and "Runtime Audio Processing" panel with effective-state diagnostics:

- Branch: https://github.com/livekit-examples/swift-example/tree/hiroshi/runtime-vp
- Audio controls UI: [`Multiplatform/Views/AudioControlsPanel.swift`](https://github.com/livekit-examples/swift-example/blob/hiroshi/runtime-vp/Multiplatform/Views/AudioControlsPanel.swift)
- Wiring: [`Multiplatform/Controllers/AppContext.swift`](https://github.com/livekit-examples/swift-example/blob/hiroshi/runtime-vp/Multiplatform/Controllers/AppContext.swift)

That branch pins its SDK dependency to this branch (`hiroshi/runtime-vp`).

## Notes

- Requires `LiveKitWebRTC` `144.7559.11` (already on `main`).
- Room defaults apply at track creation. An already-published mic track is updated through `setAudioProcessingOptions(_:)`, not by toggling the mic.
- Runtime options apply to the engine-wide audio processing module; conflicting updates from multiple local audio tracks are last-writer-wins.

## Test plan

- [x] macOS build passes
- [x] `AudioProcessingOptionsTests` and Objective-C compatibility tests pass
- [x] Generated Objective-C header inspected: shipped `AudioCaptureOptions` selector preserved, no new Swift-only types exposed
- [ ] Example app builds and runs on macOS against the final API
