### PR TITLE
feat(e2ee): add BaseKeyProvider.setKey(keyData:) for raw binary keys

### DIFF
--- a/.changes/e2ee-raw-key-data
+++ b/.changes/e2ee-raw-key-data
@@ -1,0 +1,1 @@
+patch type="added" "Add `BaseKeyProvider.setKey(keyData:participantId:index:)` for installing raw binary E2EE key material without String conversion"

--- a/Sources/LiveKit/E2EE/KeyProvider.swift
+++ b/Sources/LiveKit/E2EE/KeyProvider.swift
@@ -150,10 +150,13 @@ public final class BaseKeyProvider: NSObject, Loggable, Sendable {
     // MARK: - Key management
 
     public func setKey(key: String, participantId: String? = nil, index: Int32? = nil) {
+        setKey(keyData: Data(key.utf8), participantId: participantId, index: index)
+    }
+
+    public func setKey(keyData: Data, participantId: String? = nil, index: Int32? = nil) {
         let targetIndex = index ?? getCurrentKeyIndex()
 
         if options.sharedKey {
-            let keyData = key.data(using: .utf8)!
             rtcKeyProvider.setSharedKey(keyData, with: targetIndex)
         } else {
             if participantId == nil {
@@ -161,7 +164,6 @@ public final class BaseKeyProvider: NSObject, Loggable, Sendable {
                 return
             }
 
-            let keyData = key.data(using: .utf8)!
             rtcKeyProvider.setKey(keyData, with: targetIndex, forParticipant: participantId!)
         }
 

--- a/Sources/LiveKit/E2EE/KeyProvider.swift
+++ b/Sources/LiveKit/E2EE/KeyProvider.swift
@@ -153,6 +153,12 @@ public final class BaseKeyProvider: NSObject, Loggable, Sendable {
         setKey(keyData: Data(key.utf8), participantId: participantId, index: index)
     }
 
+    /// Sets a raw binary key without any string conversion.
+    ///
+    /// - Parameters:
+    ///   - keyData: The key bytes, stored as provided.
+    ///   - participantId: Required in non-shared key mode; the call is a no-op when `nil`.
+    ///   - index: The key index to set. Defaults to the current key index.
     public func setKey(keyData: Data, participantId: String? = nil, index: Int32? = nil) {
         let targetIndex = index ?? getCurrentKeyIndex()
 

--- a/Tests/LiveKitCoreTests/E2EE/KeyProvider.swift
+++ b/Tests/LiveKitCoreTests/E2EE/KeyProvider.swift
@@ -85,4 +85,22 @@ struct BaseKeyProviderTests {
         let exported = try #require(provider.exportKey(index: -1))
         #expect(exported == Data("k".utf8))
     }
+
+    static let nonUtf8Key = Data([0xFF, 0xFE, 0x80, 0x00, 0xDE, 0xAD])
+
+    @Test
+    func setKeyDataSharedKeyPreservesNonUtf8Bytes() throws {
+        let provider = BaseKeyProvider(options: KeyProviderOptions(sharedKey: true, keyRingSize: 16))
+        provider.setKey(keyData: Self.nonUtf8Key, index: 2)
+        let exported = try #require(provider.exportKey(index: 2))
+        #expect(exported == Self.nonUtf8Key)
+    }
+
+    @Test
+    func setKeyDataPerParticipantPreservesNonUtf8Bytes() throws {
+        let provider = BaseKeyProvider(options: KeyProviderOptions(sharedKey: false, keyRingSize: 16))
+        provider.setKey(keyData: Self.nonUtf8Key, participantId: "alice", index: 1)
+        let exported = try #require(provider.exportKey(participantId: "alice", index: 1))
+        #expect(exported == Self.nonUtf8Key)
+    }
 }


### PR DESCRIPTION
Accept arbitrary key bytes instead of a UTF-8 String so binary key material from external E2EE layers can be installed without string conversion. The String variant now delegates to it.