### PR TITLE
Fix ping/pong timeout never firing: a lost signaling connection stays `.connected` forever

### DIFF
--- a/.changes/fix-ping-timeout
+++ b/.changes/fix-ping-timeout
@@ -1,0 +1,1 @@
+patch type="fixed" "Ping/pong timeout was re-armed on every ping and never fired, leaving a lost signaling connection stuck at .connected"

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -677,7 +677,8 @@ private extension SignalClient {
             await cleanUp(withError: LiveKitError(.serverPingTimedOut))
         }
 
-        _pingTimeoutTimer.restart()
+        // Arm without resetting a running countdown, else every ping pushes the deadline out and it never fires.
+        _pingTimeoutTimer.startIfStopped()
     }
 
     func _onReceivedPong(_: Int64) async {

--- a/Sources/LiveKit/Support/Async/AsyncTimer.swift
+++ b/Sources/LiveKit/Support/Async/AsyncTimer.swift
@@ -89,4 +89,10 @@ final class AsyncTimer: Sendable, Loggable {
 
         Task { await scheduleNextInvocation() }
     }
+
+    /// Starts the timer only if not already running, leaving an in-flight countdown untouched.
+    func startIfStopped() {
+        if _state.read({ $0.isStarted }) { return }
+        restart()
+    }
 }

--- a/Tests/LiveKitCoreTests/AsyncTimerTests.swift
+++ b/Tests/LiveKitCoreTests/AsyncTimerTests.swift
@@ -23,7 +23,6 @@ import LiveKitTestSupport
 
 @Suite(.tags(.concurrency))
 struct AsyncTimerTests {
-
     @Test func startIfStoppedFiresWhileRepeatedlyArmed() async throws {
         let counter = ConcurrentCounter()
         let timer = AsyncTimer(interval: 0.2)

--- a/Tests/LiveKitCoreTests/AsyncTimerTests.swift
+++ b/Tests/LiveKitCoreTests/AsyncTimerTests.swift
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+@testable import LiveKit
+import Testing
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+@Suite(.tags(.concurrency))
+struct AsyncTimerTests {
+
+    @Test func startIfStoppedFiresWhileRepeatedlyArmed() async throws {
+        let counter = ConcurrentCounter()
+        let timer = AsyncTimer(interval: 0.2)
+        timer.setTimerBlock { _ = await counter.increment() }
+
+        // Arm every 20ms for ~500ms — ~25 arms across the 200ms timeout window.
+        for _ in 0 ..< 25 {
+            timer.startIfStopped()
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        timer.cancel()
+
+        // The first arm's countdown was never reset, so it fired at ~200ms.
+        #expect(await counter.getCount() >= 1)
+    }
+
+    @Test func restartNeverFiresWhileRepeatedlyArmed() async throws {
+        let counter = ConcurrentCounter()
+        let timer = AsyncTimer(interval: 0.2)
+        timer.setTimerBlock { _ = await counter.increment() }
+
+        for _ in 0 ..< 25 {
+            timer.restart()
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        let firedWhileArming = await counter.getCount()
+        timer.cancel()
+
+        #expect(firedWhileArming == 0)
+    }
+}


### PR DESCRIPTION
## Summary
  
When the signaling WebSocket dies but media stays up, the SDK gets stuck in a zombie state: `Room.connectionState` stays `.connected`, `didUpdateConnectionState` never fires, and the client neither reconnects nor disconnects. The ping/pong liveness check that should catch this never fires, because its timeout is re-armed on every ping.

This has happened in practice to us when the device switches networks silently in the background.
  
Related: #367, #368.

 ## Root cause

  `SignalClient._onPingIntervalTimer()` arms the ping timeout with `_pingTimeoutTimer.restart()` on **every** ping interval:

  ```swift
  func _onPingIntervalTimer() async throws {
      guard let jr = _state.lastJoinResponse else { return }
      try await _sendPing()
      _pingTimeoutTimer.setTimerInterval(TimeInterval(jr.pingTimeout))
      _pingTimeoutTimer.setTimerBlock { /* cleanUp(.serverPingTimedOut) */ }
      _pingTimeoutTimer.restart()   // cancels the in-flight countdown and starts a new one
  }
  ```

  `restart()` cancels the running countdown and starts a fresh one. With the server's typical `pingInterval` (5s) `< pingTimeout` (15s), every ping pushes the
  deadline out before it can elapse, so it **never** fires:

  ```
  t=0   ping -> arm timeout, deadline t+15
  t=5   ping -> restart,      deadline t+20   (t+15 cancelled)
  t=10  ping -> restart,      deadline t+25   (t+20 cancelled)
  ...   never fires
  ```
  
The timeout is meant to be cleared by a **pong** (`_onReceivedPong` / `_onReceivedPongResp` -> `cancel()`), not by sending another ping. Healthy connections hide the bug because a pong cancels the timer before the next ping touches it, so `restart()` and a non-resetting start are equivalent there — they only diverge once pongs stop, which is exactly the case the timeout exists to catch. (Ping sends failing doesn't help either: the send error is swallowed in the
  request queue, so `_onPingIntervalTimer` runs to completion and re-arms every interval regardless.)                                       

## Why nothing else catches it

The transport/ICE-failure path (`Room+TransportDelegate` -> `startReconnect(reason: .transport)`) only fires when the **media** peer connection dies. A signaling-only outage — signaling dead, media alive — leaves that path silent, so the ping/pong timeout is the *only* watchdog for it.
  
## Fix

Add `AsyncTimer.startIfStopped()`, which starts the timer only if it isn't already running and otherwise leaves the in-flight countdown untouched, and use it to arm the ping timeout.

 The first un-answered ping arms the deadline and subsequent pings leave it intact; when pongs stop, it elapses once -> `cleanUp(.serverPingTimedOut)` -> `.disconnected` -> the existing reconnect path runs.

## Tests
  
Added `AsyncTimerTests`:
  - `startIfStoppedFiresWhileRepeatedlyArmed` — arms the timer far more often than its interval; asserts the block still fires (fix behavior).
  - `restartNeverFiresWhileRepeatedlyArmed` — same with `restart()`; asserts it never fires while being re-armed (regression guard documenting the bug).