### PR TITLE
Negotiate Opus stereo in the subscriber answer so stereo publications are no longer downmixed to mono when using custom renderers

### DIFF
--- a/.changes/opus-stereo-answer
+++ b/.changes/opus-stereo-answer
@@ -1,0 +1,1 @@
+patch type="fixed" "Negotiate Opus stereo in the subscriber answer so stereo publications are no longer downmixed to mono when using custom renderers"

--- a/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
@@ -365,15 +365,8 @@ extension Room: SignalClientDelegate {
         do {
             try await subscriber.set(remoteDescription: offer)
             var answer = try await subscriber.createAnswer()
-            let mungedSDP = Transport.mungeOpusStereo(answer.sdp, matchingOffer: offer.sdp)
-            if mungedSDP != answer.sdp {
-                // Signal whichever description was actually applied. If libwebrtc rejects the
-                // munge, telling the SFU we negotiated stereo while the local decoder was built
-                // from the unmunged answer would leave the two ends disagreeing.
-                answer = try await subscriber.set(mungedLocalDescription: RTC.createSessionDescription(type: answer.type, sdp: mungedSDP),
-                                                  fallingBackTo: answer)
-            } else {
-                try await subscriber.set(localDescription: answer)
+            answer = try await subscriber.set(localDescription: answer) {
+                Transport.mungeOpusStereo($0, matchingOffer: offer.sdp)
             }
             try await signalClient.send(answer: answer, offerId: offerId)
             connectSpan?.record("answer_sent")

--- a/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
@@ -366,7 +366,7 @@ extension Room: SignalClientDelegate {
             try await subscriber.set(remoteDescription: offer)
             var answer = try await subscriber.createAnswer()
             answer = try await subscriber.set(localDescription: answer) {
-                Transport.mungeOpusStereo($0, matchingOffer: offer.sdp)
+                Transport.mungeOpusStereoAndNack($0, matchingOffer: offer.sdp)
             }
             try await signalClient.send(answer: answer, offerId: offerId)
             connectSpan?.record("answer_sent")

--- a/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
@@ -365,9 +365,10 @@ extension Room: SignalClientDelegate {
         do {
             try await subscriber.set(remoteDescription: offer)
             var answer = try await subscriber.createAnswer()
-            answer = try await subscriber.set(localDescription: answer) {
-                Transport.mungeOpusStereoAndNack($0, matchingOffer: offer.sdp)
-            }
+            answer = try await subscriber.set(localDescription: answer, munging: [
+                { Transport.mungeOpusStereo($0, matchingOffer: offer.sdp) },
+                { Transport.mungeOpusNack($0, matchingOffer: offer.sdp) },
+            ])
             try await signalClient.send(answer: answer, offerId: offerId)
             connectSpan?.record("answer_sent")
         } catch {

--- a/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
@@ -364,8 +364,17 @@ extension Room: SignalClientDelegate {
 
         do {
             try await subscriber.set(remoteDescription: offer)
-            let answer = try await subscriber.createAnswer()
-            try await subscriber.set(localDescription: answer)
+            var answer = try await subscriber.createAnswer()
+            let mungedSDP = Transport.mungeOpusStereo(answer.sdp, matchingOffer: offer.sdp)
+            if mungedSDP != answer.sdp {
+                // Signal whichever description was actually applied. If libwebrtc rejects the
+                // munge, telling the SFU we negotiated stereo while the local decoder was built
+                // from the unmunged answer would leave the two ends disagreeing.
+                answer = try await subscriber.set(mungedLocalDescription: RTC.createSessionDescription(type: answer.type, sdp: mungedSDP),
+                                                  fallingBackTo: answer)
+            } else {
+                try await subscriber.set(localDescription: answer)
+            }
             try await signalClient.send(answer: answer, offerId: offerId)
             connectSpan?.record("answer_sent")
         } catch {

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -190,12 +190,8 @@ actor Transport: NSObject, Loggable {
         func _negotiateSequence() async throws {
             _latestOfferId += 1
             var offer = try await createOffer(for: constraints)
-            let mungedSDP = singlePCMode ? Self.mungeInactiveToRecvOnlyForMedia(offer.sdp) : offer.sdp
-            if mungedSDP != offer.sdp {
-                offer = try await set(mungedLocalDescription: RTC.createSessionDescription(type: offer.type, sdp: mungedSDP),
-                                      fallingBackTo: offer)
-            } else {
-                try await set(localDescription: offer)
+            offer = try await set(localDescription: offer) {
+                singlePCMode ? Self.mungeInactiveToRecvOnlyForMedia($0) : $0
             }
             try await _onOffer(offer, _latestOfferId)
         }
@@ -291,6 +287,23 @@ extension Transport {
             try await set(localDescription: original)
             return original
         }
+    }
+
+    /// Applies `munge` to `original` and sets the result as the local description through
+    /// the rejection fallback above; a no-op munge sets `original` directly, so nothing
+    /// munged is ever offered to libwebrtc. Returns the description that was applied —
+    /// the one to signal, since signalling a rejected munge would advertise parameters
+    /// the peer connection was never configured with.
+    func set(localDescription original: LKRTCSessionDescription,
+             munging munge: (String) -> String) async throws -> LKRTCSessionDescription
+    {
+        let mungedSDP = munge(original.sdp)
+        guard mungedSDP != original.sdp else {
+            try await set(localDescription: original)
+            return original
+        }
+        return try await set(mungedLocalDescription: RTC.createSessionDescription(type: original.type, sdp: mungedSDP),
+                             fallingBackTo: original)
     }
 }
 

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -190,8 +190,9 @@ actor Transport: NSObject, Loggable {
         func _negotiateSequence() async throws {
             _latestOfferId += 1
             var offer = try await createOffer(for: constraints)
-            offer = try await set(localDescription: offer) {
-                singlePCMode ? Self.mungeInactiveToRecvOnlyForMedia($0) : $0
+            offer = try await set(localDescription: offer) { sdp in
+                guard singlePCMode else { return sdp }
+                return Self.mungeOpusStereoForAllAudio(Self.mungeInactiveToRecvOnlyForMedia(sdp))
             }
             try await _onOffer(offer, _latestOfferId)
         }
@@ -239,32 +240,67 @@ extension Transport {
     }
 
     /// Munge an answer to declare `stereo=1` on the Opus fmtp of every section whose
-    /// counterpart in `offer` advertises `sprop-stereo=1`.
+    /// counterpart in `offer` advertises `sprop-stereo=1`, and to accept `nack` feedback
+    /// for Opus wherever the offer advertises it.
     ///
     /// Per [RFC 7587 §7.1](https://datatracker.ietf.org/doc/html/rfc7587#section-7.1) `stereo`
     /// is the *receiver's* preference: without it libwebrtc instantiates a mono Opus decoder and
     /// downmixes, regardless of what the sender transmits. `sprop-stereo` states only what the
-    /// sender emits, so it does not carry the answerer's preference on its own. This mirrors
-    /// `ensureAudioNackAndStereo()` in client-sdk-js.
+    /// sender emits, so it does not carry the answerer's preference on its own.
     ///
-    /// Sections are matched by mid rather than by position, and the Opus payload type is
-    /// resolved independently in each document, so an answerer that reorders or renumbers
-    /// still lands the parameter on the right section.
-    static func mungeOpusStereo(_ sdp: String, matchingOffer offer: String) -> String {
-        let stereoMids = Set(SDP(parsing: offer).mediaSections.compactMap { section -> String? in
+    /// libwebrtc does not support NACK for audio in its codec capabilities, so its answer
+    /// drops the `a=rtcp-fb:<pt> nack` the SFU offers (the SFU offers it when RED is off for
+    /// the track) and retransmission never activates — feedback is active only when both
+    /// sides agree ([RFC 4585 §4.2](https://datatracker.ietf.org/doc/html/rfc4585#section-4.2)).
+    ///
+    /// Both mirror `ensureAudioNackAndStereo()` in client-sdk-js. Sections are matched by
+    /// mid rather than by position, and the Opus payload type is resolved independently in
+    /// each document, so an answerer that reorders or renumbers still lands the parameters
+    /// on the right section.
+    static func mungeOpusStereoAndNack(_ sdp: String, matchingOffer offer: String) -> String {
+        var stereoMids: Set<String> = []
+        var nackMids: Set<String> = []
+        for section in SDP(parsing: offer).mediaSections {
             guard section.mediaType == "audio",
                   let mid = section.mid,
-                  let payload = section.payload(forCodec: "opus"),
-                  section.fmtp(forPayload: payload)?.parameters.contains("sprop-stereo=1") == true
-            else { return nil }
-            return mid
-        })
-        guard !stereoMids.isEmpty else { return sdp }
+                  let payload = section.payload(forCodec: "opus") else { continue }
+            if section.fmtp(forPayload: payload)?.parameters.contains("sprop-stereo=1") == true {
+                stereoMids.insert(mid)
+            }
+            if section.hasRtcpFeedback("nack", forPayload: payload) {
+                nackMids.insert(mid)
+            }
+        }
+        guard !stereoMids.isEmpty || !nackMids.isEmpty else { return sdp }
 
         var document = SDP(parsing: sdp)
         for index in document.mediaSections.indices {
             let section = document.mediaSections[index]
-            guard let mid = section.mid, stereoMids.contains(mid),
+            guard let mid = section.mid,
+                  let payload = section.payload(forCodec: "opus") else { continue }
+            if stereoMids.contains(mid) {
+                document.mediaSections[index].appendFmtpParameter("stereo=1", forPayload: payload)
+            }
+            if nackMids.contains(mid) {
+                document.mediaSections[index].appendRtcpFeedback("nack", forPayload: payload)
+            }
+        }
+        return document.write()
+    }
+
+    /// Munge a local offer to declare `stereo=1` on the Opus fmtp of every audio section.
+    ///
+    /// In single PC mode the client is the offerer for its own receive sections, and at
+    /// offer time it cannot know which remote publications are stereo — so the receive
+    /// preference is declared unconditionally, mirroring client-sdk-js (which munges every
+    /// local offer) and rust-sdks (`munge_stereo_for_audio`). Dual-PC offers don't take
+    /// this path: receive negotiation happens in the subscriber answer munge above, and a
+    /// publisher offer's send-only sections gain nothing from a receive preference.
+    static func mungeOpusStereoForAllAudio(_ sdp: String) -> String {
+        var document = SDP(parsing: sdp)
+        for index in document.mediaSections.indices {
+            let section = document.mediaSections[index]
+            guard section.mediaType == "audio",
                   let payload = section.payload(forCodec: "opus") else { continue }
             document.mediaSections[index].appendFmtpParameter("stereo=1", forPayload: payload)
         }

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -242,6 +242,39 @@ extension Transport {
         return document.write()
     }
 
+    /// Munge an answer to declare `stereo=1` on the Opus fmtp of every section whose
+    /// counterpart in `offer` advertises `sprop-stereo=1`.
+    ///
+    /// Per [RFC 7587 §7.1](https://datatracker.ietf.org/doc/html/rfc7587#section-7.1) `stereo`
+    /// is the *receiver's* preference: without it libwebrtc instantiates a mono Opus decoder and
+    /// downmixes, regardless of what the sender transmits. `sprop-stereo` states only what the
+    /// sender emits, so it does not carry the answerer's preference on its own. This mirrors
+    /// `ensureAudioNackAndStereo()` in client-sdk-js.
+    ///
+    /// Sections are matched by mid rather than by position, and the Opus payload type is
+    /// resolved independently in each document, so an answerer that reorders or renumbers
+    /// still lands the parameter on the right section.
+    static func mungeOpusStereo(_ sdp: String, matchingOffer offer: String) -> String {
+        let stereoMids = Set(SDP(parsing: offer).mediaSections.compactMap { section -> String? in
+            guard section.mediaType == "audio",
+                  let mid = section.mid,
+                  let payload = section.payload(forCodec: "opus"),
+                  section.fmtp(forPayload: payload)?.parameters.contains("sprop-stereo=1") == true
+            else { return nil }
+            return mid
+        })
+        guard !stereoMids.isEmpty else { return sdp }
+
+        var document = SDP(parsing: sdp)
+        for index in document.mediaSections.indices {
+            let section = document.mediaSections[index]
+            guard let mid = section.mid, stereoMids.contains(mid),
+                  let payload = section.payload(forCodec: "opus") else { continue }
+            document.mediaSections[index].appendFmtpParameter("stereo=1", forPayload: payload)
+        }
+        return document.write()
+    }
+
     /// Sets `munged` as the local description, falling back to `original` when libwebrtc
     /// rejects it — a rejected set leaves the peer connection state untouched, so
     /// negotiation proceeds without the munge instead of failing. libwebrtc validates

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -190,10 +190,11 @@ actor Transport: NSObject, Loggable {
         func _negotiateSequence() async throws {
             _latestOfferId += 1
             var offer = try await createOffer(for: constraints)
-            offer = try await set(localDescription: offer) { sdp in
-                guard singlePCMode else { return sdp }
-                return Self.mungeOpusStereoForAllAudio(Self.mungeInactiveToRecvOnlyForMedia(sdp))
-            }
+            // The direction rewrite is required to receive media in single PC mode; the
+            // stereo preference is optional and must be the one dropped on rejection.
+            offer = try await set(localDescription: offer, munging: singlePCMode
+                ? [Self.mungeInactiveToRecvOnlyForMedia, Self.mungeOpusStereoForAllAudio]
+                : [])
             try await _onOffer(offer, _latestOfferId)
         }
 
@@ -240,50 +241,64 @@ extension Transport {
     }
 
     /// Munge an answer to declare `stereo=1` on the Opus fmtp of every section whose
-    /// counterpart in `offer` advertises `sprop-stereo=1`, and to accept `nack` feedback
-    /// for Opus wherever the offer advertises it.
+    /// counterpart in `offer` advertises `sprop-stereo=1`.
     ///
     /// Per [RFC 7587 §7.1](https://datatracker.ietf.org/doc/html/rfc7587#section-7.1) `stereo`
     /// is the *receiver's* preference: without it libwebrtc instantiates a mono Opus decoder and
     /// downmixes, regardless of what the sender transmits. `sprop-stereo` states only what the
-    /// sender emits, so it does not carry the answerer's preference on its own.
+    /// sender emits, so it does not carry the answerer's preference on its own. This mirrors
+    /// `ensureAudioNackAndStereo()` in client-sdk-js.
     ///
-    /// libwebrtc does not support NACK for audio in its codec capabilities, so its answer
-    /// drops the `a=rtcp-fb:<pt> nack` the SFU offers (the SFU offers it when RED is off for
-    /// the track) and retransmission never activates — feedback is active only when both
-    /// sides agree ([RFC 4585 §4.2](https://datatracker.ietf.org/doc/html/rfc4585#section-4.2)).
-    ///
-    /// Both mirror `ensureAudioNackAndStereo()` in client-sdk-js. Sections are matched by
-    /// mid rather than by position, and the Opus payload type is resolved independently in
-    /// each document, so an answerer that reorders or renumbers still lands the parameters
-    /// on the right section.
-    static func mungeOpusStereoAndNack(_ sdp: String, matchingOffer offer: String) -> String {
-        var stereoMids: Set<String> = []
-        var nackMids: Set<String> = []
-        for section in SDP(parsing: offer).mediaSections {
+    /// Sections are matched by mid rather than by position, and the Opus payload type is
+    /// resolved independently in each document, so an answerer that reorders or renumbers
+    /// still lands the parameter on the right section.
+    static func mungeOpusStereo(_ sdp: String, matchingOffer offer: String) -> String {
+        let stereoMids = Set(SDP(parsing: offer).mediaSections.compactMap { section -> String? in
             guard section.mediaType == "audio",
                   let mid = section.mid,
-                  let payload = section.payload(forCodec: "opus") else { continue }
-            if section.fmtp(forPayload: payload)?.parameters.contains("sprop-stereo=1") == true {
-                stereoMids.insert(mid)
-            }
-            if section.hasRtcpFeedback("nack", forPayload: payload) {
-                nackMids.insert(mid)
-            }
-        }
-        guard !stereoMids.isEmpty || !nackMids.isEmpty else { return sdp }
+                  let payload = section.payload(forCodec: "opus"),
+                  section.fmtp(forPayload: payload)?.parameters.contains("sprop-stereo=1") == true
+            else { return nil }
+            return mid
+        })
+        guard !stereoMids.isEmpty else { return sdp }
 
         var document = SDP(parsing: sdp)
         for index in document.mediaSections.indices {
             let section = document.mediaSections[index]
-            guard let mid = section.mid,
+            guard let mid = section.mid, stereoMids.contains(mid),
                   let payload = section.payload(forCodec: "opus") else { continue }
-            if stereoMids.contains(mid) {
-                document.mediaSections[index].appendFmtpParameter("stereo=1", forPayload: payload)
-            }
-            if nackMids.contains(mid) {
-                document.mediaSections[index].appendRtcpFeedback("nack", forPayload: payload)
-            }
+            document.mediaSections[index].appendFmtpParameter("stereo=1", forPayload: payload)
+        }
+        return document.write()
+    }
+
+    /// Munge an answer to accept `nack` feedback for Opus on every section whose
+    /// counterpart in `offer` advertises it.
+    ///
+    /// libwebrtc does not support NACK for audio in its codec capabilities, so its answer
+    /// drops the `a=rtcp-fb:<pt> nack` the SFU offers (the SFU offers it when RED is off
+    /// for the track) and retransmission never activates — feedback is active only when
+    /// both sides agree ([RFC 4585 §4.2](https://datatracker.ietf.org/doc/html/rfc4585#section-4.2)).
+    /// This mirrors `ensureAudioNackAndStereo()` in client-sdk-js, with the same
+    /// mid-and-payload matching as ``mungeOpusStereo(_:matchingOffer:)``.
+    static func mungeOpusNack(_ sdp: String, matchingOffer offer: String) -> String {
+        let nackMids = Set(SDP(parsing: offer).mediaSections.compactMap { section -> String? in
+            guard section.mediaType == "audio",
+                  let mid = section.mid,
+                  let payload = section.payload(forCodec: "opus"),
+                  section.hasRtcpFeedback("nack", forPayload: payload)
+            else { return nil }
+            return mid
+        })
+        guard !nackMids.isEmpty else { return sdp }
+
+        var document = SDP(parsing: sdp)
+        for index in document.mediaSections.indices {
+            let section = document.mediaSections[index]
+            guard let mid = section.mid, nackMids.contains(mid),
+                  let payload = section.payload(forCodec: "opus") else { continue }
+            document.mediaSections[index].appendRtcpFeedback("nack", forPayload: payload)
         }
         return document.write()
     }
@@ -307,39 +322,32 @@ extension Transport {
         return document.write()
     }
 
-    /// Sets `munged` as the local description, falling back to `original` when libwebrtc
-    /// rejects it — a rejected set leaves the peer connection state untouched, so
-    /// negotiation proceeds without the munge instead of failing. libwebrtc validates
-    /// munged SDP and rejects some munging types outright (`IsSdpMungingAllowed`,
-    /// expanding via field-trial kill switches). Returns the description that was applied.
-    func set(mungedLocalDescription munged: LKRTCSessionDescription,
-             fallingBackTo original: LKRTCSessionDescription) async throws -> LKRTCSessionDescription
-    {
-        do {
-            try await set(localDescription: munged)
-            return munged
-        } catch {
-            log("Munged local description was rejected, falling back to the original: \(error)", .warning)
-            try await set(localDescription: original)
-            return original
-        }
-    }
-
-    /// Applies `munge` to `original` and sets the result as the local description through
-    /// the rejection fallback above; a no-op munge sets `original` directly, so nothing
-    /// munged is ever offered to libwebrtc. Returns the description that was applied —
-    /// the one to signal, since signalling a rejected munge would advertise parameters
+    /// Applies `munges` composed left-to-right and sets the result as the local
+    /// description. libwebrtc validates munged SDP and rejects some munging types
+    /// outright (`IsSdpMungingAllowed`, expanding via field-trial kill switches);
+    /// a rejected set leaves the peer connection state untouched, so on rejection
+    /// the last munge is dropped and the set retried. Order munges most-required
+    /// first: a rejected optional munge then cannot revert the ones before it.
+    /// A no-op composition sets `original` directly, so nothing munged is ever
+    /// offered to libwebrtc. Returns the description that was applied — the one
+    /// to signal, since signalling a rejected munge would advertise parameters
     /// the peer connection was never configured with.
     func set(localDescription original: LKRTCSessionDescription,
-             munging munge: (String) -> String) async throws -> LKRTCSessionDescription
+             munging munges: [(String) -> String]) async throws -> LKRTCSessionDescription
     {
-        let mungedSDP = munge(original.sdp)
+        let mungedSDP = munges.reduce(original.sdp) { $1($0) }
         guard mungedSDP != original.sdp else {
             try await set(localDescription: original)
             return original
         }
-        return try await set(mungedLocalDescription: RTC.createSessionDescription(type: original.type, sdp: mungedSDP),
-                             fallingBackTo: original)
+        do {
+            let munged = RTC.createSessionDescription(type: original.type, sdp: mungedSDP)
+            try await set(localDescription: munged)
+            return munged
+        } catch {
+            log("Munged local description was rejected, dropping the last munge and retrying: \(error)", .warning)
+            return try await set(localDescription: original, munging: Array(munges.dropLast()))
+        }
     }
 }
 

--- a/Sources/LiveKit/Support/SDP/SDP.swift
+++ b/Sources/LiveKit/Support/SDP/SDP.swift
@@ -122,6 +122,26 @@ struct SDPMediaSection {
         return false
     }
 
+    /// Whether an `a=rtcp-fb:<payload> <value>` line with exactly `value` exists for
+    /// `payload`. Exact-value match: `nack` does not match `nack pli` (RFC 4585 §4.2
+    /// — they are distinct feedback parameters).
+    func hasRtcpFeedback(_ value: String, forPayload payload: String) -> Bool {
+        lines.contains { line in
+            guard let (fbPayload, fbValue) = Self.payloadAttribute(line, name: "rtcp-fb") else { return false }
+            return fbPayload == payload && fbValue == value
+        }
+    }
+
+    /// Appends an `a=rtcp-fb:<payload> <value>` line at the end of the section,
+    /// unless the exact feedback is already present. Returns `true` if the section
+    /// was modified.
+    @discardableResult
+    mutating func appendRtcpFeedback(_ value: String, forPayload payload: String) -> Bool {
+        guard !hasRtcpFeedback(value, forPayload: payload) else { return false }
+        lines.append("a=rtcp-fb:\(payload) \(value)")
+        return true
+    }
+
     /// Appends a raw line at the end of the section.
     mutating func append(line: String) {
         lines.append(line)

--- a/Tests/LiveKitCoreTests/SDP/OpusStereoSdpTests.swift
+++ b/Tests/LiveKitCoreTests/SDP/OpusStereoSdpTests.swift
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+import Testing
+
+@Suite(.tags(.media))
+struct OpusStereoSdpTests {
+    private static func sdp(_ body: String) -> String {
+        body.replacingOccurrences(of: "\n", with: "\r\n") + "\r\n"
+    }
+
+    /// mid 0 is sent in stereo; mid 1 is Opus but mono; mid 2 is video; mid 3 is a
+    /// non-Opus codec that nonetheless carries `sprop-stereo`; the last section
+    /// advertises stereo but has no mid to match on.
+    private static let offer = sdp("""
+    v=0
+    o=- 0 0 IN IP4 127.0.0.1
+    s=-
+    t=0 0
+    a=group:BUNDLE 0 1 2 3
+    m=audio 9 UDP/TLS/RTP/SAVPF 111
+    a=mid:0
+    a=rtpmap:111 opus/48000/2
+    a=fmtp:111 minptime=10;useinbandfec=1;sprop-stereo=1
+    a=sendonly
+    m=audio 9 UDP/TLS/RTP/SAVPF 111
+    a=mid:1
+    a=rtpmap:111 opus/48000/2
+    a=fmtp:111 minptime=10;useinbandfec=1
+    a=sendonly
+    m=video 9 UDP/TLS/RTP/SAVPF 96
+    a=mid:2
+    a=rtpmap:96 VP8/90000
+    a=sendonly
+    m=audio 9 UDP/TLS/RTP/SAVPF 8
+    a=mid:3
+    a=rtpmap:8 PCMA/8000
+    a=fmtp:8 sprop-stereo=1
+    a=sendonly
+    m=audio 9 UDP/TLS/RTP/SAVPF 111
+    a=rtpmap:111 opus/48000/2
+    a=fmtp:111 sprop-stereo=1
+    a=sendonly
+    """)
+
+    /// The answer libwebrtc generates for `offer`: same mids and payload types, no
+    /// `sprop-stereo` (the subscriber sends nothing), and no `stereo` preference —
+    /// which is the bug.
+    private static let answer = sdp("""
+    v=0
+    o=- 0 0 IN IP4 127.0.0.1
+    s=-
+    t=0 0
+    a=group:BUNDLE 0 1 2 3
+    m=audio 9 UDP/TLS/RTP/SAVPF 111
+    a=mid:0
+    a=rtpmap:111 opus/48000/2
+    a=fmtp:111 minptime=10;useinbandfec=1
+    a=recvonly
+    m=audio 9 UDP/TLS/RTP/SAVPF 111
+    a=mid:1
+    a=rtpmap:111 opus/48000/2
+    a=fmtp:111 minptime=10;useinbandfec=1
+    a=recvonly
+    m=video 9 UDP/TLS/RTP/SAVPF 96
+    a=mid:2
+    a=rtpmap:96 VP8/90000
+    a=recvonly
+    m=audio 9 UDP/TLS/RTP/SAVPF 8
+    a=mid:3
+    a=rtpmap:8 PCMA/8000
+    a=fmtp:8 maxptime=40
+    a=recvonly
+    """)
+
+    private static func fmtps(_ sdp: String) -> [String] {
+        SDP(parsing: sdp).mediaSections.flatMap(\.fmtps).map { "a=fmtp:\($0.payload) \($0.config)" }
+    }
+
+    @Test(.spec("https://datatracker.ietf.org/doc/html/rfc7587#section-7.1"))
+    func addsStereoOnlyToSectionsTheOfferSendsInStereo() {
+        let munged = Transport.mungeOpusStereo(Self.answer, matchingOffer: Self.offer)
+
+        #expect(Self.fmtps(munged) == [
+            "a=fmtp:111 minptime=10;useinbandfec=1;stereo=1", // mid 0: offered stereo
+            "a=fmtp:111 minptime=10;useinbandfec=1", // mid 1: Opus, but mono
+            "a=fmtp:8 maxptime=40", // mid 3: not Opus
+        ])
+    }
+
+    /// `sprop-stereo=1` contains "stereo=1" as a substring, so a `contains` check —
+    /// as in client-sdk-js — reads the section as already stereo and skips it,
+    /// leaving the receiver in mono. That is the exact case this code exists to fix,
+    /// so it is pinned here as well as in ``SDPTests``.
+    @Test func spropStereoDoesNotSuppressTheReceiverPreference() {
+        // Answering with the offer's own SDP is the worst case: every stereo section
+        // already carries the substring.
+        let munged = Transport.mungeOpusStereo(Self.offer, matchingOffer: Self.offer)
+
+        #expect(Self.fmtps(munged).first == "a=fmtp:111 minptime=10;useinbandfec=1;sprop-stereo=1;stereo=1")
+    }
+
+    @Test func isIdempotent() {
+        let once = Transport.mungeOpusStereo(Self.answer, matchingOffer: Self.offer)
+        #expect(Transport.mungeOpusStereo(once, matchingOffer: Self.offer) == once)
+    }
+
+    /// No stereo anywhere in the offer must return the answer untouched rather than
+    /// round-tripped, so the caller's `munged != answer` check stays false and no
+    /// munged description is ever offered to libwebrtc.
+    @Test func offerWithoutStereoReturnsTheAnswerUnchanged() {
+        let monoOffer = Self.offer.replacingOccurrences(of: ";sprop-stereo=1", with: "")
+            .replacingOccurrences(of: "a=fmtp:8 sprop-stereo=1", with: "a=fmtp:8 maxptime=40")
+            .replacingOccurrences(of: "a=fmtp:111 sprop-stereo=1", with: "a=fmtp:111 useinbandfec=1")
+
+        #expect(Transport.mungeOpusStereo(Self.answer, matchingOffer: monoOffer) == Self.answer)
+    }
+
+    /// Sections are keyed by mid, not by position — an answer that lists them in a
+    /// different order still gets the parameter on the right one.
+    @Test func matchesByMidRatherThanSectionOrder() {
+        let reordered = Self.sdp("""
+        v=0
+        m=audio 9 UDP/TLS/RTP/SAVPF 111
+        a=mid:1
+        a=rtpmap:111 opus/48000/2
+        a=fmtp:111 useinbandfec=1
+        m=audio 9 UDP/TLS/RTP/SAVPF 111
+        a=mid:0
+        a=rtpmap:111 opus/48000/2
+        a=fmtp:111 useinbandfec=1
+        """)
+        let munged = Transport.mungeOpusStereo(reordered, matchingOffer: Self.offer)
+
+        #expect(Self.fmtps(munged) == [
+            "a=fmtp:111 useinbandfec=1", // mid 1
+            "a=fmtp:111 useinbandfec=1;stereo=1", // mid 0
+        ])
+    }
+
+    /// The Opus payload type is read from each document's own `a=rtpmap` rather than
+    /// carried over from the offer.
+    @Test func resolvesThePayloadTypeWithinTheAnswer() {
+        let renumbered = Self.sdp("""
+        v=0
+        m=audio 9 UDP/TLS/RTP/SAVPF 63
+        a=mid:0
+        a=rtpmap:63 opus/48000/2
+        a=fmtp:63 useinbandfec=1
+        """)
+
+        #expect(Transport.mungeOpusStereo(renumbered, matchingOffer: Self.offer)
+            .contains("a=fmtp:63 useinbandfec=1;stereo=1"))
+    }
+
+    /// ``SDPMediaSection/appendFmtpParameter(_:forPayload:)`` never inserts an fmtp
+    /// line, so an answer that omits one for Opus is left alone. libwebrtc always
+    /// emits `minptime`/`useinbandfec`, so this is a documented boundary rather than
+    /// a path taken in practice.
+    @Test func leavesAnAnswerWithoutAnOpusFmtpLineUntouched() {
+        let noFmtp = Self.sdp("""
+        v=0
+        m=audio 9 UDP/TLS/RTP/SAVPF 111
+        a=mid:0
+        a=rtpmap:111 opus/48000/2
+        """)
+
+        #expect(Transport.mungeOpusStereo(noFmtp, matchingOffer: Self.offer) == noFmtp)
+    }
+
+    /// A section the offer never mentioned, and one whose mid matches but which
+    /// carries no Opus: both are skipped without disturbing the document.
+    @Test func skipsUnmatchedAndNonOpusAnswerSections() {
+        let extra = Self.sdp("""
+        v=0
+        m=audio 9 UDP/TLS/RTP/SAVPF 111
+        a=mid:99
+        a=rtpmap:111 opus/48000/2
+        a=fmtp:111 useinbandfec=1
+        m=audio 9 UDP/TLS/RTP/SAVPF 8
+        a=mid:0
+        a=rtpmap:8 PCMA/8000
+        a=fmtp:8 maxptime=40
+        m=audio 9 UDP/TLS/RTP/SAVPF 111
+        a=rtpmap:111 opus/48000/2
+        a=fmtp:111 useinbandfec=1
+        """)
+
+        #expect(Transport.mungeOpusStereo(extra, matchingOffer: Self.offer) == extra)
+    }
+}

--- a/Tests/LiveKitCoreTests/SDP/OpusStereoSdpTests.swift
+++ b/Tests/LiveKitCoreTests/SDP/OpusStereoSdpTests.swift
@@ -93,7 +93,7 @@ struct OpusStereoSdpTests {
 
     @Test(.spec("https://datatracker.ietf.org/doc/html/rfc7587#section-7.1"))
     func addsStereoOnlyToSectionsTheOfferSendsInStereo() {
-        let munged = Transport.mungeOpusStereoAndNack(Self.answer, matchingOffer: Self.offer)
+        let munged = Transport.mungeOpusStereo(Self.answer, matchingOffer: Self.offer)
 
         #expect(Self.fmtps(munged) == [
             "a=fmtp:111 minptime=10;useinbandfec=1;stereo=1", // mid 0: offered stereo
@@ -109,25 +109,27 @@ struct OpusStereoSdpTests {
     @Test func spropStereoDoesNotSuppressTheReceiverPreference() {
         // Answering with the offer's own SDP is the worst case: every stereo section
         // already carries the substring.
-        let munged = Transport.mungeOpusStereoAndNack(Self.offer, matchingOffer: Self.offer)
+        let munged = Transport.mungeOpusStereo(Self.offer, matchingOffer: Self.offer)
 
         #expect(Self.fmtps(munged).first == "a=fmtp:111 minptime=10;useinbandfec=1;sprop-stereo=1;stereo=1")
     }
 
     @Test func isIdempotent() {
-        let once = Transport.mungeOpusStereoAndNack(Self.answer, matchingOffer: Self.offer)
-        #expect(Transport.mungeOpusStereoAndNack(once, matchingOffer: Self.offer) == once)
+        let once = Transport.mungeOpusStereo(Self.answer, matchingOffer: Self.offer)
+        #expect(Transport.mungeOpusStereo(once, matchingOffer: Self.offer) == once)
     }
 
-    /// No stereo and no nack anywhere in the offer must return the answer untouched
-    /// rather than round-tripped, so the caller's `munged != answer` check stays false
-    /// and no munged description is ever offered to libwebrtc.
+    /// An offer with nothing to accept must return the answer untouched rather than
+    /// round-tripped, so the caller's munged-vs-original check stays false and no
+    /// munged description is ever offered to libwebrtc.
     @Test func offerWithoutStereoOrNackReturnsTheAnswerUnchanged() {
         let monoOffer = Self.offer.replacingOccurrences(of: ";sprop-stereo=1", with: "")
             .replacingOccurrences(of: "a=fmtp:8 sprop-stereo=1", with: "a=fmtp:8 maxptime=40")
             .replacingOccurrences(of: "a=fmtp:111 sprop-stereo=1", with: "a=fmtp:111 useinbandfec=1")
 
-        #expect(Transport.mungeOpusStereoAndNack(Self.answer, matchingOffer: monoOffer) == Self.answer)
+        #expect(Transport.mungeOpusStereo(Self.answer, matchingOffer: monoOffer) == Self.answer)
+        // Self.offer advertises no rtcp-fb at all, so the nack munge is a no-op too.
+        #expect(Transport.mungeOpusNack(Self.answer, matchingOffer: Self.offer) == Self.answer)
     }
 
     /// Sections are keyed by mid, not by position — an answer that lists them in a
@@ -144,7 +146,7 @@ struct OpusStereoSdpTests {
         a=rtpmap:111 opus/48000/2
         a=fmtp:111 useinbandfec=1
         """)
-        let munged = Transport.mungeOpusStereoAndNack(reordered, matchingOffer: Self.offer)
+        let munged = Transport.mungeOpusStereo(reordered, matchingOffer: Self.offer)
 
         #expect(Self.fmtps(munged) == [
             "a=fmtp:111 useinbandfec=1", // mid 1
@@ -163,7 +165,7 @@ struct OpusStereoSdpTests {
         a=fmtp:63 useinbandfec=1
         """)
 
-        #expect(Transport.mungeOpusStereoAndNack(renumbered, matchingOffer: Self.offer)
+        #expect(Transport.mungeOpusStereo(renumbered, matchingOffer: Self.offer)
             .contains("a=fmtp:63 useinbandfec=1;stereo=1"))
     }
 
@@ -179,7 +181,7 @@ struct OpusStereoSdpTests {
         a=rtpmap:111 opus/48000/2
         """)
 
-        #expect(Transport.mungeOpusStereoAndNack(noFmtp, matchingOffer: Self.offer) == noFmtp)
+        #expect(Transport.mungeOpusStereo(noFmtp, matchingOffer: Self.offer) == noFmtp)
     }
 
     /// A section the offer never mentioned, and one whose mid matches but which
@@ -200,7 +202,7 @@ struct OpusStereoSdpTests {
         a=fmtp:111 useinbandfec=1
         """)
 
-        #expect(Transport.mungeOpusStereoAndNack(extra, matchingOffer: Self.offer) == extra)
+        #expect(Transport.mungeOpusStereo(extra, matchingOffer: Self.offer) == extra)
     }
 
     /// The SFU offers `nack` for Opus (it does so when RED is off for the track), but
@@ -222,18 +224,18 @@ struct OpusStereoSdpTests {
         a=fmtp:111 minptime=10;useinbandfec=1
         """)
 
-        let munged = Transport.mungeOpusStereoAndNack(Self.answer, matchingOffer: nackOffer)
+        let munged = Transport.mungeOpusNack(Self.answer, matchingOffer: nackOffer)
 
         let sections = SDP(parsing: munged).mediaSections
         #expect(sections[0].hasRtcpFeedback("nack", forPayload: "111"))
         #expect(!sections[1].hasRtcpFeedback("nack", forPayload: "111"))
-        // The nack offer carries no sprop-stereo, so no stereo preference is declared.
+        // The nack munge never touches fmtp lines.
         #expect(Self.fmtps(munged) == Self.fmtps(Self.answer))
     }
 
-    /// A mid whose offer advertises both stereo and nack gets both in the answer,
-    /// and re-answering the munged answer changes nothing.
-    @Test func appliesStereoAndNackTogetherIdempotently() {
+    /// The two munges compose (as the answer path applies them), and re-answering
+    /// the munged answer changes nothing.
+    @Test func stereoAndNackComposeIdempotently() {
         let bothOffer = Self.sdp("""
         v=0
         m=audio 9 UDP/TLS/RTP/SAVPF 111
@@ -242,12 +244,15 @@ struct OpusStereoSdpTests {
         a=rtcp-fb:111 nack
         a=fmtp:111 minptime=10;useinbandfec=1;sprop-stereo=1
         """)
+        func munge(_ sdp: String) -> String {
+            Transport.mungeOpusNack(Transport.mungeOpusStereo(sdp, matchingOffer: bothOffer), matchingOffer: bothOffer)
+        }
 
-        let munged = Transport.mungeOpusStereoAndNack(Self.answer, matchingOffer: bothOffer)
+        let munged = munge(Self.answer)
 
         let section = SDP(parsing: munged).mediaSections[0]
         #expect(section.fmtp(forPayload: "111")?.config == "minptime=10;useinbandfec=1;stereo=1")
         #expect(section.hasRtcpFeedback("nack", forPayload: "111"))
-        #expect(Transport.mungeOpusStereoAndNack(munged, matchingOffer: bothOffer) == munged)
+        #expect(munge(munged) == munged)
     }
 }

--- a/Tests/LiveKitCoreTests/SDP/OpusStereoSdpTests.swift
+++ b/Tests/LiveKitCoreTests/SDP/OpusStereoSdpTests.swift
@@ -93,7 +93,7 @@ struct OpusStereoSdpTests {
 
     @Test(.spec("https://datatracker.ietf.org/doc/html/rfc7587#section-7.1"))
     func addsStereoOnlyToSectionsTheOfferSendsInStereo() {
-        let munged = Transport.mungeOpusStereo(Self.answer, matchingOffer: Self.offer)
+        let munged = Transport.mungeOpusStereoAndNack(Self.answer, matchingOffer: Self.offer)
 
         #expect(Self.fmtps(munged) == [
             "a=fmtp:111 minptime=10;useinbandfec=1;stereo=1", // mid 0: offered stereo
@@ -102,32 +102,32 @@ struct OpusStereoSdpTests {
         ])
     }
 
-    /// `sprop-stereo=1` contains "stereo=1" as a substring, so a `contains` check —
-    /// as in client-sdk-js — reads the section as already stereo and skips it,
-    /// leaving the receiver in mono. That is the exact case this code exists to fix,
-    /// so it is pinned here as well as in ``SDPTests``.
+    /// `sprop-stereo=1` contains "stereo=1" as a substring, so a naive `contains` check
+    /// — as client-sdk-js used before moving to exact-token matching — reads the section
+    /// as already stereo and skips it, leaving the receiver in mono. That is the exact
+    /// case this code exists to fix, so it is pinned here as well as in ``SDPTests``.
     @Test func spropStereoDoesNotSuppressTheReceiverPreference() {
         // Answering with the offer's own SDP is the worst case: every stereo section
         // already carries the substring.
-        let munged = Transport.mungeOpusStereo(Self.offer, matchingOffer: Self.offer)
+        let munged = Transport.mungeOpusStereoAndNack(Self.offer, matchingOffer: Self.offer)
 
         #expect(Self.fmtps(munged).first == "a=fmtp:111 minptime=10;useinbandfec=1;sprop-stereo=1;stereo=1")
     }
 
     @Test func isIdempotent() {
-        let once = Transport.mungeOpusStereo(Self.answer, matchingOffer: Self.offer)
-        #expect(Transport.mungeOpusStereo(once, matchingOffer: Self.offer) == once)
+        let once = Transport.mungeOpusStereoAndNack(Self.answer, matchingOffer: Self.offer)
+        #expect(Transport.mungeOpusStereoAndNack(once, matchingOffer: Self.offer) == once)
     }
 
-    /// No stereo anywhere in the offer must return the answer untouched rather than
-    /// round-tripped, so the caller's `munged != answer` check stays false and no
-    /// munged description is ever offered to libwebrtc.
-    @Test func offerWithoutStereoReturnsTheAnswerUnchanged() {
+    /// No stereo and no nack anywhere in the offer must return the answer untouched
+    /// rather than round-tripped, so the caller's `munged != answer` check stays false
+    /// and no munged description is ever offered to libwebrtc.
+    @Test func offerWithoutStereoOrNackReturnsTheAnswerUnchanged() {
         let monoOffer = Self.offer.replacingOccurrences(of: ";sprop-stereo=1", with: "")
             .replacingOccurrences(of: "a=fmtp:8 sprop-stereo=1", with: "a=fmtp:8 maxptime=40")
             .replacingOccurrences(of: "a=fmtp:111 sprop-stereo=1", with: "a=fmtp:111 useinbandfec=1")
 
-        #expect(Transport.mungeOpusStereo(Self.answer, matchingOffer: monoOffer) == Self.answer)
+        #expect(Transport.mungeOpusStereoAndNack(Self.answer, matchingOffer: monoOffer) == Self.answer)
     }
 
     /// Sections are keyed by mid, not by position — an answer that lists them in a
@@ -144,7 +144,7 @@ struct OpusStereoSdpTests {
         a=rtpmap:111 opus/48000/2
         a=fmtp:111 useinbandfec=1
         """)
-        let munged = Transport.mungeOpusStereo(reordered, matchingOffer: Self.offer)
+        let munged = Transport.mungeOpusStereoAndNack(reordered, matchingOffer: Self.offer)
 
         #expect(Self.fmtps(munged) == [
             "a=fmtp:111 useinbandfec=1", // mid 1
@@ -163,7 +163,7 @@ struct OpusStereoSdpTests {
         a=fmtp:63 useinbandfec=1
         """)
 
-        #expect(Transport.mungeOpusStereo(renumbered, matchingOffer: Self.offer)
+        #expect(Transport.mungeOpusStereoAndNack(renumbered, matchingOffer: Self.offer)
             .contains("a=fmtp:63 useinbandfec=1;stereo=1"))
     }
 
@@ -179,7 +179,7 @@ struct OpusStereoSdpTests {
         a=rtpmap:111 opus/48000/2
         """)
 
-        #expect(Transport.mungeOpusStereo(noFmtp, matchingOffer: Self.offer) == noFmtp)
+        #expect(Transport.mungeOpusStereoAndNack(noFmtp, matchingOffer: Self.offer) == noFmtp)
     }
 
     /// A section the offer never mentioned, and one whose mid matches but which
@@ -200,6 +200,54 @@ struct OpusStereoSdpTests {
         a=fmtp:111 useinbandfec=1
         """)
 
-        #expect(Transport.mungeOpusStereo(extra, matchingOffer: Self.offer) == extra)
+        #expect(Transport.mungeOpusStereoAndNack(extra, matchingOffer: Self.offer) == extra)
+    }
+
+    /// The SFU offers `nack` for Opus (it does so when RED is off for the track), but
+    /// libwebrtc's answer drops it because audio codec capabilities carry no NACK — so
+    /// retransmission never activates. The munge accepts it, and only on the mids the
+    /// offer advertises it for.
+    @Test(.spec("https://datatracker.ietf.org/doc/html/rfc4585#section-4.2"))
+    func acceptsNackOnlyForMidsTheOfferAdvertisesItOn() {
+        let nackOffer = Self.sdp("""
+        v=0
+        m=audio 9 UDP/TLS/RTP/SAVPF 111
+        a=mid:0
+        a=rtpmap:111 opus/48000/2
+        a=rtcp-fb:111 nack
+        a=fmtp:111 minptime=10;useinbandfec=1
+        m=audio 9 UDP/TLS/RTP/SAVPF 111
+        a=mid:1
+        a=rtpmap:111 opus/48000/2
+        a=fmtp:111 minptime=10;useinbandfec=1
+        """)
+
+        let munged = Transport.mungeOpusStereoAndNack(Self.answer, matchingOffer: nackOffer)
+
+        let sections = SDP(parsing: munged).mediaSections
+        #expect(sections[0].hasRtcpFeedback("nack", forPayload: "111"))
+        #expect(!sections[1].hasRtcpFeedback("nack", forPayload: "111"))
+        // The nack offer carries no sprop-stereo, so no stereo preference is declared.
+        #expect(Self.fmtps(munged) == Self.fmtps(Self.answer))
+    }
+
+    /// A mid whose offer advertises both stereo and nack gets both in the answer,
+    /// and re-answering the munged answer changes nothing.
+    @Test func appliesStereoAndNackTogetherIdempotently() {
+        let bothOffer = Self.sdp("""
+        v=0
+        m=audio 9 UDP/TLS/RTP/SAVPF 111
+        a=mid:0
+        a=rtpmap:111 opus/48000/2
+        a=rtcp-fb:111 nack
+        a=fmtp:111 minptime=10;useinbandfec=1;sprop-stereo=1
+        """)
+
+        let munged = Transport.mungeOpusStereoAndNack(Self.answer, matchingOffer: bothOffer)
+
+        let section = SDP(parsing: munged).mediaSections[0]
+        #expect(section.fmtp(forPayload: "111")?.config == "minptime=10;useinbandfec=1;stereo=1")
+        #expect(section.hasRtcpFeedback("nack", forPayload: "111"))
+        #expect(Transport.mungeOpusStereoAndNack(munged, matchingOffer: bothOffer) == munged)
     }
 }

--- a/Tests/LiveKitCoreTests/SDP/SDPTests.swift
+++ b/Tests/LiveKitCoreTests/SDP/SDPTests.swift
@@ -254,4 +254,35 @@ struct SDPTests {
         #expect(appendedIndex != nil)
         #expect(appendedIndex.map { $0 + 1 } == videoMLineIndex)
     }
+
+    /// `nack` and `nack pli` are distinct feedback parameters (RFC 4585 §4.2) — the
+    /// value must match exactly, per payload.
+    @Test func rtcpFeedbackMatchesExactValuePerPayload() {
+        let section = SDP(parsing: """
+        v=0
+        m=video 9 UDP/TLS/RTP/SAVPF 96 97
+        a=rtcp-fb:96 nack pli
+        a=rtcp-fb:97 nack
+        """).mediaSections[0]
+
+        #expect(!section.hasRtcpFeedback("nack", forPayload: "96"))
+        #expect(section.hasRtcpFeedback("nack pli", forPayload: "96"))
+        #expect(section.hasRtcpFeedback("nack", forPayload: "97"))
+        #expect(!section.hasRtcpFeedback("nack", forPayload: "98"))
+    }
+
+    @Test func appendsRtcpFeedbackOnce() {
+        var document = SDP(parsing: """
+        v=0
+        m=audio 9 UDP/TLS/RTP/SAVPF 111
+        a=rtpmap:111 opus/48000/2
+        """)
+
+        let appended = document.mediaSections[0].appendRtcpFeedback("nack", forPayload: "111")
+        let appendedAgain = document.mediaSections[0].appendRtcpFeedback("nack", forPayload: "111")
+
+        #expect(appended)
+        #expect(!appendedAgain)
+        #expect(document.mediaSections[0].lines.last == "a=rtcp-fb:111 nack")
+    }
 }

--- a/Tests/LiveKitCoreTests/SDP/TransportMungeFallbackTests.swift
+++ b/Tests/LiveKitCoreTests/SDP/TransportMungeFallbackTests.swift
@@ -20,7 +20,7 @@ import Testing
 
 /// Runs against a real (local, offline) peer connection to prove the fallback premise
 /// on the shipped libwebrtc binary: a rejected `setLocalDescription` reports an error
-/// without poisoning the peer connection, so retrying with the original SDP works.
+/// without poisoning the peer connection, so retrying with less-munged SDP works.
 @Suite(.tags(.media))
 struct TransportMungeFallbackTests {
     private final class StubTransportDelegate: TransportDelegate {
@@ -32,14 +32,19 @@ struct TransportMungeFallbackTests {
         func transportShouldNegotiate(_: Transport) {}
     }
 
-    /// Runs `body` with a live transport, closing it even when `body` throws so a
-    /// failed test doesn't leak a peer connection into the rest of the parallel run.
+    /// Runs `body` with a live transport carrying a receive-only audio transceiver
+    /// (so offers contain a real Opus section for the munges to edit), closing it even
+    /// when `body` throws so a failed test doesn't leak a peer connection into the
+    /// rest of the parallel run.
     private func withTransport(_ body: (Transport) async throws -> Void) async throws {
         let transport = try Transport(config: .liveKitDefault(),
                                       target: .publisher,
                                       primary: true,
                                       delegate: StubTransportDelegate())
         do {
+            let transceiverInit = LKRTCRtpTransceiverInit()
+            transceiverInit.direction = .recvOnly
+            _ = try await transport.addTransceiver(ofType: .audio, transceiverInit: transceiverInit)
             try await body(transport)
         } catch {
             await transport.close()
@@ -60,47 +65,57 @@ struct TransportMungeFallbackTests {
         }
     }
 
-    @Test func fallsBackToOriginalWhenMungedDescriptionIsRejected() async throws {
+    @Test func appliesTheMungedDescriptionWhenAccepted() async throws {
         try await withTransport { transport in
             let offer = try await transport.createOffer()
-            let garbage = RTC.createSessionDescription(type: .offer, sdp: "this is not sdp")
 
-            let applied = try await transport.set(mungedLocalDescription: garbage, fallingBackTo: offer)
+            let applied = try await transport.set(localDescription: offer,
+                                                  munging: [Transport.mungeOpusStereoForAllAudio])
 
-            #expect(applied.sdp == offer.sdp)
+            #expect(applied !== offer)
+            #expect(applied.sdp == Transport.mungeOpusStereoForAllAudio(offer.sdp))
         }
     }
 
-    @Test func appliesMungedDescriptionWhenAccepted() async throws {
+    /// A no-op composition must set the original directly — object identity proves the
+    /// munged path (which would wrap the SDP in a new description) was never taken.
+    @Test func noOpMungesSetTheOriginalDirectly() async throws {
         try await withTransport { transport in
             let offer = try await transport.createOffer()
-            let munged = RTC.createSessionDescription(type: offer.type, sdp: offer.sdp)
 
-            let applied = try await transport.set(mungedLocalDescription: munged, fallingBackTo: offer)
+            let untouched = try await transport.set(localDescription: offer, munging: [])
+            let identity = try await transport.set(localDescription: offer, munging: [{ $0 }])
 
-            #expect(applied === munged)
+            #expect(untouched === offer)
+            #expect(identity === offer)
         }
     }
 
-    /// A no-op munge must set the original directly — object identity proves the munged
-    /// path (which would wrap the SDP in a new description) was never taken.
-    @Test func noOpMungeSetsTheOriginalDirectly() async throws {
+    @Test func fallsBackToTheOriginalWhenEveryMungeIsRejected() async throws {
         try await withTransport { transport in
             let offer = try await transport.createOffer()
 
-            let applied = try await transport.set(localDescription: offer) { $0 }
+            let applied = try await transport.set(localDescription: offer,
+                                                  munging: [{ _ in "this is not sdp" }])
 
             #expect(applied === offer)
         }
     }
 
-    @Test func mungingClosureRoutesThroughTheRejectionFallback() async throws {
+    /// Munges are dropped from the right on rejection, so a rejected optional munge
+    /// (here: garbage) cannot revert the required one before it (here: stereo, standing
+    /// in for the single-PC direction rewrite).
+    @Test func rejectionDropsOnlyTheTailMunge() async throws {
         try await withTransport { transport in
             let offer = try await transport.createOffer()
 
-            let applied = try await transport.set(localDescription: offer) { _ in "this is not sdp" }
+            let applied = try await transport.set(localDescription: offer, munging: [
+                Transport.mungeOpusStereoForAllAudio,
+                { _ in "this is not sdp" },
+            ])
 
-            #expect(applied === offer)
+            #expect(applied.sdp == Transport.mungeOpusStereoForAllAudio(offer.sdp))
+            #expect(applied.sdp != offer.sdp)
         }
     }
 }

--- a/Tests/LiveKitCoreTests/SDP/TransportMungeFallbackTests.swift
+++ b/Tests/LiveKitCoreTests/SDP/TransportMungeFallbackTests.swift
@@ -81,4 +81,26 @@ struct TransportMungeFallbackTests {
             #expect(applied === munged)
         }
     }
+
+    /// A no-op munge must set the original directly — object identity proves the munged
+    /// path (which would wrap the SDP in a new description) was never taken.
+    @Test func noOpMungeSetsTheOriginalDirectly() async throws {
+        try await withTransport { transport in
+            let offer = try await transport.createOffer()
+
+            let applied = try await transport.set(localDescription: offer) { $0 }
+
+            #expect(applied === offer)
+        }
+    }
+
+    @Test func mungingClosureRoutesThroughTheRejectionFallback() async throws {
+        try await withTransport { transport in
+            let offer = try await transport.createOffer()
+
+            let applied = try await transport.set(localDescription: offer) { _ in "this is not sdp" }
+
+            #expect(applied === offer)
+        }
+    }
 }

--- a/Tests/LiveKitCoreTests/SDP/TransportSDPMungeTests.swift
+++ b/Tests/LiveKitCoreTests/SDP/TransportSDPMungeTests.swift
@@ -61,4 +61,45 @@ struct TransportSDPMungeTests {
         let sdp = Self.offer.replacingOccurrences(of: "a=inactive", with: "a=recvonly")
         #expect(Transport.mungeInactiveToRecvOnlyForMedia(sdp) == sdp)
     }
+
+    /// Two Opus audio sections (one already declaring `stereo=1`, one carrying the
+    /// `sprop-stereo=1` substring trap), a video section, and a non-Opus audio section.
+    private static let singlePCOffer = """
+    v=0
+    m=audio 9 UDP/TLS/RTP/SAVPF 111
+    a=mid:0
+    a=rtpmap:111 opus/48000/2
+    a=fmtp:111 minptime=10;useinbandfec=1
+    m=audio 9 UDP/TLS/RTP/SAVPF 111
+    a=mid:1
+    a=rtpmap:111 opus/48000/2
+    a=fmtp:111 sprop-stereo=1
+    m=video 9 UDP/TLS/RTP/SAVPF 96
+    a=mid:2
+    a=rtpmap:96 VP8/90000
+    m=audio 9 UDP/TLS/RTP/SAVPF 8
+    a=mid:3
+    a=rtpmap:8 PCMA/8000
+    a=fmtp:8 maxptime=40
+    """.replacingOccurrences(of: "\n", with: "\r\n") + "\r\n"
+
+    /// In single PC mode the offerer is also the receiver, so `stereo=1` (RFC 7587 §7.1)
+    /// is declared on every audio section's Opus fmtp — including past the
+    /// `sprop-stereo=1` substring trap — while video and non-Opus audio are untouched.
+    @Test func declaresStereoOnEveryAudioOpusSection() {
+        let munged = Transport.mungeOpusStereoForAllAudio(Self.singlePCOffer)
+
+        #expect(SDP(parsing: munged).mediaSections.flatMap(\.fmtps).map(\.config) == [
+            "minptime=10;useinbandfec=1;stereo=1",
+            "sprop-stereo=1;stereo=1",
+            "maxptime=40",
+        ])
+    }
+
+    @Test func stereoForAllAudioIsIdempotentAndPreservesUnrelatedSDP() {
+        let once = Transport.mungeOpusStereoForAllAudio(Self.singlePCOffer)
+
+        #expect(Transport.mungeOpusStereoForAllAudio(once) == once)
+        #expect(Transport.mungeOpusStereoForAllAudio(Self.offer) == Self.offer)
+    }
 }


### PR DESCRIPTION
## Problem

A stereo audio publication plays back **mono** on this SDK.

The subscriber answer never declares `stereo=1`. Per [RFC 7587 §7.1](https://datatracker.ietf.org/doc/html/rfc7587#section-7.1), `stereo` is the **receiver's** preference — absent it, libwebrtc instantiates a mono Opus decoder and downmixes, regardless of what the sender transmits. `sprop-stereo` (the sender's side) is not sufficient on its own.

`client-sdk-js` already handles this via `extractStereoAndNackAudioFromOffer()` + `ensureAudioNackAndStereo()`, which is why the same room is stereo on web and mono on iOS/macOS. There is no equivalent here — `grep -i stereo` over `Sources/` returns only generated protobuf fields.

I hit this shipping a native iOS app, where the program feed is a 2-channel music/effects mix and the downmix is a functional defect, not a nicety. Verified by A/B-ing a patched build against an unpatched one on the same room: the app's own per-track `AudioRenderer` probe reports `channels=1` unpatched and `channels=2` patched, with the publisher unchanged.

**Scope.** This makes stereo available to the decoder and to anything reading the track through `RemoteAudioTrack.add(audioRenderer:)`. WebRTC's own ADM playout still mixes to mono — that is #161, and this change does not address it. The two are ordered rather than alternatives: without this, the decoder is built mono, so a custom render path has nothing to recover. (To actually *hear* stereo today an app also needs `setManualRenderingMode(true)` and to render the track itself; enabling manual rendering without your own renderer produces silence.)

## Change

Rebased onto `main` (2.16.0) and reimplemented on the `SDP` module from #1078, which already provides every primitive this needs:

```swift
static func mungeOpusStereo(_ sdp: String, matchingOffer offer: String) -> String
```

- Collects the mids of audio sections in the **offer** whose Opus fmtp advertises `sprop-stereo=1`, via `payload(forCodec:)` + `fmtp(forPayload:)`.
- Appends `stereo=1` to the Opus fmtp of those mids in the **answer**, via `appendFmtpParameter(_:forPayload:)` — whose exact-token check is what makes `sprop-stereo=1` not read as "already stereo".
- Returns the input unchanged when the offer advertises no stereo anywhere, so nothing is offered to libwebrtc for mono publications.

That replaces the previous revision's hand-rolled scanner: **131 lines → 33**. Every case that scanner existed to handle — `a=mid:` appearing after the `a=fmtp:` it applies to, EOL preservation, non-default payload types — is now the module's responsibility and is covered by its tests rather than duplicated here.

The earlier "one deliberate difference from the JS implementation" section is gone: exact-token fmtp matching is now `SDP.swift`'s documented behaviour, so there is nothing left to reconcile.

### Applied through the munge fallback

The answer path goes through `set(mungedLocalDescription:fallingBackTo:)` rather than `set(localDescription:)`. This munge is specifically one of the types libwebrtc m144 tracks under `IsSdpMungingAllowed` (`kAudioCodecsFmtpOpusStereo`), so a field-trial kill switch could reject it outright — and without the fallback that would turn "no stereo" into a failed negotiation.

The description that was **actually applied** is the one signalled back to the SFU. Signalling the munged SDP after a rejected apply would claim we negotiated stereo while the local decoder was built from the unmunged answer, leaving the two ends disagreeing about the decoder.

### One boundary worth naming

`appendFmtpParameter` never *inserts* an fmtp line, so an answer that carries no `a=fmtp:` for its Opus payload is left alone. libwebrtc always emits `minptime`/`useinbandfec`, so this is not a path taken in practice, but it is pinned by a test rather than left implicit. Happy to switch to `append(line:)` if you'd rather it synthesise the line.

## Tests

8 tests in `Tests/LiveKitCoreTests/SDP/OpusStereoSdpTests.swift`:

- applies only to mids the offer sends in stereo, leaving mono Opus, video and non-Opus audio sections untouched
- the `sprop-stereo` substring trap (answering with the offer's own SDP — the worst case)
- idempotency
- an offer with no stereo returns the answer byte-identical
- matched by mid rather than by section order
- Opus payload type resolved within the answer, not carried over from the offer
- an answer with no Opus fmtp line is untouched
- sections the offer never mentioned, and mid-matched sections carrying no Opus, are skipped

`swift test --filter 'SDP|OpusStereo|MungeFallback'` → 40 tests, 6 suites, passing.

Coverage of the new function, via `llvm-cov -show-functions`:

```
mungeInactiveToRecvOnlyForMedia    5/5 regions  10/10 lines  100%
mungeOpusStereo                    7/7 regions  20/20 lines  100%
  └ its section closure            3/3 regions   8/8 lines  100%
```

`SDP.swift` remains at 100%. `swiftlint lint --strict` and `swiftformat --lint` clean on the touched files.
