### PR TITLE
Fix AudioEngineDevice error-code mapping (mic permission / audio session)

### DIFF
--- a/.changes/fix-adm-error-mapping
+++ b/.changes/fix-adm-error-mapping
@@ -1,0 +1,1 @@
+patch type="fixed" "Report microphone permission and audio session errors with the correct error type"

--- a/Sources/LiveKit/Audio/Manager/AudioManager.swift
+++ b/Sources/LiveKit/Audio/Manager/AudioManager.swift
@@ -539,20 +539,22 @@ extension AudioManager {
     }
 }
 
-// SDK side AudioEngine error codes
+// Error code originating from the SDK's own AudioEngineObserver chain.
 let kAudioEngineErrorFailedToConfigureAudioSession = -4100
-let kAudioEngineErrorAudioSessionCategoryRecordingRequired = -4102
 
-let kAudioEngineErrorInsufficientDevicePermission = -4101
+// Error codes originating from the WebRTC AudioEngineDevice.
+// Keep these values in sync with `audio_engine_device.h` in the webrtc-sdk fork.
+let kAudioEngineErrorInsufficientDevicePermission = -9000
+let kAudioEngineErrorAudioSessionInvalidCategory = -9001
 
 extension AudioManager {
     func checkAdmResult(code: Int) throws {
         if code == kAudioEngineErrorFailedToConfigureAudioSession {
             throw LiveKitError(.audioSession, message: "Failed to configure audio session")
         } else if code == kAudioEngineErrorInsufficientDevicePermission {
-            throw LiveKitError(.deviceAccessDenied, message: "Device permissions are not granted")
-        } else if code == kAudioEngineErrorAudioSessionCategoryRecordingRequired {
-            throw LiveKitError(.audioSession, message: "Recording category required for audio session")
+            throw LiveKitError(.deviceAccessDenied, message: "Microphone permission is not granted")
+        } else if code == kAudioEngineErrorAudioSessionInvalidCategory {
+            throw LiveKitError(.audioSession, message: "Audio session category does not support recording")
         } else if code != 0 {
             throw LiveKitError(.audioEngine, message: "Audio engine returned error code: \(code)")
         }

--- a/Sources/LiveKit/LiveKit+DeviceHelpers.swift
+++ b/Sources/LiveKit/LiveKit+DeviceHelpers.swift
@@ -41,10 +41,15 @@ public extension LiveKitSDK {
         return true
     }
 
-    /// Blocking version of ensureDeviceAccess that uses DispatchGroup to wait for permissions.
+    /// Blocking version of ``ensureDeviceAccess(for:)`` that uses a `DispatchGroup` to wait for permissions.
+    ///
+    /// - Warning: Requesting `.notDetermined` permission blocks the calling thread until the user responds.
+    ///   When the app is backgrounded (for example, woken by a CallKit call) the system dialog never appears
+    ///   and the call blocks indefinitely. Prefer the async ``ensureDeviceAccess(for:)`` instead.
+    @available(*, deprecated, message: "Blocking permission requests can hang the calling thread. Use the async ensureDeviceAccess(for:) instead.")
     static func ensureDeviceAccessSync(for types: Set<AVMediaType>) -> Bool {
         let group = DispatchGroup()
-        nonisolated(unsafe) var result = false
+        nonisolated(unsafe) var granted = true
 
         for type in types {
             if ![.video, .audio].contains(type) {
@@ -55,25 +60,25 @@ public extension LiveKitSDK {
             switch status {
             case .notDetermined:
                 group.enter()
-                AVCaptureDevice.requestAccess(for: type) { granted in
-                    if !granted {
-                        result = false
+                AVCaptureDevice.requestAccess(for: type) { result in
+                    if !result {
+                        granted = false
                     }
                     group.leave()
                 }
             case .restricted, .denied:
                 return false
             case .authorized:
-                continue // No action needed for authorized status
+                continue // No action needed for authorized status.
             @unknown default:
                 log("Unknown AVAuthorizationStatus", .error)
                 return false
             }
         }
 
-        // Wait for all permission requests to complete
+        // Wait for all permission requests to complete.
         group.wait()
 
-        return result
+        return granted
     }
 }

--- a/Tests/LiveKitAudioTests/AudioManagerAdmResultTests.swift
+++ b/Tests/LiveKitAudioTests/AudioManagerAdmResultTests.swift
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+import Testing
+
+@Suite(.tags(.audio)) struct AudioManagerAdmResultTests {
+    let audioManager = AudioManager.shared
+
+    @Test func successCodeDoesNotThrow() throws {
+        try audioManager.checkAdmResult(code: 0)
+    }
+
+    // The WebRTC AudioEngineDevice returns -9000 when microphone permission is not granted.
+    // This must map to `.deviceAccessDenied`, not the generic `.audioEngine`.
+    @Test func insufficientDevicePermissionMapsToDeviceAccessDenied() throws {
+        let error = try #require(throws: LiveKitError.self) {
+            try audioManager.checkAdmResult(code: kAudioEngineErrorInsufficientDevicePermission)
+        }
+        #expect(error.type == .deviceAccessDenied)
+    }
+
+    // The WebRTC AudioEngineDevice returns -9001 when the audio session category cannot record.
+    @Test func invalidCategoryMapsToAudioSession() throws {
+        let error = try #require(throws: LiveKitError.self) {
+            try audioManager.checkAdmResult(code: kAudioEngineErrorAudioSessionInvalidCategory)
+        }
+        #expect(error.type == .audioSession)
+    }
+
+    @Test func failedToConfigureAudioSessionMapsToAudioSession() throws {
+        let error = try #require(throws: LiveKitError.self) {
+            try audioManager.checkAdmResult(code: kAudioEngineErrorFailedToConfigureAudioSession)
+        }
+        #expect(error.type == .audioSession)
+    }
+
+    @Test func unrecognizedCodeMapsToAudioEngine() throws {
+        let error = try #require(throws: LiveKitError.self) {
+            try audioManager.checkAdmResult(code: -1234)
+        }
+        #expect(error.type == .audioEngine)
+    }
+}


### PR DESCRIPTION
`AudioManager.checkAdmResult` mapped the WebRTC `AudioEngineDevice` error codes to the wrong values, so real errors surfaced as a generic `.audioEngine` failure instead of the specific type.

## The bug

The SDK defined the ADM error constants as `-4101` / `-4102`, but the `AudioEngineDevice` on the currently shipped m144 line (`audio_engine_device.h`) returns:

- `-9000` — insufficient device (microphone) permission
- `-9001` — invalid audio session category

Because the constants didn't match, `checkAdmResult` never hit those branches and fell through to `LiveKitError(.audioEngine, "Audio engine returned error code: -9000")`. In particular a denied microphone surfaced as an opaque audio-engine error rather than `.deviceAccessDenied`.

This is a real bug against the **currently pinned** `144.7559.10` — it does not depend on any WebRTC change.

## Backing evidence (webrtc-sdk/webrtc)

Pinned to [`aaec8ce`](https://github.com/webrtc-sdk/webrtc/tree/aaec8ce56daeb1efdcda38ea588f0f7217d6a2b1) on `m144_release` (the line `144.7559.10` is built from; the values were introduced with the m144 upgrade in Mar 2026, so every `144.7559.x` build has them).

Enum definition — [`modules/audio_device/audio_engine_device.h#L101-L103`](https://github.com/webrtc-sdk/webrtc/blob/aaec8ce56daeb1efdcda38ea588f0f7217d6a2b1/modules/audio_device/audio_engine_device.h#L101-L103):

```cpp
  // Permission and session errors
  kAudioEngineErrorInsufficientDevicePermission = -9000,
  kAudioEngineErrorAudioSessionInvalidCategory = -9001
```

Return sites in the pre-enable check — [`audio_engine_device.mm#L2291`](https://github.com/webrtc-sdk/webrtc/blob/aaec8ce56daeb1efdcda38ea588f0f7217d6a2b1/modules/audio_device/audio_engine_device.mm#L2291) and [`#L2301`](https://github.com/webrtc-sdk/webrtc/blob/aaec8ce56daeb1efdcda38ea588f0f7217d6a2b1/modules/audio_device/audio_engine_device.mm#L2301):

```cpp
        return rollback(kAudioEngineErrorInsufficientDevicePermission);   // -9000
...
      return rollback(kAudioEngineErrorAudioSessionInvalidCategory);      // -9001
```

(The same values are also present on `m137_release`, so the SDK's `-4101`/`-4102` never matched either line — this is a longstanding mismatch, not an m144 regression.)

## Changes

- Align the ADM error constants with `audio_engine_device.h` (`-9000` / `-9001`) and map them in `checkAdmResult` to `.deviceAccessDenied` / `.audioSession`. `-4100` (the SDK's own `AudioSessionEngineObserver` code) is unchanged.
- Add `AudioManagerAdmResultTests` covering the success, both ADM codes, the observer code, and the fallthrough.
- Fix and deprecate `LiveKitSDK.ensureDeviceAccessSync(for:)`: it returned `false` even when permission was already granted (the result was initialized `false` and never set `true` on the authorized path). It is also a blocking call that can hang the caller, so it is now `@available(*, deprecated)` in favor of the async `ensureDeviceAccess(for:)`.

## Code path

How a device error reaches `checkAdmResult`, using the `-9000` microphone-permission case (the `-9001` category path is identical). Nothing remaps the value along the way — permalinks pinned to [`aaec8ce`](https://github.com/webrtc-sdk/webrtc/tree/aaec8ce56daeb1efdcda38ea588f0f7217d6a2b1):

1. **C++ ADM** raises it in the device-rendering pre-enable check: [`audio_engine_device.mm#L2291`](https://github.com/webrtc-sdk/webrtc/blob/aaec8ce56daeb1efdcda38ea588f0f7217d6a2b1/modules/audio_device/audio_engine_device.mm#L2291) — `return rollback(kAudioEngineErrorInsufficientDevicePermission);` (`-9000`).
2. **C++ public methods** return the `ModifyEngineState` result directly: [`InitAndStartRecording()`](https://github.com/webrtc-sdk/webrtc/blob/aaec8ce56daeb1efdcda38ea588f0f7217d6a2b1/modules/audio_device/audio_engine_device.mm#L1481) and [`SetInitRecordingPersistentMode(...)`](https://github.com/webrtc-sdk/webrtc/blob/aaec8ce56daeb1efdcda38ea588f0f7217d6a2b1/modules/audio_device/audio_engine_device.mm#L1549) (also `InitRecording` / `StartRecording`).
3. **ObjC wrapper** returns the `int32` as `NSInteger` unchanged via `BlockingCall`: [`RTCAudioDeviceModule.mm` `initAndStartRecording`](https://github.com/webrtc-sdk/webrtc/blob/aaec8ce56daeb1efdcda38ea588f0f7217d6a2b1/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm#L344) and [`setRecordingAlwaysPreparedMode:`](https://github.com/webrtc-sdk/webrtc/blob/aaec8ce56daeb1efdcda38ea588f0f7217d6a2b1/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm#L484).
4. **Swift** passes it straight to `checkAdmResult`: `AudioManager.startLocalRecording()` → `RTC.audioDeviceModule.initAndStartRecording()`, and `setRecordingAlwaysPreparedMode(_:)` → `RTC.audioDeviceModule.setRecordingAlwaysPreparedMode(_:)`.
5. **`checkAdmResult`** maps `-9000` → `.deviceAccessDenied` (this PR). Previously `-9000` matched neither `-4101` nor `-4102`, so it fell through to `.audioEngine("error code: -9000")`.

The SDK's own `-4100` (`AudioSessionEngineObserver`) round-trips through this same chain (SDK observer → ObjC delegate → C++ `OnEngineWillEnable` → `rollback` → back up), which is why it is kept mapped while the two ADM-originated codes are re-pointed.