### PR TITLE
Fix CI flakiness: data-stream races, QoS inversions, deterministic tests

### DIFF
--- a/.changes/fix-background-qos-inversions
+++ b/.changes/fix-background-qos-inversions
@@ -1,0 +1,1 @@
+patch type="fixed" "Completer timeouts and camera device discovery no longer run at background QoS, which the system may defer indefinitely under load"

--- a/.changes/fix-data-stream-ordering
+++ b/.changes/fix-data-stream-ordering
@@ -1,0 +1,1 @@
+patch type="fixed" "Incoming data streams could be dropped on stream-ID reuse or handled out of order; transcription handlers now run in wire order and open streams are failed on sender disconnect and room cleanup"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Run LiveKit Server
+        id: livekit-server
         uses: livekit/dev-server-action@61e2b4dcb170dd3591e0c9b0db3c3fe5db93b500
         with:
           github-token: ${{ github.token }}
@@ -130,6 +131,17 @@ jobs:
         with:
           name: test-log-${{ strategy.job-index }}
           path: ${{ runner.temp }}/xcodebuild.log
+          retention-days: 5
+
+      # Client-side logs can't distinguish "we gave up" from "the SFU hung up on
+      # us": a failed e2e test just shows `Connection reset by peer`. The server's
+      # JSONL log records the participant close reason, so capture both sides.
+      - name: Upload Server Log
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: server-log-${{ strategy.job-index }}
+          path: ${{ steps.livekit-server.outputs.log-path }}
           retention-days: 5
 
       - name: Build for Release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,51 +27,51 @@ jobs:
       matrix:
         include:
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
-          - os: macos-15-xlarge
+          - os: macos-15
             xcode: 16.4
             platform: "iOS Simulator,name=iPhone 16 Pro,OS=18.5"
-          - os: macos-15-xlarge
+          - os: macos-15
             xcode: 16.4
             platform: "macOS"
-          - os: macos-15-xlarge
+          - os: macos-15
             xcode: 16.4
             platform: "macOS,variant=Mac Catalyst"
-          - os: macos-15-xlarge
+          - os: macos-15
             xcode: 16.4
             platform: "tvOS Simulator,name=Apple TV,OS=18.5"
 
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md
-          - os: macos-26-xlarge
+          - os: macos-26
             xcode: 26.5
             platform: "iOS Simulator,name=iPhone 17 Pro,OS=26.5"
             symbol-graph: true
-          - os: macos-26-xlarge
+          - os: macos-26
             xcode: 26.5
             platform: "iOS Simulator,name=iPhone 17 Pro,OS=26.5"
             extension-api-only: true
-          - os: macos-26-xlarge
+          - os: macos-26
             xcode: 26.5
             platform: "macOS"
             symbol-graph: true
-          - os: macos-26-xlarge
+          - os: macos-26
             xcode: 26.5
             platform: "macOS"
             asan: true
-          - os: macos-26-xlarge
+          - os: macos-26
             xcode: 26.5
             platform: "macOS"
             tsan: true
-          - os: macos-26-xlarge
+          - os: macos-26
             xcode: 26.5
             platform: "macOS"
             strict-concurrency-env: true
-          - os: macos-26-xlarge
+          - os: macos-26
             xcode: 26.5
             platform: "macOS,variant=Mac Catalyst"
-          - os: macos-26-xlarge
+          - os: macos-26
             xcode: 26.5
             platform: "visionOS Simulator,name=Apple Vision Pro,OS=26.5"
-          - os: macos-26-xlarge
+          - os: macos-26
             xcode: 26.5
             platform: "tvOS Simulator,name=Apple TV,OS=26.5"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,24 @@ jobs:
             xcode: 26.6
             platform: "tvOS Simulator,name=Apple TV,OS=26.5"
 
+          # https://github.com/actions/runner-images/blob/main/images/macos/xcode-27-Readme.md
+          - os: xcode-27
+            xcode: latest
+            platform: "macOS"
+          - os: xcode-27
+            xcode: latest
+            platform: "macOS,variant=Mac Catalyst"
+          - os: xcode-27
+            xcode: latest
+            platform: "iOS Simulator,name=iPhone 17 Pro,OS=27.0"
+          - os: xcode-27
+            xcode: latest
+            platform: "visionOS Simulator,name=Apple Vision Pro,OS=27.0"
+          # This image has no plain "Apple TV" device, unlike macos-15/macos-26.
+          - os: xcode-27
+            xcode: latest
+            platform: "tvOS Simulator,name=Apple TV 4K (3rd generation),OS=27.0"
+
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,9 @@ concurrency:
 
 env:
   TEST_TIMEOUT_MINUTES: 30
-  TEST_RETRY_ATTEMPTS: 3
+  # TEMPORARY: 1 so any flake fails the job and the log artifacts actually
+  # upload. Restore to 3 before merging.
+  TEST_RETRY_ATTEMPTS: 1
 
 jobs:
   build-and-test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,6 +129,7 @@ jobs:
             -only-testing:LiveKitCoreTests \
             -only-testing:LiveKitObjCTests \
             -parallel-testing-enabled NO \
+            -retry-tests-on-failure -test-iterations 2 \
             | tee "$RUNNER_TEMP/xcodebuild.log" \
             | xcbeautify --renderer github-actions
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,51 +27,51 @@ jobs:
       matrix:
         include:
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
-          - os: macos-15
+          - os: macos-15-xlarge
             xcode: 16.4
             platform: "iOS Simulator,name=iPhone 16 Pro,OS=18.5"
-          - os: macos-15
+          - os: macos-15-xlarge
             xcode: 16.4
             platform: "macOS"
-          - os: macos-15
+          - os: macos-15-xlarge
             xcode: 16.4
             platform: "macOS,variant=Mac Catalyst"
-          - os: macos-15
+          - os: macos-15-xlarge
             xcode: 16.4
             platform: "tvOS Simulator,name=Apple TV,OS=18.5"
 
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md
-          - os: macos-26
+          - os: macos-26-xlarge
             xcode: 26.5
             platform: "iOS Simulator,name=iPhone 17 Pro,OS=26.5"
             symbol-graph: true
-          - os: macos-26
+          - os: macos-26-xlarge
             xcode: 26.5
             platform: "iOS Simulator,name=iPhone 17 Pro,OS=26.5"
             extension-api-only: true
-          - os: macos-26
+          - os: macos-26-xlarge
             xcode: 26.5
             platform: "macOS"
             symbol-graph: true
-          - os: macos-26
+          - os: macos-26-xlarge
             xcode: 26.5
             platform: "macOS"
             asan: true
-          - os: macos-26
+          - os: macos-26-xlarge
             xcode: 26.5
             platform: "macOS"
             tsan: true
-          - os: macos-26
+          - os: macos-26-xlarge
             xcode: 26.5
             platform: "macOS"
             strict-concurrency-env: true
-          - os: macos-26
+          - os: macos-26-xlarge
             xcode: 26.5
             platform: "macOS,variant=Mac Catalyst"
-          - os: macos-26
+          - os: macos-26-xlarge
             xcode: 26.5
             platform: "visionOS Simulator,name=Apple Vision Pro,OS=26.5"
-          - os: macos-26
+          - os: macos-26-xlarge
             xcode: 26.5
             platform: "tvOS Simulator,name=Apple TV,OS=26.5"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,37 +42,37 @@ jobs:
 
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md
           - os: macos-26
-            xcode: 26.5
+            xcode: 26.6
             platform: "iOS Simulator,name=iPhone 17 Pro,OS=26.5"
             symbol-graph: true
           - os: macos-26
-            xcode: 26.5
+            xcode: 26.6
             platform: "iOS Simulator,name=iPhone 17 Pro,OS=26.5"
             extension-api-only: true
           - os: macos-26
-            xcode: 26.5
+            xcode: 26.6
             platform: "macOS"
             symbol-graph: true
           - os: macos-26
-            xcode: 26.5
+            xcode: 26.6
             platform: "macOS"
             asan: true
           - os: macos-26
-            xcode: 26.5
+            xcode: 26.6
             platform: "macOS"
             tsan: true
           - os: macos-26
-            xcode: 26.5
+            xcode: 26.6
             platform: "macOS"
             strict-concurrency-env: true
           - os: macos-26
-            xcode: 26.5
+            xcode: 26.6
             platform: "macOS,variant=Mac Catalyst"
           - os: macos-26
-            xcode: 26.5
+            xcode: 26.6
             platform: "visionOS Simulator,name=Apple Vision Pro,OS=26.5"
           - os: macos-26
-            xcode: 26.5
+            xcode: 26.6
             platform: "tvOS Simulator,name=Apple TV,OS=26.5"
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,7 +117,20 @@ jobs:
               -only-testing:LiveKitCoreTests \
               -only-testing:LiveKitObjCTests \
               -parallel-testing-enabled NO \
+              | tee -a "$RUNNER_TEMP/xcodebuild.log" \
               | xcbeautify --renderer github-actions
+
+      # xcbeautify's github-actions renderer collapses a parameterized Swift Testing
+      # failure to "Recorded an issue (1) argument(s)" — no message, no failing
+      # argument. xcodebuild's own output has both, so keep it for post-mortems
+      # instead of re-running CI blind. Appended across retry attempts.
+      - name: Upload Test Log
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-log-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/xcodebuild.log
+          retention-days: 5
 
       - name: Build for Release
         if: ${{ matrix.symbol-graph }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  TEST_TIMEOUT_MINUTES: 30
-  # TEMPORARY: 1 so any flake fails the job and the log artifacts actually
-  # upload. Restore to 3 before merging.
-  TEST_RETRY_ATTEMPTS: 1
-
 jobs:
   build-and-test:
     name: Build & Test
@@ -124,27 +118,23 @@ jobs:
         run: xcrun swift --version
 
       - name: Build & Test
-        uses: nick-fields/retry@v4
-        with:
-          timeout_minutes: ${{ env.TEST_TIMEOUT_MINUTES }}
-          max_attempts: ${{ env.TEST_RETRY_ATTEMPTS }}
-          command: |
-            set -o pipefail && xcodebuild test \
-              -scheme LiveKit \
-              -destination 'platform=${{ matrix.platform }}' \
-              -enableAddressSanitizer ${{ matrix.asan == true && 'YES' || 'NO' }} \
-              -enableThreadSanitizer ${{ matrix.tsan == true && 'YES' || 'NO' }} \
-              APPLICATION_EXTENSION_API_ONLY=${{ matrix.extension-api-only == true && 'YES' || 'NO' }} \
-              -only-testing:LiveKitCoreTests \
-              -only-testing:LiveKitObjCTests \
-              -parallel-testing-enabled NO \
-              | tee -a "$RUNNER_TEMP/xcodebuild.log" \
-              | xcbeautify --renderer github-actions
+        timeout-minutes: 30
+        run: |
+          set -o pipefail && xcodebuild test \
+            -scheme LiveKit \
+            -destination 'platform=${{ matrix.platform }}' \
+            -enableAddressSanitizer ${{ matrix.asan == true && 'YES' || 'NO' }} \
+            -enableThreadSanitizer ${{ matrix.tsan == true && 'YES' || 'NO' }} \
+            APPLICATION_EXTENSION_API_ONLY=${{ matrix.extension-api-only == true && 'YES' || 'NO' }} \
+            -only-testing:LiveKitCoreTests \
+            -only-testing:LiveKitObjCTests \
+            -parallel-testing-enabled NO \
+            | tee "$RUNNER_TEMP/xcodebuild.log" \
+            | xcbeautify --renderer github-actions
 
       # xcbeautify's github-actions renderer collapses a parameterized Swift Testing
       # failure to "Recorded an issue (1) argument(s)" — no message, no failing
-      # argument. xcodebuild's own output has both, so keep it for post-mortems
-      # instead of re-running CI blind. Appended across retry attempts.
+      # argument. xcodebuild's own output has both, so keep it for post-mortems.
       - name: Upload Test Log
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -40,3 +40,8 @@ custom_rules:
     regex: "@objc(?![(\\[])\\s+(?:(?:public|open|final|internal|package)\\s+)*class\\b"
     message: "Use @objcMembers instead of @objc for classes to implicitly expose members to Objective-C."
     severity: warning
+  no_background_qos:
+    name: "No Background QoS"
+    regex: "(qos:\\s*\\.background\\b|priority:\\s*\\.background\\b|DispatchQoS\\.background\\b|TaskPriority\\.background\\b|qosClass:\\s*\\.background\\b|QOS_CLASS_BACKGROUND)"
+    message: "Background QoS may be deferred indefinitely under CPU pressure; anything awaiting work scheduled here can stall forever (QoS inversion). Use .utility or higher."
+    severity: error

--- a/Sources/LiveKit/Agent/Chat/Receive/TranscriptionStreamReceiver.swift
+++ b/Sources/LiveKit/Agent/Chat/Receive/TranscriptionStreamReceiver.swift
@@ -94,7 +94,7 @@ actor TranscriptionStreamReceiver: MessageReceiver, Loggable {
         // SDK-internal receiver — register via `incomingStreamManager` directly
         // so the receiver works even if the `Room.reservedTopicPrefix` guard is
         // later widened to cover non-RPC `lk.*` topics like this one.
-        try await room.incomingStreamManager.registerTextStreamHandler(for: topic) { [weak self] reader, participantIdentity in
+        try await room.incomingStreamManager.registerTextStreamHandler(for: topic, ordered: true) { [weak self] reader, participantIdentity in
             var lastMessage: ReceivedMessage?
             for try await message in reader where !message.isEmpty {
                 guard let self else { return }

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -588,6 +588,9 @@ extension Room {
         primaryTransportConnectedCompleter.reset(throwing: disconnectError)
         publisherTransportConnectedCompleter.reset(throwing: disconnectError)
         await activeParticipantCompleters.reset(throwing: disconnectError)
+        // Fail open data streams so their handlers return; a handler blocked on a
+        // reader that will never finish would stall its topic's ordered queue.
+        await incomingStreamManager.reset()
 
         await signalClient.cleanUp(withError: disconnectError)
         // Cancel all track stats timers before closing transports to prevent
@@ -677,6 +680,7 @@ extension Room {
         // so the caller sees `recipientDisconnected` (1503) immediately instead of
         // hanging until the user-supplied `responseTimeout`.
         await rpcClient.handleParticipantDisconnected(identity)
+        await incomingStreamManager.closeStreams(from: identity)
 
         guard let participant = _state.mutate({ $0.remoteParticipants.removeValue(forKey: identity) }) else {
             throw LiveKitError(.invalidState, message: "Participant not found for \(identity)")

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -106,6 +106,10 @@ actor IncomingStreamManager: Loggable {
     /// concurrently, so a still-open stream never delays later ones. Off by
     /// default: it would serialize consumers that want strict concurrency (e.g.
     /// RPC request handling).
+    ///
+    /// Contract: an ordered handler should return promptly once its reader ends —
+    /// work it keeps doing after its stream closed delays every later
+    /// non-overlapping stream on the topic.
     func registerTextStreamHandler(for topic: String, ordered: Bool = false, _ onNewStream: @escaping TextStreamHandler) throws {
         guard textStreamHandlers[topic] == nil else {
             throw StreamError.handlerAlreadyRegistered

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -182,7 +182,11 @@ actor IncomingStreamManager: Loggable {
         // conditions are signalled through `source` throwing instead.
         if let orderedQueue = orderedQueues[info.topic] {
             orderedQueue.yield {
-                try? await handler(source, identity)
+                do {
+                    try await handler(source, identity)
+                } catch {
+                    Self.log("Stream handler error: \(error)", .error)
+                }
             }
         } else {
             Task.detachedDiscarding {

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -16,6 +16,8 @@
 
 import Foundation
 
+// swiftlint:disable file_length
+
 /// Manages state of incoming data streams.
 actor IncomingStreamManager: Loggable {
     /// Information about an open data stream.
@@ -40,9 +42,15 @@ actor IncomingStreamManager: Loggable {
     private var byteStreamHandlers: [String: ByteStreamHandler] = [:]
     private var textStreamHandlers: [String: TextStreamHandler] = [:]
 
-    /// Per-topic FIFO of pending handler invocations, consumed by a single task.
-    /// A topic having an entry here is what makes it ordered.
-    private var orderedQueues: [String: AsyncStream<@Sendable () async -> Void>.Continuation] = [:]
+    /// Topics whose handlers preserve wire order (see `registerTextStreamHandler`).
+    private var orderedTopics: Set<String> = []
+    /// Handlers of streams that are still open on the wire, keyed by topic and
+    /// descriptor generation. Open streams gate nothing.
+    private var runningHandlers: [String: [UUID: Task<Void, Never>]] = [:]
+    /// Handlers of streams already closed on the wire but still executing (e.g.
+    /// draining buffered chunks or emitting a finalization). A new stream on the
+    /// topic opened after these closed, so its handler must wait for them.
+    private var finishingHandlers: [String: [UUID: Task<Void, Never>]] = [:]
 
     /// Events are processed in a serial (FIFO) order
     enum StreamEvent {
@@ -93,24 +101,18 @@ actor IncomingStreamManager: Loggable {
         byteStreamHandlers[topic] = onNewStream
     }
 
-    /// When `ordered` is true, handlers for this topic run sequentially in wire
-    /// order instead of concurrently. Off by default: it would serialize
-    /// consumers that want concurrency (e.g. RPC request handling), and a
-    /// stream that never closes would block all later ones behind it.
+    /// When `ordered` is true, handlers for streams that do not overlap on the
+    /// wire run in wire order: a stream opened after another closed waits for the
+    /// earlier handler to finish. Streams that are open concurrently are handled
+    /// concurrently, so a still-open stream never delays later ones. Off by
+    /// default: it would serialize consumers that want strict concurrency (e.g.
+    /// RPC request handling).
     func registerTextStreamHandler(for topic: String, ordered: Bool = false, _ onNewStream: @escaping TextStreamHandler) throws {
         guard textStreamHandlers[topic] == nil else {
             throw StreamError.handlerAlreadyRegistered
         }
         textStreamHandlers[topic] = onNewStream
-        if ordered {
-            let (stream, continuation) = AsyncStream.makeStream(of: (@Sendable () async -> Void).self)
-            Task.detachedDiscarding {
-                for await work in stream {
-                    await work()
-                }
-            }
-            orderedQueues[topic] = continuation
-        }
+        if ordered { orderedTopics.insert(topic) }
     }
 
     /// SDK-internal: register `onNewStream` for `topic` if no handler is registered yet,
@@ -129,7 +131,7 @@ actor IncomingStreamManager: Loggable {
 
     func unregisterTextStreamHandler(for topic: String) {
         textStreamHandlers[topic] = nil
-        orderedQueues.removeValue(forKey: topic)?.finish()
+        orderedTopics.remove(topic)
     }
 
     // MARK: - Packet processing
@@ -180,19 +182,45 @@ actor IncomingStreamManager: Loggable {
 
         // Detached: handler lifetime is not tied to the descriptor — abnormal stream
         // conditions are signalled through `source` throwing instead.
-        if let orderedQueue = orderedQueues[info.topic] {
-            orderedQueue.yield {
+        if orderedTopics.contains(info.topic) {
+            // Wire happens-before: this stream opened after `predecessors` closed,
+            // so their handlers must finish first. Same-segment streams never
+            // overlap (senders close one before opening the next), which is what
+            // makes finalizations and stream-ID reuse race-free.
+            let predecessors = Array((finishingHandlers[info.topic] ?? [:]).values)
+            let topic = info.topic
+            let generation = descriptor.generation
+            let task = Task.detached { [weak self] in
+                for predecessor in predecessors {
+                    await predecessor.value
+                }
                 do {
                     try await handler(source, identity)
                 } catch {
-                    Self.log("Stream handler error: \(error)", .error)
+                    self?.log("Text stream handler for topic '\(topic)' threw: \(error)", .warning)
                 }
+                await self?.handlerCompleted(topic: topic, generation: generation)
             }
+            runningHandlers[topic, default: [:]][generation] = task
         } else {
             Task.detachedDiscarding {
                 try await handler(source, identity)
             }
         }
+    }
+
+    /// Marks the stream's handler as gating later non-overlapping streams on the
+    /// same ordered topic. Called wherever a stream is closed on the wire.
+    private func streamDidClose(_ descriptor: Descriptor) {
+        let topic = descriptor.info.topic
+        if let task = runningHandlers[topic]?.removeValue(forKey: descriptor.generation) {
+            finishingHandlers[topic, default: [:]][descriptor.generation] = task
+        }
+    }
+
+    private func handlerCompleted(topic: String, generation: UUID) {
+        runningHandlers[topic]?[generation] = nil
+        finishingHandlers[topic]?[generation] = nil
     }
 
     /// Close the stream with the given id, unless it has been superseded by a
@@ -208,6 +236,7 @@ actor IncomingStreamManager: Loggable {
     func closeStreams(from identity: Participant.Identity) {
         for (id, descriptor) in openStreams where descriptor.identity == identity {
             openStreams[id] = nil
+            streamDidClose(descriptor)
             descriptor.continuation.finish(throwing: StreamError.terminated)
         }
     }
@@ -216,6 +245,7 @@ actor IncomingStreamManager: Loggable {
     /// survive so streams arriving after a reconnect are still handled.
     func reset() {
         for descriptor in openStreams.values {
+            streamDidClose(descriptor)
             descriptor.continuation.finish(throwing: StreamError.terminated)
         }
         openStreams.removeAll()
@@ -233,6 +263,7 @@ actor IncomingStreamManager: Loggable {
                 received: encryptionType,
             )
             openStreams[chunk.streamID] = nil
+            streamDidClose(descriptor)
             descriptor.continuation.finish(throwing: error)
             return
         }
@@ -242,6 +273,7 @@ actor IncomingStreamManager: Loggable {
         if let totalLength = descriptor.info.totalLength {
             guard readLength <= totalLength else {
                 openStreams[chunk.streamID] = nil
+                streamDidClose(descriptor)
                 descriptor.continuation.finish(throwing: StreamError.lengthExceeded)
                 return
             }
@@ -261,6 +293,7 @@ actor IncomingStreamManager: Loggable {
         // The reader's `onTermination` cleanup runs in its own task and can lose
         // that race, making `openStream` silently drop the new stream.
         openStreams[trailer.streamID] = nil
+        streamDidClose(descriptor)
 
         if descriptor.info.encryptionType != encryptionType {
             let error = StreamError.encryptionTypeMismatch(
@@ -310,9 +343,6 @@ actor IncomingStreamManager: Loggable {
 
     deinit {
         eventContinuation.finish()
-        for continuation in orderedQueues.values {
-            continuation.finish()
-        }
         guard !openStreams.isEmpty else { return }
         for descriptor in openStreams.values {
             descriptor.continuation.finish(throwing: StreamError.terminated)
@@ -388,3 +418,5 @@ extension TextStreamInfo.OperationType {
         self = Self(rawValue: operationType.rawValue) ?? .create
     }
 }
+
+// swiftlint:enable file_length

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -27,7 +27,6 @@ actor IncomingStreamManager: Loggable {
         let generation = UUID()
         let info: StreamInfo
         let identity: Participant.Identity
-        let openTime: TimeInterval
         let continuation: StreamReaderSource.Continuation
         var readLength = 0
     }
@@ -148,6 +147,7 @@ actor IncomingStreamManager: Loggable {
 
     private func openStream(with info: StreamInfo, from identity: Participant.Identity) {
         guard openStreams[info.id] == nil else {
+            log("Ignoring stream \(info.id) from \(identity): a stream with this ID is already open", .warning)
             return
         }
         guard let handler = handler(for: info) else {
@@ -167,7 +167,6 @@ actor IncomingStreamManager: Loggable {
         let descriptor = Descriptor(
             info: info,
             identity: identity,
-            openTime: Date.timeIntervalSinceReferenceDate,
             continuation: continuation,
         )
         openStreams[info.id] = descriptor
@@ -230,9 +229,8 @@ actor IncomingStreamManager: Loggable {
         openStreams[id] = nil
     }
 
-    /// Fails all open streams from the given participant. Without this, a stream
-    /// whose sender disconnects before its trailer stays open forever — and on an
-    /// ordered topic its handler blocks every stream behind it.
+    /// Fails all open streams from the given participant, whose trailers can no
+    /// longer arrive; their readers throw and their handlers return.
     func closeStreams(from identity: Participant.Identity) {
         for (id, descriptor) in openStreams where descriptor.identity == identity {
             openStreams[id] = nil
@@ -241,8 +239,8 @@ actor IncomingStreamManager: Loggable {
         }
     }
 
-    /// Fails all open streams. Registered handlers and their ordered queues
-    /// survive so streams arriving after a reconnect are still handled.
+    /// Fails all open streams. Handler registrations survive so streams arriving
+    /// after a reconnect are still handled.
     func reset() {
         for descriptor in openStreams.values {
             streamDidClose(descriptor)

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -24,6 +24,7 @@ actor IncomingStreamManager: Loggable {
         /// ID, so a stale cleanup can't remove a successor.
         let generation = UUID()
         let info: StreamInfo
+        let identity: Participant.Identity
         let openTime: TimeInterval
         let continuation: StreamReaderSource.Continuation
         var readLength = 0
@@ -31,6 +32,8 @@ actor IncomingStreamManager: Loggable {
 
     /// Mapping between stream ID and descriptor for open streams.
     private var openStreams: [String: Descriptor] = [:]
+
+    var openStreamCount: Int { openStreams.count }
     /// Stream topics without a registered handler.
     private var failedToOpenStreams: Set<String> = []
 
@@ -161,6 +164,7 @@ actor IncomingStreamManager: Loggable {
 
         let descriptor = Descriptor(
             info: info,
+            identity: identity,
             openTime: Date.timeIntervalSinceReferenceDate,
             continuation: continuation,
         )
@@ -194,15 +198,37 @@ actor IncomingStreamManager: Loggable {
         openStreams[id] = nil
     }
 
+    /// Fails all open streams from the given participant. Without this, a stream
+    /// whose sender disconnects before its trailer stays open forever — and on an
+    /// ordered topic its handler blocks every stream behind it.
+    func closeStreams(from identity: Participant.Identity) {
+        for (id, descriptor) in openStreams where descriptor.identity == identity {
+            openStreams[id] = nil
+            descriptor.continuation.finish(throwing: StreamError.terminated)
+        }
+    }
+
+    /// Fails all open streams. Registered handlers and their ordered queues
+    /// survive so streams arriving after a reconnect are still handled.
+    func reset() {
+        for descriptor in openStreams.values {
+            descriptor.continuation.finish(throwing: StreamError.terminated)
+        }
+        openStreams.removeAll()
+    }
+
     /// Handles a data stream chunk.
     private func handle(chunk: Livekit_DataStream.Chunk, encryptionType: EncryptionType) {
         guard !chunk.content.isEmpty, let descriptor = openStreams[chunk.streamID] else { return }
 
+        // Error paths remove the descriptor synchronously for the same reason as
+        // the trailer path: a header reusing this stream ID may be the next event.
         if descriptor.info.encryptionType != encryptionType {
             let error = StreamError.encryptionTypeMismatch(
                 expected: descriptor.info.encryptionType,
                 received: encryptionType,
             )
+            openStreams[chunk.streamID] = nil
             descriptor.continuation.finish(throwing: error)
             return
         }
@@ -211,6 +237,7 @@ actor IncomingStreamManager: Loggable {
 
         if let totalLength = descriptor.info.totalLength {
             guard readLength <= totalLength else {
+                openStreams[chunk.streamID] = nil
                 descriptor.continuation.finish(throwing: StreamError.lengthExceeded)
                 return
             }

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -187,20 +187,6 @@ actor IncomingStreamManager: Loggable {
         }
     }
 
-    /// FIFO work queue for an ordered topic, created on first use. The consumer
-    /// task ends when the continuation is finished (unregister or deinit).
-    private func orderedQueue(for topic: String) -> AsyncStream<@Sendable () async -> Void>.Continuation {
-        if let existing = orderedQueues[topic] { return existing }
-        let (stream, continuation) = AsyncStream.makeStream(of: (@Sendable () async -> Void).self)
-        Task.detachedDiscarding {
-            for await work in stream {
-                await work()
-            }
-        }
-        orderedQueues[topic] = continuation
-        return continuation
-    }
-
     /// Close the stream with the given id, unless it has been superseded by a
     /// newer stream reusing the same id.
     private func closeStream(with id: String, generation: UUID) {

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -20,6 +20,9 @@ import Foundation
 actor IncomingStreamManager: Loggable {
     /// Information about an open data stream.
     private struct Descriptor {
+        /// Distinguishes this descriptor from others that reuse the same stream
+        /// ID, so a stale cleanup can't remove a successor.
+        let generation = UUID()
         let info: StreamInfo
         let openTime: TimeInterval
         let continuation: StreamReaderSource.Continuation
@@ -153,18 +156,23 @@ actor IncomingStreamManager: Loggable {
 
         var continuation: StreamReaderSource.Continuation!
         let source = StreamReaderSource {
-            $0.onTermination = { @Sendable [weak self] _ in
-                guard let self else { return }
-                Task { await self.closeStream(with: info.id) }
-            }
             continuation = $0
         }
 
-        openStreams[info.id] = Descriptor(
+        let descriptor = Descriptor(
             info: info,
             openTime: Date.timeIntervalSinceReferenceDate,
             continuation: continuation,
         )
+        openStreams[info.id] = descriptor
+
+        // Set after the descriptor is stored: this task runs at an arbitrary
+        // later point, and a sender may have reused the stream ID by then, so
+        // it must only remove its own generation.
+        continuation.onTermination = { @Sendable [weak self, generation = descriptor.generation] _ in
+            guard let self else { return }
+            Task { await self.closeStream(with: info.id, generation: generation) }
+        }
 
         // Detached: handler lifetime is not tied to the descriptor — abnormal stream
         // conditions are signalled through `source` throwing instead.
@@ -193,8 +201,10 @@ actor IncomingStreamManager: Loggable {
         return continuation
     }
 
-    /// Close the stream with the given id.
-    private func closeStream(with id: String) {
+    /// Close the stream with the given id, unless it has been superseded by a
+    /// newer stream reusing the same id.
+    private func closeStream(with id: String, generation: UUID) {
+        guard openStreams[id]?.generation == generation else { return }
         openStreams[id] = nil
     }
 

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -34,6 +34,11 @@ actor IncomingStreamManager: Loggable {
     private var byteStreamHandlers: [String: ByteStreamHandler] = [:]
     private var textStreamHandlers: [String: TextStreamHandler] = [:]
 
+    /// Topics whose handlers run one at a time, in wire order.
+    private var orderedTopics: Set<String> = []
+    /// Per-topic FIFO of pending handler invocations, consumed by a single task.
+    private var orderedQueues: [String: AsyncStream<@Sendable () async -> Void>.Continuation] = [:]
+
     /// Events are processed in a serial (FIFO) order
     enum StreamEvent {
         case header(Livekit_DataStream.Header, String, EncryptionType)
@@ -83,11 +88,16 @@ actor IncomingStreamManager: Loggable {
         byteStreamHandlers[topic] = onNewStream
     }
 
-    func registerTextStreamHandler(for topic: String, _ onNewStream: @escaping TextStreamHandler) throws {
+    /// When `ordered` is true, handlers for this topic run sequentially in wire
+    /// order instead of concurrently. Off by default: it would serialize
+    /// consumers that want concurrency (e.g. RPC request handling), and a
+    /// stream that never closes would block all later ones behind it.
+    func registerTextStreamHandler(for topic: String, ordered: Bool = false, _ onNewStream: @escaping TextStreamHandler) throws {
         guard textStreamHandlers[topic] == nil else {
             throw StreamError.handlerAlreadyRegistered
         }
         textStreamHandlers[topic] = onNewStream
+        if ordered { orderedTopics.insert(topic) }
     }
 
     /// SDK-internal: register `onNewStream` for `topic` if no handler is registered yet,
@@ -106,6 +116,8 @@ actor IncomingStreamManager: Loggable {
 
     func unregisterTextStreamHandler(for topic: String) {
         textStreamHandlers[topic] = nil
+        orderedTopics.remove(topic)
+        orderedQueues.removeValue(forKey: topic)?.finish()
     }
 
     // MARK: - Packet processing
@@ -150,9 +162,29 @@ actor IncomingStreamManager: Loggable {
 
         // Detached: handler lifetime is not tied to the descriptor — abnormal stream
         // conditions are signalled through `source` throwing instead.
-        Task.detachedDiscarding {
-            try await handler(source, identity)
+        if orderedTopics.contains(info.topic) {
+            orderedQueue(for: info.topic).yield {
+                try? await handler(source, identity)
+            }
+        } else {
+            Task.detachedDiscarding {
+                try await handler(source, identity)
+            }
         }
+    }
+
+    /// FIFO work queue for an ordered topic, created on first use. The consumer
+    /// task ends when the continuation is finished (unregister or deinit).
+    private func orderedQueue(for topic: String) -> AsyncStream<@Sendable () async -> Void>.Continuation {
+        if let existing = orderedQueues[topic] { return existing }
+        let (stream, continuation) = AsyncStream.makeStream(of: (@Sendable () async -> Void).self)
+        Task.detachedDiscarding {
+            for await work in stream {
+                await work()
+            }
+        }
+        orderedQueues[topic] = continuation
+        return continuation
     }
 
     /// Close the stream with the given id.
@@ -190,6 +222,12 @@ actor IncomingStreamManager: Loggable {
         guard let descriptor = openStreams[trailer.streamID] else {
             return
         }
+
+        // Remove synchronously: senders may reuse a stream ID, and the reopening
+        // header is processed by this same event loop right after the trailer.
+        // The reader's `onTermination` cleanup runs in its own task and can lose
+        // that race, making `openStream` silently drop the new stream.
+        openStreams[trailer.streamID] = nil
 
         if descriptor.info.encryptionType != encryptionType {
             let error = StreamError.encryptionTypeMismatch(
@@ -239,6 +277,9 @@ actor IncomingStreamManager: Loggable {
 
     deinit {
         eventContinuation.finish()
+        for continuation in orderedQueues.values {
+            continuation.finish()
+        }
         guard !openStreams.isEmpty else { return }
         for descriptor in openStreams.values {
             descriptor.continuation.finish(throwing: StreamError.terminated)

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -34,9 +34,8 @@ actor IncomingStreamManager: Loggable {
     private var byteStreamHandlers: [String: ByteStreamHandler] = [:]
     private var textStreamHandlers: [String: TextStreamHandler] = [:]
 
-    /// Topics whose handlers run one at a time, in wire order.
-    private var orderedTopics: Set<String> = []
     /// Per-topic FIFO of pending handler invocations, consumed by a single task.
+    /// A topic having an entry here is what makes it ordered.
     private var orderedQueues: [String: AsyncStream<@Sendable () async -> Void>.Continuation] = [:]
 
     /// Events are processed in a serial (FIFO) order
@@ -97,7 +96,15 @@ actor IncomingStreamManager: Loggable {
             throw StreamError.handlerAlreadyRegistered
         }
         textStreamHandlers[topic] = onNewStream
-        if ordered { orderedTopics.insert(topic) }
+        if ordered {
+            let (stream, continuation) = AsyncStream.makeStream(of: (@Sendable () async -> Void).self)
+            Task.detachedDiscarding {
+                for await work in stream {
+                    await work()
+                }
+            }
+            orderedQueues[topic] = continuation
+        }
     }
 
     /// SDK-internal: register `onNewStream` for `topic` if no handler is registered yet,
@@ -116,7 +123,6 @@ actor IncomingStreamManager: Loggable {
 
     func unregisterTextStreamHandler(for topic: String) {
         textStreamHandlers[topic] = nil
-        orderedTopics.remove(topic)
         orderedQueues.removeValue(forKey: topic)?.finish()
     }
 
@@ -162,8 +168,8 @@ actor IncomingStreamManager: Loggable {
 
         // Detached: handler lifetime is not tied to the descriptor — abnormal stream
         // conditions are signalled through `source` throwing instead.
-        if orderedTopics.contains(info.topic) {
-            orderedQueue(for: info.topic).yield {
+        if let orderedQueue = orderedQueues[info.topic] {
+            orderedQueue.yield {
                 try? await handler(source, identity)
             }
         } else {

--- a/Sources/LiveKit/Support/Async/AsyncCompleter.swift
+++ b/Sources/LiveKit/Support/Async/AsyncCompleter.swift
@@ -87,7 +87,12 @@ final class AsyncCompleter<T: Sendable>: @unchecked Sendable, Loggable {
 
     let label: String
 
-    private let _timerQueue = DispatchQueue(label: "LiveKitSDK.AsyncCompleter", qos: .background)
+    // Timeout blocks resume waiters that nothing else will resume, so they must
+    // run even when the host is busy. At `.background` QoS the system may defer
+    // them indefinitely under CPU pressure, leaving a default-priority waiter
+    // suspended on a continuation only this queue can resume (QoS inversion
+    // with no donation edge).
+    private let _timerQueue = DispatchQueue(label: "LiveKitSDK.AsyncCompleter", qos: .default)
 
     // Internal states
     private var _defaultTimeout: DispatchTimeInterval

--- a/Sources/LiveKit/Support/Async/AsyncCompleter.swift
+++ b/Sources/LiveKit/Support/Async/AsyncCompleter.swift
@@ -87,12 +87,7 @@ final class AsyncCompleter<T: Sendable>: @unchecked Sendable, Loggable {
 
     let label: String
 
-    // Timeout blocks resume waiters that nothing else will resume, so they must
-    // run even when the host is busy. At `.background` QoS the system may defer
-    // them indefinitely under CPU pressure, leaving a default-priority waiter
-    // suspended on a continuation only this queue can resume (QoS inversion
-    // with no donation edge).
-    private let _timerQueue = DispatchQueue(label: "LiveKitSDK.AsyncCompleter", qos: .default)
+    private let _timerQueue = DispatchQueue(label: "LiveKitSDK.AsyncCompleter", qos: .utility)
 
     // Internal states
     private var _defaultTimeout: DispatchTimeInterval

--- a/Sources/LiveKit/Support/Async/AsyncTimer.swift
+++ b/Sources/LiveKit/Support/Async/AsyncTimer.swift
@@ -20,6 +20,7 @@ final class AsyncTimer: Sendable, Loggable {
     // MARK: - Public types
 
     typealias TimerBlock = @Sendable () async throws -> Void
+    typealias SleepFunction = @Sendable (TimeInterval) async throws -> Void
 
     // MARK: - Private
 
@@ -32,8 +33,12 @@ final class AsyncTimer: Sendable, Loggable {
     }
 
     let _state: StateSync<State>
+    private let _sleep: SleepFunction
 
-    init(interval: TimeInterval) {
+    init(interval: TimeInterval,
+         sleep: @escaping SleepFunction = { try await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000)) })
+    {
+        _sleep = sleep
         _state = StateSync(State(interval: interval))
     }
 
@@ -60,7 +65,7 @@ final class AsyncTimer: Sendable, Loggable {
             while !Task.isCancelled {
                 guard let self else { return }
                 let (interval, block) = _state.read { ($0.interval, $0.block) }
-                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+                try? await _sleep(interval)
                 if Task.isCancelled { break }
                 do {
                     try await block?()

--- a/Sources/LiveKit/Support/Async/AsyncTimer.swift
+++ b/Sources/LiveKit/Support/Async/AsyncTimer.swift
@@ -22,6 +22,8 @@ final class AsyncTimer: Sendable, Loggable {
     typealias TimerBlock = @Sendable () async throws -> Void
     typealias SleepFunction = @Sendable (TimeInterval) async throws -> Void
 
+    static let taskSleep: SleepFunction = { try await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000)) }
+
     // MARK: - Private
 
     struct State {
@@ -35,9 +37,7 @@ final class AsyncTimer: Sendable, Loggable {
     let _state: StateSync<State>
     private let _sleep: SleepFunction
 
-    init(interval: TimeInterval,
-         sleep: @escaping SleepFunction = { try await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000)) })
-    {
+    init(interval: TimeInterval, sleep: @escaping SleepFunction = AsyncTimer.taskSleep) {
         _sleep = sleep
         _state = StateSync(State(interval: interval))
     }

--- a/Sources/LiveKit/Support/Video/DeviceManager.swift
+++ b/Sources/LiveKit/Support/Video/DeviceManager.swift
@@ -100,7 +100,7 @@ class DeviceManager: @unchecked Sendable, Loggable {
         log()
 
         #if os(iOS) || os(macOS) || os(tvOS)
-        DispatchQueue.global(qos: .background).async { [weak self] in
+        DispatchQueue.global(qos: .default).async { [weak self] in
             guard let self else { return }
             _devicesObservation = discoverySession.observe(\.devices, options: [.initial, .new]) { [weak self] _, value in
                 guard let self else { return }
@@ -122,7 +122,7 @@ class DeviceManager: @unchecked Sendable, Loggable {
         #endif
 
         #if os(iOS) || os(tvOS)
-        DispatchQueue.global(qos: .background).async { [weak self] in
+        DispatchQueue.global(qos: .default).async { [weak self] in
             guard let self else { return }
             _multiCamDeviceSetsObservation = discoverySession.observe(\.supportedMultiCamDeviceSets, options: [.initial, .new]) { [weak self] _, value in
                 guard let self else { return }

--- a/Sources/LiveKit/Support/Video/DeviceManager.swift
+++ b/Sources/LiveKit/Support/Video/DeviceManager.swift
@@ -100,7 +100,7 @@ class DeviceManager: @unchecked Sendable, Loggable {
         log()
 
         #if os(iOS) || os(macOS) || os(tvOS)
-        DispatchQueue.global(qos: .default).async { [weak self] in
+        DispatchQueue.global(qos: .utility).async { [weak self] in
             guard let self else { return }
             _devicesObservation = discoverySession.observe(\.devices, options: [.initial, .new]) { [weak self] _, value in
                 guard let self else { return }
@@ -122,7 +122,7 @@ class DeviceManager: @unchecked Sendable, Loggable {
         #endif
 
         #if os(iOS) || os(tvOS)
-        DispatchQueue.global(qos: .default).async { [weak self] in
+        DispatchQueue.global(qos: .utility).async { [weak self] in
             guard let self else { return }
             _multiCamDeviceSetsObservation = discoverySession.observe(\.supportedMultiCamDeviceSets, options: [.initial, .new]) { [weak self] _, value in
                 guard let self else { return }

--- a/Tests/LiveKitCoreTests/Agent/TranscriptionTests.swift
+++ b/Tests/LiveKitCoreTests/Agent/TranscriptionTests.swift
@@ -227,15 +227,20 @@ actor MessageCollector {
         expectedContent: [String],
         expectedIsFinal: [Bool],
     ) {
-        // Validate updates
-        #expect(updates.count == expectedContent.count)
+        // Validate updates. Bail on a count mismatch instead of indexing past the
+        // end: a soft `#expect` doesn't stop execution, so the subsequent
+        // subscripts used to trap and abort the whole test *process*, taking every
+        // later suite (and the ObjC bundle) down with it.
+        guard updates.count == expectedContent.count, updates.count == expectedIsFinal.count else {
+            Issue.record("Expected \(expectedContent.count) updates, got \(updates.count): \(updates.map(\.content))")
+            return
+        }
         for (index, expected) in expectedContent.enumerated() {
             #expect(updates[index].content == .agentTranscript(expected))
             #expect(updates[index].id == segmentID)
         }
 
         // Validate isFinal
-        #expect(updates.count == expectedIsFinal.count)
         for (index, expected) in expectedIsFinal.enumerated() {
             #expect(updates[index].isFinal == expected, "isFinal mismatch at index \(index)")
         }
@@ -247,9 +252,12 @@ actor MessageCollector {
         }
 
         // Validate final message
-        #expect(messages.count == 1)
+        guard messages.count == 1, let expectedFinal = expectedContent.last else {
+            Issue.record("Expected exactly 1 final message, got \(messages.count)")
+            return
+        }
         #expect(messages.keys[0] == segmentID)
-        #expect(messages.values[0].content == .agentTranscript(expectedContent.last!))
+        #expect(messages.values[0].content == .agentTranscript(expectedFinal))
         #expect(messages.values[0].id == segmentID)
         #expect(messages.values[0].timestamp == firstTimestamp)
         #expect(messages.values[0].isFinal)

--- a/Tests/LiveKitCoreTests/Agent/TranscriptionTests.swift
+++ b/Tests/LiveKitCoreTests/Agent/TranscriptionTests.swift
@@ -227,10 +227,8 @@ actor MessageCollector {
         expectedContent: [String],
         expectedIsFinal: [Bool],
     ) {
-        // Validate updates. Bail on a count mismatch instead of indexing past the
-        // end: a soft `#expect` doesn't stop execution, so the subsequent
-        // subscripts used to trap and abort the whole test *process*, taking every
-        // later suite (and the ObjC bundle) down with it.
+        // Bail on a count mismatch rather than indexing past the end: `#expect` is
+        // soft, so the subscripts below would trap and abort the test process.
         guard updates.count == expectedContent.count, updates.count == expectedIsFinal.count else {
             Issue.record("Expected \(expectedContent.count) updates, got \(updates.count): \(updates.map(\.content))")
             return

--- a/Tests/LiveKitCoreTests/Agent/TranscriptionTests.swift
+++ b/Tests/LiveKitCoreTests/Agent/TranscriptionTests.swift
@@ -38,9 +38,7 @@ actor MessageCollector {
         messages
     }
 
-    /// Waits until `count` updates have arrived, or `timeout` elapses. Trailing
-    /// stream-close finalizations land after the last `sendText` returns, so a
-    /// fixed sleep either flakes on a loaded host or slows every run down.
+    /// Waits until `count` updates have arrived, or `timeout` elapses.
     func waitForUpdates(count: Int, timeout: TimeInterval = 10) async {
         let deadline = Date().addingTimeInterval(timeout)
         while updates.count < count, Date() < deadline {

--- a/Tests/LiveKitCoreTests/Agent/TranscriptionTests.swift
+++ b/Tests/LiveKitCoreTests/Agent/TranscriptionTests.swift
@@ -37,6 +37,16 @@ actor MessageCollector {
     func getMessages() -> OrderedDictionary<ReceivedMessage.ID, ReceivedMessage> {
         messages
     }
+
+    /// Waits until `count` updates have arrived, or `timeout` elapses. Trailing
+    /// stream-close finalizations land after the last `sendText` returns, so a
+    /// fixed sleep either flakes on a loaded host or slows every run down.
+    func waitForUpdates(count: Int, timeout: TimeInterval = 10) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while updates.count < count, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
 }
 
 @Suite(.serialized, .tags(.e2e)) final class TranscriptionTests: @unchecked Sendable {
@@ -118,8 +128,7 @@ actor MessageCollector {
                     try await Task.sleep(nanoseconds: 10_000_000)
                 }
                 try await writer.close()
-                // Wait for the stream-close finalization message to propagate
-                try await Task.sleep(nanoseconds: 500_000_000)
+                await self.messageCollector.waitForUpdates(count: expectedContent.count)
             }
 
             self.collectionTask.cancel()
@@ -167,8 +176,7 @@ actor MessageCollector {
                 ]
                 let options = StreamTextOptions(topic: topic, attributes: attributes)
                 try await self.senderRoom.localParticipant.sendText("Hello!", options: options)
-                // Wait for message delivery
-                try await Task.sleep(nanoseconds: 500_000_000)
+                await self.messageCollector.waitForUpdates(count: 1)
             }
 
             // Brief wait to ensure no extra messages arrive
@@ -291,6 +299,7 @@ actor MessageCollector {
                     streamID: streamID,
                     to: senderRoom,
                 )
+                await messageCollector.waitForUpdates(count: expectedContent.count)
             }
 
             let updates = await messageCollector.getUpdates()

--- a/Tests/LiveKitCoreTests/AsyncTimerTests.swift
+++ b/Tests/LiveKitCoreTests/AsyncTimerTests.swift
@@ -21,14 +21,10 @@ import Testing
 import LiveKitTestSupport
 #endif
 
-/// `AsyncTimer` drives its loop from `Task.detached(priority: .utility)`, so the
-/// only guarantee it offers is "fires no *earlier* than the interval". Every
-/// "did fire" assertion here therefore waits for the event with a generous
-/// deadline (`ConcurrentCounter.wait(untilAtLeast:)`) instead of sleeping a fixed
-/// multiple of the interval, and every "did not fire" assertion is bounded so
-/// sleep overshoot can't manufacture a fire.
-/// Drives `AsyncTimer` ticks from the test rather than the scheduler, so liveness
-/// assertions don't depend on a 50ms deadline the platform may miss by 200x.
+/// `AsyncTimer` only guarantees "fires no earlier than the interval", so "did
+/// fire" assertions wait for the event and "did not fire" assertions are bounded
+/// so sleep overshoot can't manufacture a fire.
+/// Drives `AsyncTimer` ticks from the test instead of the scheduler.
 private actor ManualSleeper {
     private var parked: [CheckedContinuation<Void, Never>] = []
 
@@ -63,8 +59,6 @@ private actor ManualSleeper {
 
 @Suite(.tags(.concurrency))
 struct AsyncTimerTests {
-    /// Short enough to keep the suite fast, long enough that one deferred wake-up
-    /// doesn't change the outcome.
     private static let interval: TimeInterval = 0.05
 
     @Test func startIfStoppedFiresWhileRepeatedlyArmed() async {
@@ -133,7 +127,7 @@ struct AsyncTimerTests {
         // 5ms rather than 50ms: the loop still races real time here, but fires often
         // enough that the liveness check below can't be starved out.
         let interval: TimeInterval = 0.005
-        let timer = AsyncTimer(interval: interval, sleep: { try await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000)) })
+        let timer = AsyncTimer(interval: interval)
         timer.setTimerBlock { _ = await counter.increment() }
 
         // Hammer with concurrent restart()/startIfStopped(): the previous design

--- a/Tests/LiveKitCoreTests/AsyncTimerTests.swift
+++ b/Tests/LiveKitCoreTests/AsyncTimerTests.swift
@@ -160,19 +160,24 @@ struct AsyncTimerTests {
                 "\(count) fires in \(elapsed)s exceeds what a single loop can produce")
     }
 
-    @Test func blockCancellingOwnTimerFiresOnce() async throws {
+    @Test func blockCancellingOwnTimerFiresOnce() async {
         // Mirrors the ping-timeout path: the block cancels its own timer (via cleanUp).
         // Must fire exactly once and not deadlock on the state lock.
         let counter = ConcurrentCounter()
-        let timer = AsyncTimer(interval: Self.interval)
+        let sleeper = ManualSleeper()
+        let timer = AsyncTimer(interval: Self.interval, sleep: sleeper.sleep)
         timer.setTimerBlock { [weak timer] in
             _ = await counter.increment()
             timer?.cancel()
         }
         timer.restart()
 
+        await sleeper.waitForParked(1)
+        await sleeper.tickAll()
         #expect(await counter.wait(untilAtLeast: 1) >= 1)
-        try await Task.sleep(nanoseconds: 500_000_000) // 10 intervals if it didn't stop
+
+        // Self-cancelling means the loop exits, so nothing parks for another cycle.
+        await sleeper.tickAll()
         #expect(await counter.getCount() == 1)
     }
 
@@ -205,61 +210,89 @@ struct AsyncTimerTests {
     @Test func updatesBlockOnNextCycle() async {
         let first = ConcurrentCounter()
         let second = ConcurrentCounter()
-        let timer = AsyncTimer(interval: Self.interval)
+        let sleeper = ManualSleeper()
+        let timer = AsyncTimer(interval: Self.interval, sleep: sleeper.sleep)
         timer.setTimerBlock { _ = await first.increment() }
         timer.restart()
 
-        #expect(await first.wait(untilAtLeast: 1) >= 1) // first block fires
+        // The loop reads the block before sleeping, so swapping it now must not
+        // affect the countdown already in flight.
+        await sleeper.waitForParked(1)
         timer.setTimerBlock { _ = await second.increment() }
-        #expect(await second.wait(untilAtLeast: 1) >= 1) // the updated block took effect
+        await sleeper.tickAll()
+        #expect(await first.wait(untilAtLeast: 1) >= 1)
+        #expect(await second.getCount() == 0)
+
+        // The next cycle picks it up.
+        await sleeper.waitForParked(1)
+        await sleeper.tickAll()
+        #expect(await second.wait(untilAtLeast: 1) >= 1)
+
         timer.cancel()
+        await sleeper.tickAll()
     }
 
-    @Test func deinitStopsTimer() async throws {
+    @Test func deinitStopsTimer() async {
         let counter = ConcurrentCounter()
+        let sleeper = ManualSleeper()
         do {
-            let timer = AsyncTimer(interval: Self.interval)
+            let timer = AsyncTimer(interval: Self.interval, sleep: sleeper.sleep)
             timer.setTimerBlock { _ = await counter.increment() }
             timer.restart()
-            // Wait for a fire *before* releasing, so the assertion below doesn't
-            // depend on the timer having been scheduled within a fixed window.
+            await sleeper.waitForParked(1)
+            await sleeper.tickAll()
             #expect(await counter.wait(untilAtLeast: 1) >= 1)
-        } // timer released here
+            await sleeper.waitForParked(1) // parked for the next cycle
+        } // timer released here — deinit cancels the loop
 
-        // Let the in-flight invocation finish and deinit cancel the loop.
-        try await Task.sleep(nanoseconds: 200_000_000)
         let afterRelease = await counter.getCount()
-
-        try await Task.sleep(nanoseconds: 500_000_000) // 10 intervals
-        #expect(await counter.getCount() == afterRelease) // deinit stopped it
+        // Releasing the parked countdown must find the loop cancelled.
+        await sleeper.tickAll()
+        #expect(await counter.getCount() == afterRelease)
     }
 
     @Test func continuesFiringAfterBlockThrows() async {
         struct BlockError: Error {}
         let counter = ConcurrentCounter()
-        let timer = AsyncTimer(interval: Self.interval)
+        let sleeper = ManualSleeper()
+        let timer = AsyncTimer(interval: Self.interval, sleep: sleeper.sleep)
         timer.setTimerBlock {
             // First invocation throws; the loop must catch, log, and keep going.
             if await counter.increment() == 0 { throw BlockError() }
         }
         timer.restart()
 
+        await sleeper.waitForParked(1)
+        await sleeper.tickAll()
+        #expect(await counter.wait(untilAtLeast: 1) >= 1) // threw
+
+        await sleeper.waitForParked(1) // the loop survived and parked again
+        await sleeper.tickAll()
         #expect(await counter.wait(untilAtLeast: 2) >= 2) // fired again after the throw
+
         timer.cancel()
+        await sleeper.tickAll()
     }
 
-    @Test func startIfStoppedReArmsAfterCancel() async throws {
+    @Test func startIfStoppedReArmsAfterCancel() async {
         let counter = ConcurrentCounter()
-        let timer = AsyncTimer(interval: Self.interval)
+        let sleeper = ManualSleeper()
+        let timer = AsyncTimer(interval: Self.interval, sleep: sleeper.sleep)
         timer.setTimerBlock { _ = await counter.increment() }
 
         timer.startIfStopped()
+        await sleeper.waitForParked(1)
+        await sleeper.tickAll()
         #expect(await counter.wait(untilAtLeast: 1) >= 1)
+
+        await sleeper.waitForParked(1)
         timer.cancel()
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await sleeper.tickAll() // loop observes the cancel and exits
         let afterCancel = await counter.getCount()
 
         timer.startIfStopped() // cancel cleared the task, so this re-arms
+        await sleeper.waitForParked(1)
+        await sleeper.tickAll()
         #expect(await counter.wait(untilAtLeast: afterCancel + 1) > afterCancel) // fired again after re-arm
         timer.cancel()
     }

--- a/Tests/LiveKitCoreTests/AsyncTimerTests.swift
+++ b/Tests/LiveKitCoreTests/AsyncTimerTests.swift
@@ -21,30 +21,44 @@ import Testing
 import LiveKitTestSupport
 #endif
 
+/// `AsyncTimer` drives its loop from `Task.detached(priority: .utility)`, so the
+/// only guarantee it offers is "fires no *earlier* than the interval". Every
+/// "did fire" assertion here therefore waits for the event with a generous
+/// deadline (`ConcurrentCounter.wait(untilAtLeast:)`) instead of sleeping a fixed
+/// multiple of the interval, and every "did not fire" assertion is bounded so
+/// sleep overshoot can't manufacture a fire.
 @Suite(.tags(.concurrency))
 struct AsyncTimerTests {
+    /// Short enough to keep the suite fast, long enough that one deferred wake-up
+    /// doesn't change the outcome.
+    private static let interval: TimeInterval = 0.05
+
     @Test func startIfStoppedFiresWhileRepeatedlyArmed() async throws {
         let counter = ConcurrentCounter()
         let timer = AsyncTimer(interval: 0.2)
         timer.setTimerBlock { _ = await counter.increment() }
 
-        // Arm every 20ms for ~500ms — ~25 arms across the 200ms timeout window.
-        for _ in 0 ..< 25 {
+        // Keep re-arming every 20ms until it fires: `startIfStopped` must leave the
+        // in-flight countdown alone, so the first arm's timeout still elapses.
+        let deadline = Date().addingTimeInterval(10)
+        while await counter.getCount() == 0, Date() < deadline {
             timer.startIfStopped()
             try await Task.sleep(nanoseconds: 20_000_000)
         }
         timer.cancel()
 
-        // The first arm's countdown was never reset, so it fired at ~200ms.
         #expect(await counter.getCount() >= 1)
     }
 
     @Test func restartNeverFiresWhileRepeatedlyArmed() async throws {
         let counter = ConcurrentCounter()
-        let timer = AsyncTimer(interval: 0.2)
+        // Interval far larger than the arming window below, so a fire would mean the
+        // countdown genuinely wasn't reset — not that a sleep overshot.
+        let timer = AsyncTimer(interval: 5)
         timer.setTimerBlock { _ = await counter.increment() }
 
-        for _ in 0 ..< 25 {
+        let armingEnd = Date().addingTimeInterval(0.5)
+        while Date() < armingEnd {
             timer.restart()
             try await Task.sleep(nanoseconds: 20_000_000)
         }
@@ -56,25 +70,24 @@ struct AsyncTimerTests {
 
     @Test func cancelStopsFiring() async throws {
         let counter = ConcurrentCounter()
-        let timer = AsyncTimer(interval: 0.05)
+        let timer = AsyncTimer(interval: Self.interval)
         timer.setTimerBlock { _ = await counter.increment() }
         timer.restart()
 
-        try await Task.sleep(nanoseconds: 175_000_000) // ~3 intervals
+        #expect(await counter.wait(untilAtLeast: 1) >= 1) // it actually ran
         timer.cancel()
 
         // Let any in-flight invocation settle before sampling.
         try await Task.sleep(nanoseconds: 100_000_000)
         let afterCancel = await counter.getCount()
-        #expect(afterCancel >= 1) // it actually ran
 
-        try await Task.sleep(nanoseconds: 200_000_000) // 4 more intervals
+        try await Task.sleep(nanoseconds: 500_000_000) // 10 intervals
         #expect(await counter.getCount() == afterCancel) // nothing fired after cancel
     }
 
     @Test func concurrentArmingLeavesSingleLoop() async throws {
         let counter = ConcurrentCounter()
-        let timer = AsyncTimer(interval: 0.05)
+        let timer = AsyncTimer(interval: Self.interval)
         timer.setTimerBlock { _ = await counter.increment() }
 
         // Hammer with concurrent restart()/startIfStopped(): the previous design
@@ -85,34 +98,41 @@ struct AsyncTimerTests {
             }
         }
 
-        try await Task.sleep(nanoseconds: 275_000_000) // ~5 intervals for one loop
+        let start = Date()
+        #expect(await counter.wait(untilAtLeast: 1) >= 1) // a loop is running
+        try await Task.sleep(nanoseconds: 275_000_000)
         timer.cancel()
-
+        let elapsed = Date().timeIntervalSince(start)
         let count = await counter.getCount()
-        #expect(count >= 1) // a loop is running
-        // One loop fires ~5x here; the bound has headroom for sleep overshoot under
-        // parallel CI load. The orphan bug spawned dozens of loops, so it still trips.
-        #expect(count <= 15)
+
+        // A single loop can fire at most `elapsed / interval` times. Normalizing by
+        // the *measured* elapsed time rather than the requested sleep keeps this
+        // bound valid when the host defers wake-ups; the orphan bug spawned dozens
+        // of concurrent loops, so a 3x allowance still trips on it.
+        let singleLoopBound = elapsed / Self.interval + 1
+        #expect(Double(count) <= singleLoopBound * 3,
+                "\(count) fires in \(elapsed)s exceeds what a single loop can produce")
     }
 
     @Test func blockCancellingOwnTimerFiresOnce() async throws {
         // Mirrors the ping-timeout path: the block cancels its own timer (via cleanUp).
         // Must fire exactly once and not deadlock on the state lock.
         let counter = ConcurrentCounter()
-        let timer = AsyncTimer(interval: 0.05)
+        let timer = AsyncTimer(interval: Self.interval)
         timer.setTimerBlock { [weak timer] in
             _ = await counter.increment()
             timer?.cancel()
         }
         timer.restart()
 
-        try await Task.sleep(nanoseconds: 250_000_000) // ~5 intervals if it didn't stop
+        #expect(await counter.wait(untilAtLeast: 1) >= 1)
+        try await Task.sleep(nanoseconds: 500_000_000) // 10 intervals if it didn't stop
         #expect(await counter.getCount() == 1)
     }
 
     @Test func concurrentRestartAndCancelLeaveNoOrphan() async throws {
         let counter = ConcurrentCounter()
-        let timer = AsyncTimer(interval: 0.05)
+        let timer = AsyncTimer(interval: Self.interval)
         timer.setTimerBlock { _ = await counter.increment() }
 
         // Interleave restart / startIfStopped / cancel concurrently.
@@ -130,80 +150,71 @@ struct AsyncTimerTests {
 
         // Whatever the interleaving, a final cancel must stop every loop — no orphan survives.
         timer.cancel()
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await Task.sleep(nanoseconds: 200_000_000)
         let afterCancel = await counter.getCount()
-        try await Task.sleep(nanoseconds: 250_000_000) // 5 intervals
+        try await Task.sleep(nanoseconds: 500_000_000) // 10 intervals
         #expect(await counter.getCount() == afterCancel)
     }
 
-    @Test func updatesBlockOnNextCycle() async throws {
+    @Test func updatesBlockOnNextCycle() async {
         let first = ConcurrentCounter()
         let second = ConcurrentCounter()
-        let timer = AsyncTimer(interval: 0.05)
+        let timer = AsyncTimer(interval: Self.interval)
         timer.setTimerBlock { _ = await first.increment() }
         timer.restart()
 
-        try await Task.sleep(nanoseconds: 120_000_000) // first block fires
+        #expect(await first.wait(untilAtLeast: 1) >= 1) // first block fires
         timer.setTimerBlock { _ = await second.increment() }
-        try await Task.sleep(nanoseconds: 150_000_000) // swapped block fires
+        #expect(await second.wait(untilAtLeast: 1) >= 1) // the updated block took effect
         timer.cancel()
-        try await Task.sleep(nanoseconds: 80_000_000)
-
-        #expect(await first.getCount() >= 1)
-        #expect(await second.getCount() >= 1) // the updated block took effect
     }
 
     @Test func deinitStopsTimer() async throws {
         let counter = ConcurrentCounter()
         do {
-            let timer = AsyncTimer(interval: 0.05)
+            let timer = AsyncTimer(interval: Self.interval)
             timer.setTimerBlock { _ = await counter.increment() }
             timer.restart()
-            try await Task.sleep(nanoseconds: 120_000_000)
+            // Wait for a fire *before* releasing, so the assertion below doesn't
+            // depend on the timer having been scheduled within a fixed window.
+            #expect(await counter.wait(untilAtLeast: 1) >= 1)
         } // timer released here
 
         // Let the in-flight invocation finish and deinit cancel the loop.
-        try await Task.sleep(nanoseconds: 150_000_000)
-        let afterRelease = await counter.getCount()
-        #expect(afterRelease >= 1)
-
         try await Task.sleep(nanoseconds: 200_000_000)
+        let afterRelease = await counter.getCount()
+
+        try await Task.sleep(nanoseconds: 500_000_000) // 10 intervals
         #expect(await counter.getCount() == afterRelease) // deinit stopped it
     }
 
-    @Test func continuesFiringAfterBlockThrows() async throws {
+    @Test func continuesFiringAfterBlockThrows() async {
         struct BlockError: Error {}
         let counter = ConcurrentCounter()
-        let timer = AsyncTimer(interval: 0.05)
+        let timer = AsyncTimer(interval: Self.interval)
         timer.setTimerBlock {
             // First invocation throws; the loop must catch, log, and keep going.
             if await counter.increment() == 0 { throw BlockError() }
         }
         timer.restart()
 
-        try await Task.sleep(nanoseconds: 300_000_000) // ~6 intervals
+        #expect(await counter.wait(untilAtLeast: 2) >= 2) // fired again after the throw
         timer.cancel()
-        try await Task.sleep(nanoseconds: 80_000_000)
-
-        #expect(await counter.getCount() >= 2) // fired again after the throw
     }
 
     @Test func startIfStoppedReArmsAfterCancel() async throws {
         let counter = ConcurrentCounter()
-        let timer = AsyncTimer(interval: 0.05)
+        let timer = AsyncTimer(interval: Self.interval)
         timer.setTimerBlock { _ = await counter.increment() }
 
         timer.startIfStopped()
-        try await Task.sleep(nanoseconds: 120_000_000)
+        #expect(await counter.wait(untilAtLeast: 1) >= 1)
         timer.cancel()
-        try await Task.sleep(nanoseconds: 80_000_000)
+        try await Task.sleep(nanoseconds: 100_000_000)
         let afterCancel = await counter.getCount()
 
-        timer.startIfStopped() // cancel cleared isStarted, so this re-arms
-        try await Task.sleep(nanoseconds: 150_000_000)
+        timer.startIfStopped() // cancel cleared the task, so this re-arms
+        #expect(await counter.wait(untilAtLeast: afterCancel + 1) > afterCancel) // fired again after re-arm
         timer.cancel()
-        try await Task.sleep(nanoseconds: 80_000_000)
-
-        #expect(await counter.getCount() > afterCancel) // fired again after re-arm
     }
 }

--- a/Tests/LiveKitCoreTests/AsyncTimerTests.swift
+++ b/Tests/LiveKitCoreTests/AsyncTimerTests.swift
@@ -27,27 +27,67 @@ import LiveKitTestSupport
 /// deadline (`ConcurrentCounter.wait(untilAtLeast:)`) instead of sleeping a fixed
 /// multiple of the interval, and every "did not fire" assertion is bounded so
 /// sleep overshoot can't manufacture a fire.
+/// Drives `AsyncTimer` ticks from the test rather than the scheduler, so liveness
+/// assertions don't depend on a 50ms deadline the platform may miss by 200x.
+private actor ManualSleeper {
+    private var parked: [CheckedContinuation<Void, Never>] = []
+
+    nonisolated var sleep: AsyncTimer.SleepFunction {
+        { [weak self] _ in await self?.park() }
+    }
+
+    private func park() async {
+        await withCheckedContinuation { parked.append($0) }
+    }
+
+    /// How many countdowns are currently waiting — one per live loop.
+    var parkedCount: Int { parked.count }
+
+    /// Releases every parked countdown. Also required before a test ends, so no
+    /// checked continuation is left unresumed.
+    func tickAll() {
+        let waiters = parked
+        parked = []
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    func waitForParked(_ count: Int, timeout: TimeInterval = 30) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while parked.count < count, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+}
+
 @Suite(.tags(.concurrency))
 struct AsyncTimerTests {
     /// Short enough to keep the suite fast, long enough that one deferred wake-up
     /// doesn't change the outcome.
     private static let interval: TimeInterval = 0.05
 
-    @Test func startIfStoppedFiresWhileRepeatedlyArmed() async throws {
+    @Test func startIfStoppedFiresWhileRepeatedlyArmed() async {
         let counter = ConcurrentCounter()
-        let timer = AsyncTimer(interval: 0.2)
+        let sleeper = ManualSleeper()
+        let timer = AsyncTimer(interval: 0.2, sleep: sleeper.sleep)
         timer.setTimerBlock { _ = await counter.increment() }
 
-        // Keep re-arming every 20ms until it fires: `startIfStopped` must leave the
-        // in-flight countdown alone, so the first arm's timeout still elapses.
-        let deadline = Date().addingTimeInterval(10)
-        while await counter.getCount() == 0, Date() < deadline {
-            timer.startIfStopped()
-            try await Task.sleep(nanoseconds: 20_000_000)
-        }
-        timer.cancel()
+        timer.startIfStopped()
+        await sleeper.waitForParked(1)
 
-        #expect(await counter.getCount() >= 1)
+        // Re-arming must leave the in-flight countdown alone rather than starting
+        // another one, so exactly one stays parked.
+        for _ in 0 ..< 25 {
+            timer.startIfStopped()
+        }
+        #expect(await sleeper.parkedCount == 1)
+
+        await sleeper.tickAll() // the original countdown elapses
+        #expect(await counter.wait(untilAtLeast: 1) >= 1)
+
+        timer.cancel()
+        await sleeper.tickAll()
     }
 
     @Test func restartNeverFiresWhileRepeatedlyArmed() async throws {
@@ -68,26 +108,32 @@ struct AsyncTimerTests {
         #expect(firedWhileArming == 0)
     }
 
-    @Test func cancelStopsFiring() async throws {
+    @Test func cancelStopsFiring() async {
         let counter = ConcurrentCounter()
-        let timer = AsyncTimer(interval: Self.interval)
+        let sleeper = ManualSleeper()
+        let timer = AsyncTimer(interval: Self.interval, sleep: sleeper.sleep)
         timer.setTimerBlock { _ = await counter.increment() }
         timer.restart()
 
+        await sleeper.waitForParked(1)
+        await sleeper.tickAll()
         #expect(await counter.wait(untilAtLeast: 1) >= 1) // it actually ran
-        timer.cancel()
 
-        // Let any in-flight invocation settle before sampling.
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await sleeper.waitForParked(1) // parked again for the next cycle
+        timer.cancel()
         let afterCancel = await counter.getCount()
 
-        try await Task.sleep(nanoseconds: 500_000_000) // 10 intervals
-        #expect(await counter.getCount() == afterCancel) // nothing fired after cancel
+        // Releasing further countdowns must not produce another invocation.
+        await sleeper.tickAll()
+        #expect(await counter.getCount() == afterCancel)
     }
 
     @Test func concurrentArmingLeavesSingleLoop() async throws {
         let counter = ConcurrentCounter()
-        let timer = AsyncTimer(interval: Self.interval)
+        // 5ms rather than 50ms: the loop still races real time here, but fires often
+        // enough that the liveness check below can't be starved out.
+        let interval: TimeInterval = 0.005
+        let timer = AsyncTimer(interval: interval, sleep: { try await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000)) })
         timer.setTimerBlock { _ = await counter.increment() }
 
         // Hammer with concurrent restart()/startIfStopped(): the previous design
@@ -100,16 +146,16 @@ struct AsyncTimerTests {
 
         let start = Date()
         #expect(await counter.wait(untilAtLeast: 1) >= 1) // a loop is running
-        try await Task.sleep(nanoseconds: 275_000_000)
+        try await Task.sleep(nanoseconds: 100_000_000)
         timer.cancel()
         let elapsed = Date().timeIntervalSince(start)
         let count = await counter.getCount()
 
         // A single loop can fire at most `elapsed / interval` times. Normalizing by
-        // the *measured* elapsed time rather than the requested sleep keeps this
-        // bound valid when the host defers wake-ups; the orphan bug spawned dozens
-        // of concurrent loops, so a 3x allowance still trips on it.
-        let singleLoopBound = elapsed / Self.interval + 1
+        // the measured elapsed time keeps this valid when the host defers wake-ups;
+        // the orphan bug spawned dozens of concurrent loops, so a 3x allowance
+        // still trips on it.
+        let singleLoopBound = elapsed / interval + 1
         #expect(Double(count) <= singleLoopBound * 3,
                 "\(count) fires in \(elapsed)s exceeds what a single loop can produce")
     }

--- a/Tests/LiveKitCoreTests/DataChannel/RealiableDataChannelTests.swift
+++ b/Tests/LiveKitCoreTests/DataChannel/RealiableDataChannelTests.swift
@@ -115,15 +115,14 @@ import LiveKitTestSupport
                     try await sending.send(userPacket: userPacket, kind: .reliable)
                     try await Task.sleep(nanoseconds: UInt64(sendInterval * 1_000_000_000))
                 }
-            }
 
-            // `withRooms` tears the rooms down once its body returns, but
-            // the last few deliveries may still be in flight. Poll until
-            // all confirms have fired (or the deadline expires) so we
-            // don't end the confirmation body prematurely.
-            let deadline = Date().addingTimeInterval(receiveDeadline)
-            while Date() < deadline, self._receivedIndices.copy().count < iterations {
-                try? await Task.sleep(nanoseconds: 100_000_000)
+                // Wait for the receiver inside `withRooms` so the data channel stays
+                // open until every packet has been delivered; waiting after the body
+                // returns loses anything still in flight to the room teardown.
+                let deadline = Date().addingTimeInterval(receiveDeadline)
+                while Date() < deadline, self._receivedIndices.copy().count < iterations {
+                    try? await Task.sleep(nanoseconds: 100_000_000)
+                }
             }
         }
 

--- a/Tests/LiveKitCoreTests/DataStream/IncomingStreamManagerTests.swift
+++ b/Tests/LiveKitCoreTests/DataStream/IncomingStreamManagerTests.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// swiftlint:disable file_length
+
 import Foundation
 @testable import LiveKit
 import Testing
@@ -317,6 +319,23 @@ struct IncomingStreamManagerTests: @unchecked Sendable {
 }
 
 extension IncomingStreamManagerTests {
+    /// `handle(_:)` only enqueues onto the manager's event loop, so tests that
+    /// call cleanup APIs directly must first wait for the events to be processed.
+    private func waitForOpenStreams(_ count: Int) async {
+        let deadline = Date().addingTimeInterval(10)
+        while await manager.openStreamCount < count, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+
+    private func sendTextHeader(streamID: String) async {
+        var header = Livekit_DataStream.Header()
+        header.streamID = streamID
+        header.topic = topicName
+        header.contentHeader = .textHeader(Livekit_DataStream.TextHeader())
+        manager.handle(.header(header, participant.stringValue, .none))
+    }
+
     /// Senders may reuse one stream ID for consecutive streams (each `sendText`
     /// in a transcription segment does). Descriptor cleanup used to run in the
     /// reader's `onTermination` task, which raced the reopening header and made
@@ -344,6 +363,89 @@ extension IncomingStreamManagerTests {
         }
 
         #expect(received.copy().sorted() == payloads.sorted())
+        await manager.unregisterTextStreamHandler(for: topicName)
+    }
+
+    /// A stream failing mid-flight (here: exceeding its declared length) must not
+    /// block a new stream that immediately reuses the same stream ID.
+    @Test func reusedStreamIDAfterChunkErrorDeliversNextStream() async throws {
+        let received = StateSync<[String]>([])
+
+        try await manager.registerTextStreamHandler(for: topicName) { reader, _ in
+            let payload = try await reader.readAll()
+            received.mutate { $0.append(payload) }
+        }
+
+        let streamID = UUID().uuidString
+        // 8-byte chunk against a declared total of 4 → lengthExceeded.
+        await sendTextStream(rawPayload: Data("ABCDEFGH".utf8), totalLength: 4, streamID: streamID, settle: false)
+        await sendTextStream(chunks: ["ok"], streamID: streamID, settle: false)
+
+        let deadline = Date().addingTimeInterval(10)
+        while received.copy().isEmpty, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(received.copy() == ["ok"])
+        await manager.unregisterTextStreamHandler(for: topicName)
+    }
+
+    /// A sender disconnecting before its trailer leaves the stream open forever;
+    /// `closeStreams(from:)` must fail it so an ordered topic's queue drains.
+    @Test func closeStreamsUnblocksOrderedTopic() async throws {
+        let received = StateSync<[String]>([])
+        let errors = StateSync<[StreamError]>([])
+
+        try await manager.registerTextStreamHandler(for: topicName, ordered: true) { reader, _ in
+            do {
+                let payload = try await reader.readAll()
+                received.mutate { $0.append(payload) }
+            } catch let error as StreamError {
+                errors.mutate { $0.append(error) }
+                throw error
+            }
+        }
+
+        // Header only — no trailer ever arrives, so the handler blocks in readAll
+        // and, at the head of the ordered queue, would block every later stream.
+        await sendTextHeader(streamID: "orphan")
+        await waitForOpenStreams(1)
+
+        await manager.closeStreams(from: participant)
+        await sendTextStream(chunks: ["after"], settle: false)
+
+        let deadline = Date().addingTimeInterval(10)
+        while received.copy().isEmpty, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(received.copy() == ["after"])
+        #expect(errors.copy() == [.terminated])
+        await manager.unregisterTextStreamHandler(for: topicName)
+    }
+
+    /// Same shape as above via the room-lifecycle path: `reset()` fails all open
+    /// streams but keeps handlers registered for after a reconnect.
+    @Test func resetUnblocksOrderedTopicAndKeepsHandler() async throws {
+        let received = StateSync<[String]>([])
+
+        try await manager.registerTextStreamHandler(for: topicName, ordered: true) { reader, _ in
+            let payload = try await reader.readAll()
+            received.mutate { $0.append(payload) }
+        }
+
+        await sendTextHeader(streamID: "orphan")
+        await waitForOpenStreams(1)
+
+        await manager.reset()
+        await sendTextStream(chunks: ["after-reset"], settle: false)
+
+        let deadline = Date().addingTimeInterval(10)
+        while received.copy().isEmpty, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(received.copy() == ["after-reset"])
         await manager.unregisterTextStreamHandler(for: topicName)
     }
 

--- a/Tests/LiveKitCoreTests/DataStream/IncomingStreamManagerTests.swift
+++ b/Tests/LiveKitCoreTests/DataStream/IncomingStreamManagerTests.swift
@@ -318,6 +318,26 @@ struct IncomingStreamManagerTests: @unchecked Sendable {
     }
 }
 
+/// One-shot latch: `wait()` suspends until `open()`; waiters after `open()` pass through.
+private actor TestGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        let continuations = waiters
+        waiters = []
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
+}
+
 extension IncomingStreamManagerTests {
     /// `handle(_:)` only enqueues onto the manager's event loop, so tests that
     /// call cleanup APIs directly must first wait for the events to be processed.
@@ -400,6 +420,35 @@ extension IncomingStreamManagerTests {
         }
 
         #expect(received.copy() == ["ok"])
+        await manager.unregisterTextStreamHandler(for: topicName)
+    }
+
+    /// Ordering must compose transitively: C waits on B even while B is itself
+    /// still waiting on A. If the chain breaks, B and C complete while A's
+    /// handler is gated and the order comes out wrong.
+    @Test func orderedTopicChainsAcrossFinishingHandlers() async throws {
+        let received = StateSync<[String]>([])
+        let gate = TestGate()
+
+        try await manager.registerTextStreamHandler(for: topicName, ordered: true) { reader, _ in
+            let payload = try await reader.readAll()
+            // First handler stalls after its stream closed, becoming a
+            // still-finishing predecessor for the streams sent after it.
+            if payload == "a" { await gate.wait() }
+            received.mutate { $0.append(payload) }
+        }
+
+        for payload in ["a", "b", "c"] {
+            await sendTextStream(chunks: [payload], settle: false)
+        }
+        await gate.open()
+
+        let deadline = Date().addingTimeInterval(10)
+        while received.copy().count < 3, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(received.copy() == ["a", "b", "c"])
         await manager.unregisterTextStreamHandler(for: topicName)
     }
 

--- a/Tests/LiveKitCoreTests/DataStream/IncomingStreamManagerTests.swift
+++ b/Tests/LiveKitCoreTests/DataStream/IncomingStreamManagerTests.swift
@@ -276,9 +276,7 @@ struct IncomingStreamManagerTests: @unchecked Sendable {
         }
     }
 
-    private func sendTextStream(chunks: [String]? = nil, rawPayload: Data? = nil, totalLength: UInt64? = nil) async {
-        let streamID = UUID().uuidString
-
+    private func sendTextStream(chunks: [String]? = nil, rawPayload: Data? = nil, totalLength: UInt64? = nil, streamID: String = UUID().uuidString, settle: Bool = true) async {
         var header = Livekit_DataStream.Header()
         header.streamID = streamID
         header.topic = topicName
@@ -307,11 +305,69 @@ struct IncomingStreamManagerTests: @unchecked Sendable {
         trailer.reason = ""
         manager.handle(.trailer(trailer, .none))
 
+        guard settle else { return }
+        // Handler processes asynchronously — give it time to complete
         await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
             Task {
                 try? await Task.sleep(nanoseconds: 100_000_000)
                 c.resume()
             }
         }
+    }
+}
+
+extension IncomingStreamManagerTests {
+    /// Senders may reuse one stream ID for consecutive streams (each `sendText`
+    /// in a transcription segment does). Descriptor cleanup used to run in the
+    /// reader's `onTermination` task, which raced the reopening header and made
+    /// `openStream` silently drop the new stream.
+    @Test func reusedStreamIDDeliversEveryStream() async throws {
+        let payloads = ["one", "two", "three"]
+        let received = StateSync<[String]>([])
+
+        try await manager.registerTextStreamHandler(for: topicName) { reader, _ in
+            let payload = try await reader.readAll()
+            received.mutate { $0.append(payload) }
+        }
+
+        // Back-to-back, no settling between streams: the reopening header must
+        // hit the event loop while the previous stream's cleanup could still be
+        // pending.
+        let streamID = UUID().uuidString
+        for payload in payloads {
+            await sendTextStream(chunks: [payload], streamID: streamID, settle: false)
+        }
+
+        let deadline = Date().addingTimeInterval(10)
+        while received.copy().count < payloads.count, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(received.copy().sorted() == payloads.sorted())
+        await manager.unregisterTextStreamHandler(for: topicName)
+    }
+
+    /// Handlers for an `ordered` topic must observe streams in wire order, not
+    /// the scheduling order of independently spawned handler tasks.
+    @Test func orderedTopicDeliversStreamsInOrder() async throws {
+        let count = 16
+        let received = StateSync<[String]>([])
+
+        try await manager.registerTextStreamHandler(for: topicName, ordered: true) { reader, _ in
+            let payload = try await reader.readAll()
+            received.mutate { $0.append(payload) }
+        }
+
+        for index in 0 ..< count {
+            await sendTextStream(chunks: ["payload-\(index)"], settle: false)
+        }
+
+        let deadline = Date().addingTimeInterval(10)
+        while received.copy().count < count, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(received.copy() == (0 ..< count).map { "payload-\($0)" })
+        await manager.unregisterTextStreamHandler(for: topicName)
     }
 }

--- a/Tests/LiveKitCoreTests/DataStream/IncomingStreamManagerTests.swift
+++ b/Tests/LiveKitCoreTests/DataStream/IncomingStreamManagerTests.swift
@@ -336,6 +336,19 @@ extension IncomingStreamManagerTests {
         manager.handle(.header(header, participant.stringValue, .none))
     }
 
+    private func sendTextChunk(streamID: String, content: String) async {
+        var chunk = Livekit_DataStream.Chunk()
+        chunk.streamID = streamID
+        chunk.content = Data(content.utf8)
+        manager.handle(.chunk(chunk, .none))
+    }
+
+    private func sendTextTrailer(streamID: String) async {
+        var trailer = Livekit_DataStream.Trailer()
+        trailer.streamID = streamID
+        manager.handle(.trailer(trailer, .none))
+    }
+
     /// Senders may reuse one stream ID for consecutive streams (each `sendText`
     /// in a transcription segment does). Descriptor cleanup used to run in the
     /// reader's `onTermination` task, which raced the reopening header and made
@@ -387,6 +400,39 @@ extension IncomingStreamManagerTests {
         }
 
         #expect(received.copy() == ["ok"])
+        await manager.unregisterTextStreamHandler(for: topicName)
+    }
+
+    /// A still-open stream must not delay streams that overlap with it on the
+    /// wire (e.g. a user's live transcript arriving while an agent's message
+    /// stream is still open). Ordering applies only to non-overlapping streams.
+    @Test func orderedTopicDoesNotDelayOverlappingStreams() async throws {
+        let received = StateSync<[String]>([])
+
+        try await manager.registerTextStreamHandler(for: topicName, ordered: true) { reader, _ in
+            let payload = try await reader.readAll()
+            received.mutate { $0.append(payload) }
+        }
+
+        // Stream A opens and stays open; stream B opens, delivers, and closes
+        // while A is still open — B's handler must complete without waiting.
+        await sendTextHeader(streamID: "open-a")
+        await sendTextChunk(streamID: "open-a", content: "a")
+        await sendTextStream(chunks: ["b"], streamID: "b", settle: false)
+
+        var deadline = Date().addingTimeInterval(10)
+        while received.copy().isEmpty, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(received.copy() == ["b"])
+
+        // A still completes normally once its trailer arrives.
+        await sendTextTrailer(streamID: "open-a")
+        deadline = Date().addingTimeInterval(10)
+        while received.copy().count < 2, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(received.copy() == ["b", "a"])
         await manager.unregisterTextStreamHandler(for: topicName)
     }
 

--- a/Tests/LiveKitCoreTests/PeerConnectionSignalingTests.swift
+++ b/Tests/LiveKitCoreTests/PeerConnectionSignalingTests.swift
@@ -346,19 +346,15 @@ struct PeerConnectionSignalingTests {
                 try await Task.sleep(nanoseconds: 500_000_000)
             }
 
-            // One buffer, allocated once and asserted: a discarded allocation failure
-            // used to surface as an opaque 10s publish timeout.
             let frame = try #require(TestFrame())
 
             for i in 0 ..< videoCount {
                 let track = LocalVideoTrack.createBufferTrack(name: "video-\(i)")
                 let capturer = try #require(track.capturer as? BufferCapturer)
 
-                // Publish gates on resolved dimensions, but captured frames resolve
-                // them on the capture processing queue, which a loaded host can defer
-                // past the publish timeout. This test is about signaling, not the
-                // capture pipeline, so resolve them directly; the feeding task
-                // supplies media so the subscriber sees the tracks.
+                // Resolve dimensions directly (captured frames resolve them on the
+                // capture queue, which can lag past the publish timeout); the feeding
+                // task supplies media so the subscriber sees the tracks.
                 capturer.set(dimensions: Dimensions(width: 320, height: 240))
                 let frames = Task.detached {
                     while !Task.isCancelled {
@@ -405,8 +401,7 @@ struct PeerConnectionSignalingTests {
         }
     }
 
-    /// A blank frame, boxed so it can be fed from a background task. The buffer is
-    /// only ever read, never written.
+    /// A blank frame, boxed for feeding from a task. Only ever read.
     private final class TestFrame: @unchecked Sendable {
         let buffer: CVPixelBuffer
 

--- a/Tests/LiveKitCoreTests/PeerConnectionSignalingTests.swift
+++ b/Tests/LiveKitCoreTests/PeerConnectionSignalingTests.swift
@@ -354,11 +354,12 @@ struct PeerConnectionSignalingTests {
                 let track = LocalVideoTrack.createBufferTrack(name: "video-\(i)")
                 let capturer = try #require(track.capturer as? BufferCapturer)
 
-                // `BufferCapturer` resolves dimensions only from a captured frame, and
-                // publish waits for them. Capture synchronously so that wait can't
-                // depend on a background task being scheduled, then keep feeding the
-                // same frame the way the capturer is documented to be driven.
-                capturer.capture(frame.buffer)
+                // Publish gates on resolved dimensions, but captured frames resolve
+                // them on the capture processing queue, which a loaded host can defer
+                // past the publish timeout. This test is about signaling, not the
+                // capture pipeline, so resolve them directly; the feeding task
+                // supplies media so the subscriber sees the tracks.
+                capturer.set(dimensions: Dimensions(width: 320, height: 240))
                 let frames = Task.detached {
                     while !Task.isCancelled {
                         capturer.capture(frame.buffer)

--- a/Tests/LiveKitCoreTests/PeerConnectionSignalingTests.swift
+++ b/Tests/LiveKitCoreTests/PeerConnectionSignalingTests.swift
@@ -348,13 +348,19 @@ struct PeerConnectionSignalingTests {
 
             for i in 0 ..< videoCount {
                 let track = LocalVideoTrack.createBufferTrack(name: "video-\(i)")
-                guard let capturer = track.capturer as? BufferCapturer else {
-                    Issue.record("Expected BufferCapturer")
-                    return
+                let capturer = try #require(track.capturer as? BufferCapturer)
+
+                // `BufferCapturer` resolves dimensions only from captured frames and
+                // is documented to be fed repeatedly, so keep frames flowing until
+                // publish returns rather than relying on a single one landing in time.
+                let frames = Task.detached {
+                    while !Task.isCancelled {
+                        if let buffer = Self.makeTestPixelBuffer() { capturer.capture(buffer) }
+                        try? await Task.sleep(nanoseconds: 50_000_000)
+                    }
                 }
-                var pixelBuffer: CVPixelBuffer?
-                CVPixelBufferCreate(kCFAllocatorDefault, 320, 240, kCVPixelFormatType_32BGRA, nil, &pixelBuffer)
-                if let pixelBuffer { capturer.capture(pixelBuffer) }
+                defer { frames.cancel() }
+
                 try await room1.localParticipant.publish(videoTrack: track)
                 try await Task.sleep(nanoseconds: 500_000_000)
             }
@@ -390,6 +396,16 @@ struct PeerConnectionSignalingTests {
                 #expect(room.connectionState == .connected, "Room should be connected after reconnect #\(attempt)")
             }
         }
+    }
+
+    /// A fresh blank frame. Created per capture so nothing non-Sendable crosses
+    /// into the feeding task.
+    private static func makeTestPixelBuffer() -> CVPixelBuffer? {
+        var pixelBuffer: CVPixelBuffer?
+        guard CVPixelBufferCreate(kCFAllocatorDefault, 320, 240, kCVPixelFormatType_32BGRA, nil, &pixelBuffer) == kCVReturnSuccess else {
+            return nil
+        }
+        return pixelBuffer
     }
 
     private static var isLocalhost: Bool {

--- a/Tests/LiveKitCoreTests/PeerConnectionSignalingTests.swift
+++ b/Tests/LiveKitCoreTests/PeerConnectionSignalingTests.swift
@@ -346,16 +346,22 @@ struct PeerConnectionSignalingTests {
                 try await Task.sleep(nanoseconds: 500_000_000)
             }
 
+            // One buffer, allocated once and asserted: a discarded allocation failure
+            // used to surface as an opaque 10s publish timeout.
+            let frame = try #require(TestFrame())
+
             for i in 0 ..< videoCount {
                 let track = LocalVideoTrack.createBufferTrack(name: "video-\(i)")
                 let capturer = try #require(track.capturer as? BufferCapturer)
 
-                // `BufferCapturer` resolves dimensions only from captured frames and
-                // is documented to be fed repeatedly, so keep frames flowing until
-                // publish returns rather than relying on a single one landing in time.
+                // `BufferCapturer` resolves dimensions only from a captured frame, and
+                // publish waits for them. Capture synchronously so that wait can't
+                // depend on a background task being scheduled, then keep feeding the
+                // same frame the way the capturer is documented to be driven.
+                capturer.capture(frame.buffer)
                 let frames = Task.detached {
                     while !Task.isCancelled {
-                        if let buffer = Self.makeTestPixelBuffer() { capturer.capture(buffer) }
+                        capturer.capture(frame.buffer)
                         try? await Task.sleep(nanoseconds: 50_000_000)
                     }
                 }
@@ -398,14 +404,18 @@ struct PeerConnectionSignalingTests {
         }
     }
 
-    /// A fresh blank frame. Created per capture so nothing non-Sendable crosses
-    /// into the feeding task.
-    private static func makeTestPixelBuffer() -> CVPixelBuffer? {
-        var pixelBuffer: CVPixelBuffer?
-        guard CVPixelBufferCreate(kCFAllocatorDefault, 320, 240, kCVPixelFormatType_32BGRA, nil, &pixelBuffer) == kCVReturnSuccess else {
-            return nil
+    /// A blank frame, boxed so it can be fed from a background task. The buffer is
+    /// only ever read, never written.
+    private final class TestFrame: @unchecked Sendable {
+        let buffer: CVPixelBuffer
+
+        init?() {
+            var pixelBuffer: CVPixelBuffer?
+            guard CVPixelBufferCreate(kCFAllocatorDefault, 320, 240, kCVPixelFormatType_32BGRA, nil, &pixelBuffer) == kCVReturnSuccess,
+                  let pixelBuffer
+            else { return nil }
+            buffer = pixelBuffer
         }
-        return pixelBuffer
     }
 
     private static var isLocalhost: Bool {

--- a/Tests/LiveKitCoreTests/RpcClientServerTests.swift
+++ b/Tests/LiveKitCoreTests/RpcClientServerTests.swift
@@ -33,25 +33,25 @@ struct RpcClientTests {
 
     @Test func performRpc() async throws {
         try await TestEnvironment.withRoom { room in
-            let mockDataChannel = MockDataChannelPair { packet in
+            // Assert the wire format from the mock, but inject the ack/response from
+            // the `afterPublish` hook, which `performRpc` *awaits*. Spawning an
+            // unstructured `Task` here instead made the test depend on that task
+            // being scheduled before the 15s response timeout — the top cause of
+            // this suite's CI flakes.
+            let observed = StateSync<Livekit_RpcRequest?>(nil)
+            room.publisherDataChannel = MockDataChannelPair { packet in
                 guard case let .rpcRequest(request) = packet.value else { return }
-                guard request.method == "test-method",
-                      request.payload == "test-payload",
-                      request.responseTimeoutMs == 15000
-                else { return }
-
-                // Pre-registration in performRpc is synchronous on the actor before
-                // publish, so the ack/response can fire immediately without a sleep.
-                Task {
-                    await room.rpcClient.handleIncomingAck(requestId: request.id)
-                    await room.rpcClient.handleIncomingResponse(
-                        requestId: request.id,
-                        payload: "response-payload",
-                        error: nil,
-                    )
-                }
+                observed.mutate { $0 = request }
             }
-            room.publisherDataChannel = mockDataChannel
+
+            await room.rpcClient.setAfterPublish { requestId in
+                await room.rpcClient.handleIncomingAck(requestId: requestId)
+                await room.rpcClient.handleIncomingResponse(
+                    requestId: requestId,
+                    payload: "response-payload",
+                    error: nil,
+                )
+            }
 
             let response = try await room.localParticipant.performRpc(
                 destinationIdentity: Participant.Identity(from: "test-destination"),
@@ -60,6 +60,13 @@ struct RpcClientTests {
             )
             #expect(response == "response-payload")
             #expect(await room.rpcClient.pendingCount == 0)
+
+            // Wire format, previously gated behind an early `return` in the mock —
+            // which silently turned a format regression into a timeout.
+            let request = try #require(observed.copy())
+            #expect(request.method == "test-method")
+            #expect(request.payload == "test-payload")
+            #expect(request.responseTimeoutMs == 15000)
         }
     }
 
@@ -238,19 +245,20 @@ struct RpcClientTests {
             let destination = Participant.Identity(from: "test-destination")
             let collector = TestStringCollector()
 
-            let mockDataChannel = MockDataChannelPair { packet in
-                guard case let .rpcRequest(request) = packet.value else { return }
-                Task {
-                    await collector.append(request.id)
-                    await room.rpcClient.handleIncomingAck(requestId: request.id)
-                    await room.rpcClient.handleIncomingResponse(
-                        requestId: request.id,
-                        payload: "response-\(request.id)",
-                        error: nil,
-                    )
-                }
+            room.publisherDataChannel = MockDataChannelPair { _ in }
+
+            // Injected from the awaited `afterPublish` hook rather than an
+            // unstructured `Task`, so five concurrent calls can't be starved past
+            // their response timeout on a loaded host.
+            await room.rpcClient.setAfterPublish { requestId in
+                await collector.append(requestId)
+                await room.rpcClient.handleIncomingAck(requestId: requestId)
+                await room.rpcClient.handleIncomingResponse(
+                    requestId: requestId,
+                    payload: "response-\(requestId)",
+                    error: nil,
+                )
             }
-            room.publisherDataChannel = mockDataChannel
 
             let responses = try await withThrowingTaskGroup { group in
                 for _ in 0 ..< 5 {
@@ -448,18 +456,18 @@ struct RpcClientTests {
             let imposter = Participant.Identity(from: "v2-imposter")
             try await RpcTestSupport.installRemote(in: room, identity: destination, clientProtocol: .v1)
 
-            let mockDataChannel = MockDataChannelPair { packet in
-                if case let .streamHeader(header) = packet.value, header.topic == RpcStreamTopic.request {
-                    Task {
-                        let requestId = try #require(header.attributes[RpcStreamAttribute.requestId])
-                        await room.rpcClient.handleIncomingAck(requestId: requestId)
-                        // Inject a response stream from the imposter — must be ignored.
-                        let reader = RpcTestSupport.makeResponseReader(requestId: requestId, payload: "spoofed")
-                        await room.rpcClient.handleIncomingResponseStream(reader: reader, senderIdentity: imposter)
-                    }
-                }
+            room.publisherDataChannel = MockDataChannelPair { _ in }
+
+            // Awaited hook, not an unstructured `Task`: the legitimate ack has to
+            // land before the 2s ack-watchdog, otherwise this fails with
+            // `connectionTimeout` (1501) instead of the `responseTimeout` (1502)
+            // the test is actually about.
+            await room.rpcClient.setAfterPublish { requestId in
+                await room.rpcClient.handleIncomingAck(requestId: requestId)
+                // Inject a response stream from the imposter — must be ignored.
+                let reader = RpcTestSupport.makeResponseReader(requestId: requestId, payload: "spoofed")
+                await room.rpcClient.handleIncomingResponseStream(reader: reader, senderIdentity: imposter)
             }
-            room.publisherDataChannel = mockDataChannel
 
             do {
                 let response = try await room.localParticipant.performRpc(

--- a/Tests/LiveKitCoreTests/RpcClientServerTests.swift
+++ b/Tests/LiveKitCoreTests/RpcClientServerTests.swift
@@ -34,10 +34,8 @@ struct RpcClientTests {
     @Test func performRpc() async throws {
         try await TestEnvironment.withRoom { room in
             // Assert the wire format from the mock, but inject the ack/response from
-            // the `afterPublish` hook, which `performRpc` *awaits*. Spawning an
-            // unstructured `Task` here instead made the test depend on that task
-            // being scheduled before the 15s response timeout — the top cause of
-            // this suite's CI flakes.
+            // the `afterPublish` hook, which `performRpc` awaits — an unstructured
+            // `Task` here would race the response timeout.
             let observed = StateSync<Livekit_RpcRequest?>(nil)
             room.publisherDataChannel = MockDataChannelPair { packet in
                 guard case let .rpcRequest(request) = packet.value else { return }
@@ -61,8 +59,6 @@ struct RpcClientTests {
             #expect(response == "response-payload")
             #expect(await room.rpcClient.pendingCount == 0)
 
-            // Wire format, previously gated behind an early `return` in the mock —
-            // which silently turned a format regression into a timeout.
             let request = try #require(observed.copy())
             #expect(request.method == "test-method")
             #expect(request.payload == "test-payload")
@@ -247,9 +243,6 @@ struct RpcClientTests {
 
             room.publisherDataChannel = MockDataChannelPair { _ in }
 
-            // Injected from the awaited `afterPublish` hook rather than an
-            // unstructured `Task`, so five concurrent calls can't be starved past
-            // their response timeout on a loaded host.
             await room.rpcClient.setAfterPublish { requestId in
                 await collector.append(requestId)
                 await room.rpcClient.handleIncomingAck(requestId: requestId)
@@ -353,18 +346,16 @@ struct RpcClientTests {
             let destination = Participant.Identity(from: "v1-destination")
             try await RpcTestSupport.installRemote(in: room, identity: destination, clientProtocol: .v0)
 
-            let mockDataChannel = MockDataChannelPair { packet in
-                guard case let .rpcRequest(request) = packet.value else { return }
-                Task {
-                    await room.rpcClient.handleIncomingAck(requestId: request.id)
-                    await room.rpcClient.handleIncomingResponse(
-                        requestId: request.id,
-                        payload: nil,
-                        error: RpcError(code: 101, message: "Test error message", data: ""),
-                    )
-                }
+            room.publisherDataChannel = MockDataChannelPair { _ in }
+
+            await room.rpcClient.setAfterPublish { requestId in
+                await room.rpcClient.handleIncomingAck(requestId: requestId)
+                await room.rpcClient.handleIncomingResponse(
+                    requestId: requestId,
+                    payload: nil,
+                    error: RpcError(code: 101, message: "Test error message", data: ""),
+                )
             }
-            room.publisherDataChannel = mockDataChannel
 
             do {
                 _ = try await room.localParticipant.performRpc(
@@ -418,17 +409,13 @@ struct RpcClientTests {
             let destination = Participant.Identity(from: "v2-destination")
             try await RpcTestSupport.installRemote(in: room, identity: destination, clientProtocol: .v1)
 
-            let mockDataChannel = MockDataChannelPair { packet in
-                if case let .streamHeader(header) = packet.value, header.topic == RpcStreamTopic.request {
-                    Task {
-                        let requestId = try #require(header.attributes[RpcStreamAttribute.requestId])
-                        await room.rpcClient.handleIncomingAck(requestId: requestId)
-                        let reader = RpcTestSupport.makeFailingResponseReader(requestId: requestId)
-                        await room.rpcClient.handleIncomingResponseStream(reader: reader, senderIdentity: destination)
-                    }
-                }
+            room.publisherDataChannel = MockDataChannelPair { _ in }
+
+            await room.rpcClient.setAfterPublish { requestId in
+                await room.rpcClient.handleIncomingAck(requestId: requestId)
+                let reader = RpcTestSupport.makeFailingResponseReader(requestId: requestId)
+                await room.rpcClient.handleIncomingResponseStream(reader: reader, senderIdentity: destination)
             }
-            room.publisherDataChannel = mockDataChannel
 
             do {
                 _ = try await room.localParticipant.performRpc(
@@ -458,10 +445,6 @@ struct RpcClientTests {
 
             room.publisherDataChannel = MockDataChannelPair { _ in }
 
-            // Awaited hook, not an unstructured `Task`: the legitimate ack has to
-            // land before the 2s ack-watchdog, otherwise this fails with
-            // `connectionTimeout` (1501) instead of the `responseTimeout` (1502)
-            // the test is actually about.
             await room.rpcClient.setAfterPublish { requestId in
                 await room.rpcClient.handleIncomingAck(requestId: requestId)
                 // Inject a response stream from the imposter — must be ignored.

--- a/Tests/LiveKitCoreTests/WebSocket/WebSocketTests.swift
+++ b/Tests/LiveKitCoreTests/WebSocket/WebSocketTests.swift
@@ -44,15 +44,10 @@ struct WebSocketTests {
         try? await Task.sleep(nanoseconds: 1_000_000) // 1ms
         task.cancel()
 
-        let result = await task.result
-        switch result {
-        case .success:
-            // Connected before cancel fired — clean up
-            await room.disconnect()
-        case .failure:
-            // Cancelled as expected
-            break
-        }
+        // Disconnect either way: a cancelled connect can still have completed the
+        // server-side join, and the participant then lingers until the process dies.
+        _ = await task.result
+        await room.disconnect()
     }
 
     @Test func rapidFireConnectCancel() async throws {
@@ -77,14 +72,11 @@ struct WebSocketTests {
             try? await Task.sleep(nanoseconds: delay)
             task.cancel()
 
-            let result = await task.result
-            switch result {
-            case .success:
-                connected += 1
-                await room.disconnect()
-            case .failure:
-                cancelled += 1
+            switch await task.result {
+            case .success: connected += 1
+            case .failure: cancelled += 1
             }
+            await room.disconnect()
         }
 
         // At least some should have been cancelled or connected — no crashes
@@ -116,6 +108,7 @@ struct WebSocketTests {
             try? await Task.sleep(nanoseconds: delay)
             task.cancel()
             _ = await task.result
+            await room.disconnect()
         }
 
         // Final connect — must succeed cleanly despite all the prior churn

--- a/Tests/LiveKitObjCTests/DataStreamObjCTests.m
+++ b/Tests/LiveKitObjCTests/DataStreamObjCTests.m
@@ -60,7 +60,7 @@
 
     // Connect room0
     XCTestExpectation *connect0 = [self expectationWithDescription:@"connect0"];
-    [room0 connectWithUrl:url token:token0 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room0 url:url token:token0 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect0 fulfill];
     }];
@@ -71,7 +71,7 @@
 
     // Connect room1
     XCTestExpectation *connect1 = [self expectationWithDescription:@"connect1"];
-    [room1 connectWithUrl:url token:token1 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room1 url:url token:token1 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect1 fulfill];
     }];
@@ -170,7 +170,7 @@
 
     // Connect both rooms
     XCTestExpectation *connect0 = [self expectationWithDescription:@"connect0"];
-    [room0 connectWithUrl:url token:token0 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room0 url:url token:token0 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect0 fulfill];
     }];
@@ -179,7 +179,7 @@
     self.participantJoinedExp = [self expectationWithDescription:@"participantJoined"];
 
     XCTestExpectation *connect1 = [self expectationWithDescription:@"connect1"];
-    [room1 connectWithUrl:url token:token1 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room1 url:url token:token1 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect1 fulfill];
     }];
@@ -266,7 +266,7 @@
 
     // Connect both rooms
     XCTestExpectation *connect0 = [self expectationWithDescription:@"connect0"];
-    [room0 connectWithUrl:url token:token0 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room0 url:url token:token0 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect0 fulfill];
     }];
@@ -275,7 +275,7 @@
     self.participantJoinedExp = [self expectationWithDescription:@"participantJoined"];
 
     XCTestExpectation *connect1 = [self expectationWithDescription:@"connect1"];
-    [room1 connectWithUrl:url token:token1 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room1 url:url token:token1 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect1 fulfill];
     }];
@@ -374,7 +374,7 @@
 
     // Connect both rooms
     XCTestExpectation *connect0 = [self expectationWithDescription:@"connect0"];
-    [room0 connectWithUrl:url token:token0 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room0 url:url token:token0 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect0 fulfill];
     }];
@@ -383,7 +383,7 @@
     self.participantJoinedExp = [self expectationWithDescription:@"participantJoined"];
 
     XCTestExpectation *connect1 = [self expectationWithDescription:@"connect1"];
-    [room1 connectWithUrl:url token:token1 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room1 url:url token:token1 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect1 fulfill];
     }];

--- a/Tests/LiveKitObjCTests/DelegateObjCTests.m
+++ b/Tests/LiveKitObjCTests/DelegateObjCTests.m
@@ -70,7 +70,7 @@
     // Verify roomDidConnect fires
     self.roomDidConnectExp = [self expectationWithDescription:@"roomDidConnect"];
     XCTestExpectation *connectExp = [self expectationWithDescription:@"connectCompletion"];
-    [room connectWithUrl:url token:token connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room url:url token:token completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connectExp fulfill];
     }];
@@ -110,7 +110,7 @@
     Room *room1 = [[Room alloc] initWithDelegate:self connectOptions:nil roomOptions:nil];
 
     XCTestExpectation *connect1 = [self expectationWithDescription:@"connect1"];
-    [room1 connectWithUrl:url token:token1 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room1 url:url token:token1 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect1 fulfill];
     }];
@@ -123,7 +123,7 @@
     Room *room2 = [[Room alloc] initWithDelegate:nil connectOptions:nil roomOptions:nil];
 
     XCTestExpectation *connect2 = [self expectationWithDescription:@"connect2"];
-    [room2 connectWithUrl:url token:token2 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room2 url:url token:token2 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect2 fulfill];
     }];
@@ -166,7 +166,7 @@
     Room *room1 = [[Room alloc] initWithDelegate:self connectOptions:nil roomOptions:nil];
 
     XCTestExpectation *connect1 = [self expectationWithDescription:@"connect1"];
-    [room1 connectWithUrl:url token:token1 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room1 url:url token:token1 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect1 fulfill];
     }];
@@ -179,7 +179,7 @@
     Room *room2 = [[Room alloc] initWithDelegate:nil connectOptions:nil roomOptions:nil];
 
     XCTestExpectation *connect2 = [self expectationWithDescription:@"connect2"];
-    [room2 connectWithUrl:url token:token2 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room2 url:url token:token2 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect2 fulfill];
     }];

--- a/Tests/LiveKitObjCTests/ParticipantObjCTests.m
+++ b/Tests/LiveKitObjCTests/ParticipantObjCTests.m
@@ -55,7 +55,7 @@
     Room *room1 = [[Room alloc] initWithDelegate:self connectOptions:nil roomOptions:nil];
 
     XCTestExpectation *connect1 = [self expectationWithDescription:@"connect1"];
-    [room1 connectWithUrl:url token:token1 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room1 url:url token:token1 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect1 fulfill];
     }];
@@ -68,7 +68,7 @@
     Room *room2 = [[Room alloc] initWithDelegate:nil connectOptions:nil roomOptions:nil];
 
     XCTestExpectation *connect2 = [self expectationWithDescription:@"connect2"];
-    [room2 connectWithUrl:url token:token2 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room2 url:url token:token2 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect2 fulfill];
     }];
@@ -99,7 +99,7 @@
     Room *room = [[Room alloc] initWithDelegate:nil connectOptions:nil roomOptions:nil];
 
     XCTestExpectation *connectExp = [self expectationWithDescription:@"connect"];
-    [room connectWithUrl:url token:token connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room url:url token:token completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connectExp fulfill];
     }];

--- a/Tests/LiveKitObjCTests/RoomObjCTests.m
+++ b/Tests/LiveKitObjCTests/RoomObjCTests.m
@@ -51,7 +51,7 @@
 
     // Connect
     XCTestExpectation *connectExp = [self expectationWithDescription:@"connect"];
-    [room connectWithUrl:url token:token connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room url:url token:token completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connectExp fulfill];
     }];
@@ -85,7 +85,7 @@
 
     // Connect
     XCTestExpectation *connectExp = [self expectationWithDescription:@"connect"];
-    [room connectWithUrl:url token:token connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room url:url token:token completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connectExp fulfill];
     }];
@@ -126,7 +126,7 @@
 
     // Connect
     XCTestExpectation *connectExp = [self expectationWithDescription:@"connect"];
-    [room connectWithUrl:url token:token connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room url:url token:token completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connectExp fulfill];
     }];

--- a/Tests/LiveKitObjCTests/RpcObjCTests.m
+++ b/Tests/LiveKitObjCTests/RpcObjCTests.m
@@ -58,7 +58,7 @@
 
     // Connect room0
     XCTestExpectation *connect0 = [self expectationWithDescription:@"connect0"];
-    [room0 connectWithUrl:url token:token0 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room0 url:url token:token0 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect0 fulfill];
     }];
@@ -68,7 +68,7 @@
 
     // Connect room1
     XCTestExpectation *connect1 = [self expectationWithDescription:@"connect1"];
-    [room1 connectWithUrl:url token:token1 connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room1 url:url token:token1 completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connect1 fulfill];
     }];
@@ -129,7 +129,7 @@
     Room *room = [[Room alloc] initWithDelegate:nil connectOptions:nil roomOptions:nil];
 
     XCTestExpectation *connectExp = [self expectationWithDescription:@"connect"];
-    [room connectWithUrl:url token:token connectOptions:nil roomOptions:nil completionHandler:^(NSError *err) {
+    [LKObjCRoomHelper connectWithRoom:room url:url token:token completionHandler:^(NSError *err) {
         XCTAssertNil(err);
         [connectExp fulfill];
     }];

--- a/Tests/LiveKitTestSupport/ConcurrentCounter.swift
+++ b/Tests/LiveKitTestSupport/ConcurrentCounter.swift
@@ -29,4 +29,20 @@ public actor ConcurrentCounter {
     public func getCount() -> Int {
         count
     }
+
+    /// Polls until `count >= target` (or `timeout` elapses) and returns the observed count.
+    ///
+    /// Timing-sensitive tests must not assert "it fired by now" after a fixed
+    /// `Task.sleep`: CI hosts — simulators especially, where `AsyncTimer` runs its
+    /// loop at `.utility` QoS and is subject to timer coalescing — routinely defer a
+    /// 50 ms sleep by hundreds of milliseconds. Waiting for the event with a
+    /// generous deadline keeps the assertion meaningful without encoding a
+    /// scheduling guarantee the platform doesn't make.
+    public func wait(untilAtLeast target: Int, timeout: TimeInterval = 10) async -> Int {
+        let deadline = Date().addingTimeInterval(timeout)
+        while count < target, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return count
+    }
 }

--- a/Tests/LiveKitTestSupport/ConcurrentCounter.swift
+++ b/Tests/LiveKitTestSupport/ConcurrentCounter.swift
@@ -31,13 +31,6 @@ public actor ConcurrentCounter {
     }
 
     /// Polls until `count >= target` (or `timeout` elapses) and returns the observed count.
-    ///
-    /// Timing-sensitive tests must not assert "it fired by now" after a fixed
-    /// `Task.sleep`: CI hosts — simulators especially, where `AsyncTimer` runs its
-    /// loop at `.utility` QoS and is subject to timer coalescing — routinely defer a
-    /// 50 ms sleep by hundreds of milliseconds. Waiting for the event with a
-    /// generous deadline keeps the assertion meaningful without encoding a
-    /// scheduling guarantee the platform doesn't make.
     public func wait(untilAtLeast target: Int, timeout: TimeInterval = 10) async -> Int {
         let deadline = Date().addingTimeInterval(timeout)
         while count < target, Date() < deadline {

--- a/Tests/LiveKitTestSupport/ObjCRoomHelper.swift
+++ b/Tests/LiveKitTestSupport/ObjCRoomHelper.swift
@@ -21,6 +21,39 @@ import LiveKitUniFFI
 /// ObjC-compatible helper for generating tokens and reading server configuration.
 @objcMembers
 public class LKObjCRoomHelper: NSObject {
+    private static let connectAttempts = 3
+    private static let connectRetryDelay: UInt64 = 2_000_000_000
+
+    /// Connects with retries, matching `TestEnvironment.withRooms`. The first `Room`
+    /// in a process pays one-time WebRTC and audio-stack initialization that can
+    /// exceed the connect timeout on a simulator.
+    @objc(connectWithRoom:url:token:completionHandler:)
+    public static func connect(room: Room,
+                               url: String,
+                               token: String,
+                               completionHandler: @escaping @Sendable (Error?) -> Void)
+    {
+        Task {
+            var lastError: Error?
+            for attempt in 1 ... connectAttempts {
+                do {
+                    try await room.connect(url: url, token: token)
+                    completionHandler(nil)
+                    return
+                } catch {
+                    lastError = error
+                    // A timed-out connect can leave the signal connection live, so
+                    // reset before retrying instead of leaking a participant.
+                    await room.disconnect()
+                    if attempt < connectAttempts {
+                        try? await Task.sleep(nanoseconds: connectRetryDelay)
+                    }
+                }
+            }
+            completionHandler(lastError)
+        }
+    }
+
     public static func serverURL() -> String {
         if let string = ProcessInfo.processInfo.environment["LIVEKIT_TESTING_URL"]?.trimmingCharacters(in: .whitespacesAndNewlines),
            !string.isEmpty

--- a/Tests/LiveKitTestSupport/ObjCRoomHelper.swift
+++ b/Tests/LiveKitTestSupport/ObjCRoomHelper.swift
@@ -42,8 +42,7 @@ public class LKObjCRoomHelper: NSObject {
                     return
                 } catch {
                     lastError = error
-                    // A timed-out connect can leave the signal connection live, so
-                    // reset before retrying instead of leaking a participant.
+                    // Reset so a half-established connect doesn't leak a participant.
                     await room.disconnect()
                     if attempt < connectAttempts {
                         try? await Task.sleep(nanoseconds: connectRetryDelay)

--- a/Tests/LiveKitTestSupport/TestEnvironment.swift
+++ b/Tests/LiveKitTestSupport/TestEnvironment.swift
@@ -116,13 +116,9 @@ public enum TestEnvironment {
 
         let allRooms = rooms.map(\.room)
 
-        // Tear down on *every* exit path, including a failed connect or a thrown
-        // body. A `Room` keeps itself alive through its signaling read loop and
-        // transport tasks, so an early exit that skipped `disconnect()` used to
-        // leak a fully-live Room — WebSocket, both peer connections and timers —
-        // into every test that ran after it, in the same host process. That is
-        // what turned a single flaky failure into a whole run of unrelated
-        // timeouts, including the ObjC suites that run last.
+        // Tear down on every exit path: a `Room` keeps itself alive through its
+        // signaling and transport tasks, so an early exit without `disconnect()`
+        // leaks a live Room into the rest of the test process.
         do {
             try await connectAndDiscover(rooms, roomName: roomName)
             try await block(allRooms)

--- a/Tests/LiveKitTestSupport/TestEnvironment.swift
+++ b/Tests/LiveKitTestSupport/TestEnvironment.swift
@@ -115,6 +115,31 @@ public enum TestEnvironment {
                     token: token)
         }
 
+        let allRooms = rooms.map(\.room)
+
+        // Tear down on *every* exit path, including a failed connect or a thrown
+        // body. A `Room` keeps itself alive through its signaling read loop and
+        // transport tasks, so an early exit that skipped `disconnect()` used to
+        // leak a fully-live Room — WebSocket, both peer connections and timers —
+        // into every test that ran after it, in the same host process. That is
+        // what turned a single flaky failure into a whole run of unrelated
+        // timeouts, including the ObjC suites that run last.
+        do {
+            try await connectAndDiscover(rooms, roomName: roomName)
+            try await block(allRooms)
+        } catch {
+            await teardown(allRooms)
+            throw error
+        }
+        await teardown(allRooms)
+
+        // Allow the server to fully tear down resources before the next test.
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+    }
+
+    private typealias RoomFixture = (room: Room, identity: String, url: String, token: String)
+
+    private static func connectAndDiscover(_ rooms: [RoomFixture], roomName: String) async throws {
         // Connect all Rooms concurrently (retry on transient failure)
         try await Task.retrying(totalAttempts: 3, retryDelay: 2) { _, _ in
             try await withThrowingTaskGroup { group in
@@ -163,23 +188,17 @@ public enum TestEnvironment {
                 }
             }
         }
+    }
 
-        let allRooms = rooms.map(\.room)
-        // Execute block
-        try await block(allRooms)
-
-        // Gracefully unpublish all tracks then disconnect.
-        try await withThrowingTaskGroup { group in
-            for element in rooms {
+    /// Gracefully unpublish all tracks then disconnect, best-effort.
+    private static func teardown(_ rooms: [Room]) async {
+        await withTaskGroup(of: Void.self) { group in
+            for room in rooms {
                 group.addTask {
-                    await element.room.localParticipant.unpublishAll()
-                    await element.room.disconnect()
+                    await room.localParticipant.unpublishAll()
+                    await room.disconnect()
                 }
             }
-            try await group.waitForAll()
         }
-
-        // Allow the server to fully tear down resources before the next test.
-        try await Task.sleep(nanoseconds: 1_000_000_000)
     }
 }

--- a/Tests/LiveKitTestSupport/TestEnvironment.swift
+++ b/Tests/LiveKitTestSupport/TestEnvironment.swift
@@ -78,7 +78,6 @@ public enum TestEnvironment {
 
     // Set up variable number of Rooms, connect them, wait for participants to discover each other,
     // execute the block, then disconnect. Framework-agnostic (no XCTest/Testing dependency).
-    // swiftlint:disable:next function_body_length
     public static func withRooms(_ options: [RoomTestingOptions] = [],
                                  _ block: @escaping ([Room]) async throws -> Void) async throws
     {
@@ -109,10 +108,10 @@ public enum TestEnvironment {
 
             print("Token: \(token) for room: \(roomName)")
 
-            return (room: room,
-                    identity: identity,
-                    url: url,
-                    token: token)
+            return RoomFixture(room: room,
+                               identity: identity,
+                               url: url,
+                               token: token)
         }
 
         let allRooms = rooms.map(\.room)
@@ -137,7 +136,12 @@ public enum TestEnvironment {
         try await Task.sleep(nanoseconds: 1_000_000_000)
     }
 
-    private typealias RoomFixture = (room: Room, identity: String, url: String, token: String)
+    private struct RoomFixture {
+        let room: Room
+        let identity: String
+        let url: String
+        let token: String
+    }
 
     private static func connectAndDiscover(_ rooms: [RoomFixture], roomName: String) async throws {
         // Connect all Rooms concurrently (retry on transient failure)
@@ -169,7 +173,8 @@ public enum TestEnvironment {
         if rooms.count >= 2 {
             let allIdentities = rooms.map(\.identity)
 
-            for (room, identity, _, _) in rooms {
+            for fixture in rooms {
+                let (room, identity) = (fixture.room, fixture.identity)
                 let exceptSelfIdentity = allIdentities.filter { $0 != identity }
                 print("Will wait for remote participants: \(exceptSelfIdentity)")
 


### PR DESCRIPTION
Deep investigation of CI flakiness (61 failed runs sampled across Jun–Jul, plus per-run test/server log capture). Every fix below is root-caused from CI evidence; several turned out to be production bugs rather than test issues.

## Production code changes

**`IncomingStreamManager` — dropped and reordered incoming data streams**
Senders reuse a stream ID for consecutive streams (transcription does); descriptor cleanup ran in a per-reader task that raced the reopening header and silently dropped the new stream (`confirmed 2 of 5` in CI). Cleanup is now synchronous in the trailer and chunk-error paths and generation-guarded so a stale cleanup can never remove a successor; open streams are failed on sender disconnect and room cleanup. Cross-stream handler ordering was also a scheduler race (one detached task per stream); topics registered with `ordered: true` now order handlers by wire happens-before — a handler waits for handlers of streams that closed before its own opened, while concurrently open streams run concurrently, so a long-lived stream never delays overlapping ones (e.g. a user's transcript during barge-in). Opt-in, used by the transcription receiver.

**`AsyncCompleter` — timeout timers could be deferred indefinitely**
Timeout blocks ran on a `.background` queue, the QoS tier the system may defer without bound under CPU pressure. A waiter whose only resume path is the timeout then never wakes: two CI legs burned full 30-minute attempts hung this way, and RPC callers saw `1501` instead of `1502` when the 0.05 s timer lost to a 2 s watchdog. Now `.utility`.

**`DeviceManager` — same QoS inversion on camera start**
Device-discovery KVO registration ran on the `.background` global queue and is the only resumer of the completers `CameraCapturer.startCapture` awaits. Now `.utility`, matching the completer timers.

**`AsyncTimer` — injectable sleep**
Internal `sleep:` parameter (defaulted, all call sites unchanged) so timing tests drive ticks deterministically instead of asserting against the scheduler.

**SwiftLint: `no_background_qos`** — errors on any `.background` queue QoS or task priority to keep the inversion class out.

## Test changes

**`withRooms` teardown on every exit path** — a thrown body previously skipped `disconnect()`, leaking live Rooms (WebSocket, peer connections, timers) into every later suite in the process; this was the amplifier that turned one flake into a run-wide cascade.

**Deterministic waits instead of fixed sleeps** — AsyncTimer tests drive ticks via the injected sleep (`ManualSleeper`); transcription tests wait for expected update counts; reliable-data tests wait for delivery *inside* `withRooms` (waiting after teardown lost in-flight packets: 56–127 of 128 delivered).

**RPC tests inject via the awaited `afterPublish` hook** — unstructured `Task {}` injection raced response timeouts under load (`1502` flakes).

**ObjC tests retry connects** (like `withRooms` always has) — the first `Room` in a fresh process pays one-time WebRTC/audio init that can exceed the connect timeout on simulators (`testSendFile`, 40 historical failures).

**Buffer-track tests resolve dimensions directly** — captured frames resolve dimensions on the capture queue, which lags past the publish timeout under load.

**`WebSocketTests` disconnect cancelled connects** — a cancelled connect can still complete the server-side join; 21 leaked participants per run otherwise.

**New regression tests** — stream-ID reuse delivery and ordered-topic FIFO (unit-level, drive the manager's event loop directly; the reuse test reproduces the drop deterministically without the fix), transcription burst-ordering, AsyncTimer semantics.

**Guard against process aborts** — transcription validation indexed past `#expect` count mismatches, crashing the whole test process (52 aborts historically).

## CI changes

- **Job-level retries replaced with in-run test retries**: the `nick-fields/retry` wrapper masked every flake above behind full rebuild-and-rerun attempts, with failures buried in superseded logs. Now `-retry-tests-on-failure -test-iterations 2` re-runs failures inside the same xcodebuild invocation (XCTest re-runs only the failed cases; Swift Testing runs a second iteration) — a flaky leg costs one extra test pass, and per-iteration results stay visible in the log and xcresult.
- **Failure artifacts**: raw `xcodebuild` output (xcbeautify swallows parameterized-test failure details) and the dev-server log (close reasons prove client vs server fault) upload on failure.
- Xcode 26.6 on macos-26 legs; new `xcode-27` preview legs (macOS, Catalyst, iOS/tvOS/visionOS 27.0 sims).

