### PR TITLE
Disable wrapIfStatementBodies SwiftFormat rule

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -5,4 +5,5 @@
 --disable modifiersOnSameLine
 --disable wrapPropertyBodies
 --disable wrapFunctionBodies
+--disable wrapIfStatementBodies
 --disable docComments


### PR DESCRIPTION
SwiftFormat 0.62 deprecated `wrapConditionalBodies` and split out `wrapIfStatementBodies` as enabled by default, which fails CI lint on 39 files (141 violations) repo-wide — blocking all PRs. Disabling it preserves the existing single-line style, consistent with the already-disabled `wrapPropertyBodies`/`wrapFunctionBodies`, with zero code churn.

Verified locally with swiftformat 0.62.1: `0/372 files require formatting`.