### PR TITLE
Remove non-public buttonPressed: selector from broadcast picker activation

### DIFF
--- a/.changes/broadcast-picker-private-selector
+++ b/.changes/broadcast-picker-private-selector
@@ -1,0 +1,1 @@
+patch type="fixed" "Remove non-public buttonPressed: selector from broadcast picker activation"

--- a/Sources/LiveKit/Broadcast/BroadcastManager.swift
+++ b/Sources/LiveKit/Broadcast/BroadcastManager.swift
@@ -23,6 +23,8 @@ import Foundation
 import ReplayKit
 #endif
 
+import UIKit
+
 /// Manages the broadcast state and track publication for screen sharing on iOS.
 public final class BroadcastManager: Sendable {
     /// Shared broadcast manager instance.
@@ -115,16 +117,22 @@ public protocol BroadcastManagerDelegate: Sendable {
     func broadcastManager(didChangeState isBroadcasting: Bool)
 }
 
-private extension RPSystemBroadcastPickerView {
+extension RPSystemBroadcastPickerView {
     /// Convenience function to show broadcast picker.
     static func showPicker(for preferredExtension: String?) {
         let view = RPSystemBroadcastPickerView()
         view.preferredExtension = preferredExtension
         view.showsMicrophoneButton = false
+        view.triggerPicker()
+    }
 
-        let selector = NSSelectorFromString("buttonPressed:")
-        guard view.responds(to: selector) else { return }
-        view.perform(selector, with: nil)
+    /// Simulates a tap on the picker's button using only public API.
+    func triggerPicker() {
+        guard let button = subviews.compactMap({ $0 as? UIButton }).first else {
+            sharedLogger.log("Unable to find button in RPSystemBroadcastPickerView", .warning, type: RPSystemBroadcastPickerView.self)
+            return
+        }
+        button.sendActions(for: .touchUpInside)
     }
 }
 

--- a/Sources/LiveKit/Track/Support/Extensions.swift
+++ b/Sources/LiveKit/Track/Support/Extensions.swift
@@ -111,10 +111,7 @@ public extension RPSystemBroadcastPickerView {
         let view = RPSystemBroadcastPickerView()
         view.preferredExtension = preferredExtension
         view.showsMicrophoneButton = showsMicrophoneButton
-        let selector = NSSelectorFromString("buttonPressed:")
-        if view.responds(to: selector) {
-            view.perform(selector, with: nil)
-        }
+        view.triggerPicker()
     }
 }
 #endif


### PR DESCRIPTION
## Summary

Apple's automated App Review now flags the literal `buttonPressed:` selector string in application binaries (ITMS-90338 / Guideline 2.5.1) and blocks submissions of any app that links LiveKit — even apps that never use screen sharing or ReplayKit (#1064).

Two code paths embedded the private selector:

- `BroadcastManager.requestActivation()` (`Sources/LiveKit/Broadcast/BroadcastManager.swift`) — the current activation path, invoked automatically from `LocalParticipant.setScreenShare(enabled:)` when `useBroadcastExtension` is enabled
- The deprecated `RPSystemBroadcastPickerView.show(for:showsMicrophoneButton:)` extension (`Sources/LiveKit/Track/Support/Extensions.swift`) — deprecated in #586, but the selector still shipped in the binary

Both now activate the picker using only public API: locate the picker's `UIButton` subview and fire it via `sendActions(for: .touchUpInside)`. This is the same approach used by other RTC SDKs (Tencent TUIRoomKit, Nextcloud Talk, Agora examples, 100ms). If the button is ever not found (e.g. a future OS changes the view hierarchy), a warning is logged instead of silently no-opping.

No public API changes; behavior is identical at runtime.

## Verification

- `rg buttonPressed Sources/` returns no matches, and `strings` over the compiled objects and a device build of the example app confirms the selector string no longer appears in downstream binaries
- Tested on a physical iPhone with the swift-example app: the system broadcast picker opens via `requestActivation()`, shows the app's broadcast extension preselected, and the broadcast starts and publishes normally
- `xcodebuild build -scheme LiveKit -destination 'generic/platform=iOS Simulator'` succeeds; swiftformat / swiftlint clean

Fixes #1064
