### PR TITLE
Fix quiet remote audio with software voice processing on iOS

### DIFF
--- a/.changes/software-vp-session-mode
+++ b/.changes/software-vp-session-mode
@@ -1,0 +1,1 @@
+patch type="fixed" "Use media session mode when recording with software voice processing to fix quiet remote audio"

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -64,12 +64,39 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         set { _state.mutate { $0.isSpeakerOutputPreferred = newValue } }
     }
 
+    /// Controls whether the session mode follows the voice processing implementation.
+    ///
+    /// iOS applies a reduced, call-tuned speaker gain when the session mode is
+    /// `.videoChat` or `.voiceChat` while the microphone is active. Apple's
+    /// Voice Processing I/O compensates with its own loudness stage, WebRTC
+    /// software processing does not, which makes remote audio noticeably
+    /// quieter in software mode.
+    ///
+    /// - When `true`: `.default` mode is used while recording with software
+    ///   voice processing, keeping media playback loudness. Chat modes are
+    ///   used when Apple voice processing is active.
+    /// - When `false`: Chat modes are always used while recording (legacy behavior).
+    ///
+    /// > Note: This value is only used when `isAutomaticConfigurationEnabled` is `true`.
+    ///
+    /// Default value: `true`
+    public var isSoftwareProcessingMediaModeEnabled: Bool {
+        get { _state.isSoftwareProcessingMediaModeEnabled }
+        set { _state.mutate { $0.isSoftwareProcessingMediaModeEnabled = newValue } }
+    }
+
     struct State {
         var next: (any AudioEngineObserver)?
 
         var isAutomaticConfigurationEnabled: Bool = true
         var isAutomaticDeactivationEnabled: Bool = true
         var isSpeakerOutputPreferred: Bool = true
+        var isSoftwareProcessingMediaModeEnabled: Bool = true
+
+        // Whether the next capture is expected to use Apple's voice processing
+        // path. Updated by AudioManager before recording starts, since the ADM
+        // state is not yet committed when engineWillEnable fires.
+        var isPlatformVoiceProcessingExpected: Bool = true
 
         var sessionRequirements: [UUID: SessionRequirement] = [:]
     }
@@ -86,13 +113,21 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
     public init() {
         _state.onDidMutate = { [weak self] new, old in
             guard let self,
-                  new.isSpeakerOutputPreferred != old.isSpeakerOutputPreferred else { return }
+                  new.isSpeakerOutputPreferred != old.isSpeakerOutputPreferred ||
+                  new.isSoftwareProcessingMediaModeEnabled != old.isSoftwareProcessingMediaModeEnabled ||
+                  new.isPlatformVoiceProcessingExpected != old.isPlatformVoiceProcessingExpected else { return }
             do {
                 try configureIfNeeded(oldState: old, newState: new)
             } catch {
-                log("Failed to configure audio session after speaker preference change: \(error)", .error)
+                log("Failed to configure audio session after configuration preference change: \(error)", .error)
             }
         }
+    }
+
+    /// Updates the expected voice processing implementation for the next capture.
+    /// Called by ``AudioManager`` before recording starts or is prepared.
+    func setPlatformVoiceProcessingExpected(_ expected: Bool) {
+        _state.mutate { $0.isPlatformVoiceProcessingExpected = expected }
     }
 
     /// Acquires an audio session requirement handle for external ownership.
@@ -177,8 +212,16 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
                 log("AudioSession deactivation skipped...")
             }
         } else if newState.isRecordingEnabled || newState.isPlayoutEnabled {
-            // Configure and activate the session with the appropriate category
-            let playAndRecord: AudioSessionConfiguration = newState.isSpeakerOutputPreferred ? .playAndRecordSpeaker : .playAndRecordReceiver
+            // Configure and activate the session with the appropriate category.
+            // Chat modes engage the call-tuned speaker gain and are only kept
+            // when Apple voice processing provides its compensating loudness
+            // stage. See isSoftwareProcessingMediaModeEnabled.
+            let useChatModes = !newState.isSoftwareProcessingMediaModeEnabled || newState.isPlatformVoiceProcessingExpected
+            let playAndRecord: AudioSessionConfiguration = if useChatModes {
+                newState.isSpeakerOutputPreferred ? .playAndRecordSpeaker : .playAndRecordReceiver
+            } else {
+                newState.isSpeakerOutputPreferred ? .playAndRecordSpeakerMedia : .playAndRecordReceiverMedia
+            }
             let config: AudioSessionConfiguration = newState.isRecordingEnabled ? playAndRecord : .playback
 
             do {

--- a/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
+++ b/Sources/LiveKit/Audio/AudioSessionEngineObserver.swift
@@ -64,34 +64,12 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         set { _state.mutate { $0.isSpeakerOutputPreferred = newValue } }
     }
 
-    /// Controls whether the session mode follows the voice processing implementation.
-    ///
-    /// iOS applies a reduced, call-tuned speaker gain when the session mode is
-    /// `.videoChat` or `.voiceChat` while the microphone is active. Apple's
-    /// Voice Processing I/O compensates with its own loudness stage, WebRTC
-    /// software processing does not, which makes remote audio noticeably
-    /// quieter in software mode.
-    ///
-    /// - When `true`: `.default` mode is used while recording with software
-    ///   voice processing, keeping media playback loudness. Chat modes are
-    ///   used when Apple voice processing is active.
-    /// - When `false`: Chat modes are always used while recording (legacy behavior).
-    ///
-    /// > Note: This value is only used when `isAutomaticConfigurationEnabled` is `true`.
-    ///
-    /// Default value: `true`
-    public var isSoftwareProcessingMediaModeEnabled: Bool {
-        get { _state.isSoftwareProcessingMediaModeEnabled }
-        set { _state.mutate { $0.isSoftwareProcessingMediaModeEnabled = newValue } }
-    }
-
     struct State {
         var next: (any AudioEngineObserver)?
 
         var isAutomaticConfigurationEnabled: Bool = true
         var isAutomaticDeactivationEnabled: Bool = true
         var isSpeakerOutputPreferred: Bool = true
-        var isSoftwareProcessingMediaModeEnabled: Bool = true
 
         // Whether the next capture is expected to use Apple's voice processing
         // path. Updated by AudioManager before recording starts, since the ADM
@@ -114,7 +92,6 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
         _state.onDidMutate = { [weak self] new, old in
             guard let self,
                   new.isSpeakerOutputPreferred != old.isSpeakerOutputPreferred ||
-                  new.isSoftwareProcessingMediaModeEnabled != old.isSoftwareProcessingMediaModeEnabled ||
                   new.isPlatformVoiceProcessingExpected != old.isPlatformVoiceProcessingExpected else { return }
             do {
                 try configureIfNeeded(oldState: old, newState: new)
@@ -213,11 +190,11 @@ public class AudioSessionEngineObserver: AudioEngineObserver, Loggable, @uncheck
             }
         } else if newState.isRecordingEnabled || newState.isPlayoutEnabled {
             // Configure and activate the session with the appropriate category.
-            // Chat modes engage the call-tuned speaker gain and are only kept
+            // Chat modes engage iOS's call-tuned speaker gain and are only kept
             // when Apple voice processing provides its compensating loudness
-            // stage. See isSoftwareProcessingMediaModeEnabled.
-            let useChatModes = !newState.isSoftwareProcessingMediaModeEnabled || newState.isPlatformVoiceProcessingExpected
-            let playAndRecord: AudioSessionConfiguration = if useChatModes {
+            // stage. With software processing, the media-tuned presets keep
+            // remote audio at media playback loudness.
+            let playAndRecord: AudioSessionConfiguration = if newState.isPlatformVoiceProcessingExpected {
                 newState.isSpeakerOutputPreferred ? .playAndRecordSpeaker : .playAndRecordReceiver
             } else {
                 newState.isSpeakerOutputPreferred ? .playAndRecordSpeakerMedia : .playAndRecordReceiverMedia

--- a/Sources/LiveKit/Audio/Manager/AudioManager.swift
+++ b/Sources/LiveKit/Audio/Manager/AudioManager.swift
@@ -445,26 +445,6 @@ public class AudioManager: Loggable {
         try checkAdmResult(code: result)
     }
 
-    /// Tells the session observer which voice processing implementation the
-    /// next capture resolves to, before the ADM engine transition starts. The
-    /// session category and mode are configured during that transition, so the
-    /// expectation must be known up front. Also called from
-    /// ``LocalAudioTrack/setAudioProcessingOptions(_:)`` since track-level
-    /// requests reach the ADM through the sender, bypassing this manager.
-    func updateExpectedPlatformVoiceProcessing(for options: AudioProcessingOptions?) {
-        #if os(iOS) || os(visionOS) || os(tvOS)
-        // nil requests no processing change and the ADM keeps its current
-        // voice processing state, so the expectation must stay unchanged too.
-        guard let options else { return }
-        #if targetEnvironment(simulator)
-        let expected = false
-        #else
-        let expected = options.requestsPlatformEchoNoisePath && isPlatformVoiceProcessingAllowed
-        #endif
-        audioSession.setPlatformVoiceProcessingExpected(expected)
-        #endif
-    }
-
     /// Stops mic input after it was started with ``startLocalRecording()``
     public func stopLocalRecording() throws {
         let result = RTC.audioDeviceModule.stopRecording()
@@ -590,6 +570,26 @@ public extension AudioManager {
 }
 
 extension AudioManager {
+    /// Tells the session observer which voice processing implementation the
+    /// next capture resolves to, before the ADM engine transition starts. The
+    /// session category and mode are configured during that transition, so the
+    /// expectation must be known up front. Also called from
+    /// ``LocalAudioTrack/setAudioProcessingOptions(_:)`` since track-level
+    /// requests reach the ADM through the sender, bypassing this manager.
+    func updateExpectedPlatformVoiceProcessing(for options: AudioProcessingOptions?) {
+        #if os(iOS) || os(visionOS) || os(tvOS)
+        // nil requests no processing change and the ADM keeps its current
+        // voice processing state, so the expectation must stay unchanged too.
+        guard let options else { return }
+        #if targetEnvironment(simulator)
+        let expected = false
+        #else
+        let expected = options.requestsPlatformEchoNoisePath && isPlatformVoiceProcessingAllowed
+        #endif
+        audioSession.setPlatformVoiceProcessingExpected(expected)
+        #endif
+    }
+
     func buildEngineObserverChain() -> (any AudioEngineObserver)? {
         var objects = _state.engineObservers
         guard !objects.isEmpty else { return nil }

--- a/Sources/LiveKit/Audio/Manager/AudioManager.swift
+++ b/Sources/LiveKit/Audio/Manager/AudioManager.swift
@@ -422,6 +422,9 @@ public class AudioManager: Loggable {
         _ enabled: Bool,
         audioProcessingOptions: AudioProcessingOptions? = nil,
     ) async throws {
+        if enabled {
+            updateExpectedPlatformVoiceProcessing(for: audioProcessingOptions)
+        }
         let result = RTC.audioDeviceModule.setRecordingAlwaysPreparedMode(
             enabled,
             audioProcessingOptions: audioProcessingOptions?.toRTCType(),
@@ -432,6 +435,7 @@ public class AudioManager: Loggable {
     /// Starts mic input to the SDK even without any ``Room`` or a connection.
     /// Audio buffers will flow into ``LocalAudioTrack/add(audioRenderer:)`` and ``capturePostProcessingDelegate``.
     public func startLocalRecording(audioProcessingOptions: AudioProcessingOptions? = nil) throws {
+        updateExpectedPlatformVoiceProcessing(for: audioProcessingOptions)
         // Always unmute APM if muted by last session.
         RTC.audioProcessingModule.isMuted = false // TODO: Possibly not required anymore with new libs
         // Start recording on the ADM.
@@ -439,6 +443,22 @@ public class AudioManager: Loggable {
             audioProcessingOptions: audioProcessingOptions?.toRTCType(),
         )
         try checkAdmResult(code: result)
+    }
+
+    /// Tells the session observer which voice processing implementation the
+    /// next capture resolves to, before the ADM engine transition starts. The
+    /// session category and mode are configured during that transition, so the
+    /// expectation must be known up front.
+    private func updateExpectedPlatformVoiceProcessing(for options: AudioProcessingOptions?) {
+        #if os(iOS) || os(visionOS) || os(tvOS)
+        #if targetEnvironment(simulator)
+        let expected = false
+        #else
+        let requested = (options ?? AudioProcessingOptions()).requestsPlatformEchoNoisePath
+        let expected = requested && isPlatformVoiceProcessingAllowed
+        #endif
+        audioSession.setPlatformVoiceProcessingExpected(expected)
+        #endif
     }
 
     /// Stops mic input after it was started with ``startLocalRecording()``

--- a/Sources/LiveKit/Audio/Manager/AudioManager.swift
+++ b/Sources/LiveKit/Audio/Manager/AudioManager.swift
@@ -453,11 +453,13 @@ public class AudioManager: Loggable {
     /// requests reach the ADM through the sender, bypassing this manager.
     func updateExpectedPlatformVoiceProcessing(for options: AudioProcessingOptions?) {
         #if os(iOS) || os(visionOS) || os(tvOS)
+        // nil requests no processing change and the ADM keeps its current
+        // voice processing state, so the expectation must stay unchanged too.
+        guard let options else { return }
         #if targetEnvironment(simulator)
         let expected = false
         #else
-        let requested = (options ?? AudioProcessingOptions()).requestsPlatformEchoNoisePath
-        let expected = requested && isPlatformVoiceProcessingAllowed
+        let expected = options.requestsPlatformEchoNoisePath && isPlatformVoiceProcessingAllowed
         #endif
         audioSession.setPlatformVoiceProcessingExpected(expected)
         #endif

--- a/Sources/LiveKit/Audio/Manager/AudioManager.swift
+++ b/Sources/LiveKit/Audio/Manager/AudioManager.swift
@@ -334,6 +334,16 @@ public class AudioManager: Loggable {
     public func setPlatformVoiceProcessingAllowed(_ allowed: Bool) throws {
         let result = RTC.audioDeviceModule.setPlatformVoiceProcessingAllowed(allowed)
         try checkAdmResult(code: result)
+        #if os(iOS) || os(visionOS) || os(tvOS)
+        // Disallowing the platform path tears down any current VPIO and makes
+        // future captures resolve to software processing regardless of their
+        // options, so the session must not keep the chat mode expectation.
+        // Re-allowing does not enable VPIO by itself, the next capture's
+        // options decide, so the expectation is left for that path to update.
+        if !allowed {
+            audioSession.setPlatformVoiceProcessingExpected(false)
+        }
+        #endif
     }
 
     @available(*, deprecated, renamed: "isPlatformVoiceProcessingAllowed")

--- a/Sources/LiveKit/Audio/Manager/AudioManager.swift
+++ b/Sources/LiveKit/Audio/Manager/AudioManager.swift
@@ -448,8 +448,10 @@ public class AudioManager: Loggable {
     /// Tells the session observer which voice processing implementation the
     /// next capture resolves to, before the ADM engine transition starts. The
     /// session category and mode are configured during that transition, so the
-    /// expectation must be known up front.
-    private func updateExpectedPlatformVoiceProcessing(for options: AudioProcessingOptions?) {
+    /// expectation must be known up front. Also called from
+    /// ``LocalAudioTrack/setAudioProcessingOptions(_:)`` since track-level
+    /// requests reach the ADM through the sender, bypassing this manager.
+    func updateExpectedPlatformVoiceProcessing(for options: AudioProcessingOptions?) {
         #if os(iOS) || os(visionOS) || os(tvOS)
         #if targetEnvironment(simulator)
         let expected = false

--- a/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/Local/LocalAudioTrack.swift
@@ -110,7 +110,12 @@ public class LocalAudioTrack: Track, LocalTrackProtocol, AudioTrackProtocol, @un
                 message: "Media track is not an audio track",
             )
         }
-        return try audioTrack.setAudioProcessingOptions(options.toRTCType()).toLKType()
+        let result = try audioTrack.setAudioProcessingOptions(options.toRTCType()).toLKType()
+        // Track-level options reach the ADM through the sender, so inform the
+        // session observer here to keep the session mode in sync with the
+        // requested voice processing implementation.
+        AudioManager.shared.updateExpectedPlatformVoiceProcessing(for: options)
+        return result
     }
 
     // MARK: - Internal

--- a/Sources/LiveKit/Types/AudioProcessingOptions.swift
+++ b/Sources/LiveKit/Types/AudioProcessingOptions.swift
@@ -76,6 +76,18 @@ public struct AudioProcessingOptions: Hashable, Sendable {
     }
 }
 
+extension AudioProcessingOptions {
+    /// Whether these options request Apple's coupled voice processing path.
+    ///
+    /// Mirrors the coupled AEC/NS resolution: any enabled echo cancellation or
+    /// noise suppression component that is not forced to software prefers the
+    /// platform path when it is available.
+    var requestsPlatformEchoNoisePath: Bool {
+        (echoCancellation && echoCancellationMode != .software) ||
+            (noiseSuppression && noiseSuppressionMode != .software)
+    }
+}
+
 /// The caller's request for one audio processing component: enabled flag plus
 /// implementation mode.
 public struct AudioProcessingComponentRequest<Mode: Sendable>: Sendable {

--- a/Sources/LiveKit/Types/AudioSessionConfiguration.swift
+++ b/Sources/LiveKit/Types/AudioSessionConfiguration.swift
@@ -46,6 +46,13 @@ public extension AudioSessionConfiguration {
                                                                  categoryOptions: playAndRecordOptions,
                                                                  mode: .voiceChat)
 
+    // tvOS has neither a receiver nor a built-in speaker route to prefer.
+    #if os(tvOS)
+    private static let playAndRecordSpeakerMediaOptions: AVAudioSession.CategoryOptions = playAndRecordOptions
+    #else
+    private static let playAndRecordSpeakerMediaOptions: AVAudioSession.CategoryOptions = playAndRecordOptions.union(.defaultToSpeaker)
+    #endif
+
     /// Media-tuned variants for recording without Apple voice processing.
     ///
     /// iOS applies a reduced, call-tuned speaker gain when the session mode is
@@ -56,7 +63,7 @@ public extension AudioSessionConfiguration {
     /// speaker variant needs an explicit `.defaultToSpeaker` since `.default`
     /// mode routes to the receiver otherwise.
     static let playAndRecordSpeakerMedia = AudioSessionConfiguration(category: .playAndRecord,
-                                                                     categoryOptions: playAndRecordOptions.union(.defaultToSpeaker),
+                                                                     categoryOptions: playAndRecordSpeakerMediaOptions,
                                                                      mode: .default)
 
     static let playAndRecordReceiverMedia = AudioSessionConfiguration(category: .playAndRecord,

--- a/Sources/LiveKit/Types/AudioSessionConfiguration.swift
+++ b/Sources/LiveKit/Types/AudioSessionConfiguration.swift
@@ -64,13 +64,13 @@ public extension AudioSessionConfiguration {
     /// Processing I/O adds its own loudness stage that compensates for this,
     /// but with WebRTC software processing there is no VPIO and playback stays
     /// noticeably quieter. Using `.default` mode keeps the media gain.
-    static let playAndRecordSpeakerMedia = AudioSessionConfiguration(category: .playAndRecord,
-                                                                     categoryOptions: playAndRecordSpeakerOptions,
-                                                                     mode: .default)
+    internal static let playAndRecordSpeakerMedia = AudioSessionConfiguration(category: .playAndRecord,
+                                                                              categoryOptions: playAndRecordSpeakerOptions,
+                                                                              mode: .default)
 
-    static let playAndRecordReceiverMedia = AudioSessionConfiguration(category: .playAndRecord,
-                                                                      categoryOptions: playAndRecordOptions,
-                                                                      mode: .default)
+    internal static let playAndRecordReceiverMedia = AudioSessionConfiguration(category: .playAndRecord,
+                                                                               categoryOptions: playAndRecordOptions,
+                                                                               mode: .default)
 }
 
 @objcMembers

--- a/Sources/LiveKit/Types/AudioSessionConfiguration.swift
+++ b/Sources/LiveKit/Types/AudioSessionConfiguration.swift
@@ -38,20 +38,24 @@ public extension AudioSessionConfiguration {
     private static let playAndRecordOptions: AVAudioSession.CategoryOptions = [.mixWithOthers, .allowBluetooth, .allowBluetoothA2DP, .allowAirPlay]
     #endif
 
+    // Explicit speaker preference for the speaker presets. The chat modes
+    // imply a speaker route, but iOS may rewrite the mode when Voice
+    // Processing I/O is instantiated (observed switching to voiceChat, adding
+    // this option itself), and `.default` mode routes to the receiver without
+    // it. tvOS has neither a receiver nor a built-in speaker route to prefer.
+    #if os(tvOS)
+    private static let playAndRecordSpeakerOptions: AVAudioSession.CategoryOptions = playAndRecordOptions
+    #else
+    private static let playAndRecordSpeakerOptions: AVAudioSession.CategoryOptions = playAndRecordOptions.union(.defaultToSpeaker)
+    #endif
+
     static let playAndRecordSpeaker = AudioSessionConfiguration(category: .playAndRecord,
-                                                                categoryOptions: playAndRecordOptions,
+                                                                categoryOptions: playAndRecordSpeakerOptions,
                                                                 mode: .videoChat)
 
     static let playAndRecordReceiver = AudioSessionConfiguration(category: .playAndRecord,
                                                                  categoryOptions: playAndRecordOptions,
                                                                  mode: .voiceChat)
-
-    // tvOS has neither a receiver nor a built-in speaker route to prefer.
-    #if os(tvOS)
-    private static let playAndRecordSpeakerMediaOptions: AVAudioSession.CategoryOptions = playAndRecordOptions
-    #else
-    private static let playAndRecordSpeakerMediaOptions: AVAudioSession.CategoryOptions = playAndRecordOptions.union(.defaultToSpeaker)
-    #endif
 
     /// Media-tuned variants for recording without Apple voice processing.
     ///
@@ -59,11 +63,9 @@ public extension AudioSessionConfiguration {
     /// `.videoChat` or `.voiceChat` while capture is active. Apple's Voice
     /// Processing I/O adds its own loudness stage that compensates for this,
     /// but with WebRTC software processing there is no VPIO and playback stays
-    /// noticeably quieter. Using `.default` mode keeps the media gain. The
-    /// speaker variant needs an explicit `.defaultToSpeaker` since `.default`
-    /// mode routes to the receiver otherwise.
+    /// noticeably quieter. Using `.default` mode keeps the media gain.
     static let playAndRecordSpeakerMedia = AudioSessionConfiguration(category: .playAndRecord,
-                                                                     categoryOptions: playAndRecordSpeakerMediaOptions,
+                                                                     categoryOptions: playAndRecordSpeakerOptions,
                                                                      mode: .default)
 
     static let playAndRecordReceiverMedia = AudioSessionConfiguration(category: .playAndRecord,

--- a/Sources/LiveKit/Types/AudioSessionConfiguration.swift
+++ b/Sources/LiveKit/Types/AudioSessionConfiguration.swift
@@ -45,6 +45,23 @@ public extension AudioSessionConfiguration {
     static let playAndRecordReceiver = AudioSessionConfiguration(category: .playAndRecord,
                                                                  categoryOptions: playAndRecordOptions,
                                                                  mode: .voiceChat)
+
+    /// Media-tuned variants for recording without Apple voice processing.
+    ///
+    /// iOS applies a reduced, call-tuned speaker gain when the session mode is
+    /// `.videoChat` or `.voiceChat` while capture is active. Apple's Voice
+    /// Processing I/O adds its own loudness stage that compensates for this,
+    /// but with WebRTC software processing there is no VPIO and playback stays
+    /// noticeably quieter. Using `.default` mode keeps the media gain. The
+    /// speaker variant needs an explicit `.defaultToSpeaker` since `.default`
+    /// mode routes to the receiver otherwise.
+    static let playAndRecordSpeakerMedia = AudioSessionConfiguration(category: .playAndRecord,
+                                                                     categoryOptions: playAndRecordOptions.union(.defaultToSpeaker),
+                                                                     mode: .default)
+
+    static let playAndRecordReceiverMedia = AudioSessionConfiguration(category: .playAndRecord,
+                                                                      categoryOptions: playAndRecordOptions,
+                                                                      mode: .default)
 }
 
 @objcMembers

--- a/Tests/LiveKitCoreTests/AudioProcessingOptionsTests.swift
+++ b/Tests/LiveKitCoreTests/AudioProcessingOptionsTests.swift
@@ -88,4 +88,47 @@ struct AudioProcessingOptionsTests {
         #expect(echoCancellation.mode == .platform)
         #expect(highpassFilter.mode == .software)
     }
+
+    @Test func defaultOptionsRequestPlatformEchoNoisePath() {
+        #expect(AudioProcessingOptions().requestsPlatformEchoNoisePath == true)
+    }
+
+    @Test func softwareModesDoNotRequestPlatformEchoNoisePath() {
+        let options = AudioProcessingOptions(
+            echoCancellationMode: .software,
+            autoGainControlMode: .software,
+            noiseSuppressionMode: .software,
+        )
+        #expect(options.requestsPlatformEchoNoisePath == false)
+    }
+
+    @Test func singleNonSoftwareComponentRequestsPlatformEchoNoisePath() {
+        let options = AudioProcessingOptions(
+            echoCancellationMode: .software,
+            noiseSuppressionMode: .automatic,
+        )
+        #expect(options.requestsPlatformEchoNoisePath == true)
+    }
+
+    @Test func disabledComponentsDoNotRequestPlatformEchoNoisePath() {
+        #expect(AudioProcessingOptions.noProcessing.requestsPlatformEchoNoisePath == false)
+
+        let disabledButPlatformMode = AudioProcessingOptions(
+            echoCancellation: false,
+            noiseSuppression: false,
+            echoCancellationMode: .platform,
+            noiseSuppressionMode: .platform,
+        )
+        #expect(disabledButPlatformMode.requestsPlatformEchoNoisePath == false)
+    }
+
+    @Test func agcAloneDoesNotRequestPlatformEchoNoisePath() {
+        let options = AudioProcessingOptions(
+            echoCancellation: false,
+            autoGainControl: true,
+            noiseSuppression: false,
+            autoGainControlMode: .platform,
+        )
+        #expect(options.requestsPlatformEchoNoisePath == false)
+    }
 }


### PR DESCRIPTION
## Problem

With software voice processing (`echoCancellationMode: .software` etc.) and the microphone published, remote audio plays out noticeably quieter than with Apple voice processing. Reported by a customer and reproduced on device.

## Root cause

iOS applies a reduced, call tuned speaker gain when the audio session mode is `.videoChat` or `.voiceChat` while capture is active. Apple Voice Processing I/O adds its own loudness stage on the playout path that compensates for this. WebRTC software processing has no VPIO, so the SDK's chat mode session config exposes the raw call tuned gain.

Verified with a pure AVFoundation reproduction app (no WebRTC): with capture active and VPIO off, flipping only the session mode between `.videoChat` and `.default` toggles playout between quiet and loud. Everything else was ruled out on device: category options (mixWithOthers, Bluetooth options), mono output connects, the full ADM graph shape, VPIO teardown residue, and the WebRTC render path (bit identical between modes).

## Change

`AudioSessionEngineObserver` now selects the session config from the voice processing implementation:

- Apple voice processing active: `.playAndRecordSpeaker` / `.playAndRecordReceiver` (chat modes, unchanged)
- Software processing: new `.playAndRecordSpeakerMedia` / `.playAndRecordReceiverMedia` presets using `.default` mode (plus `.defaultToSpeaker` for the speaker preference)

The ADM commits its engine state only at the end of a transition, but the session is configured during it (`engineWillEnable`), so the observer cannot read the resolved state back. Instead, `AudioManager.startLocalRecording`, `setRecordingAlwaysPreparedMode`, and `LocalAudioTrack.setAudioProcessingOptions` inform the observer of the expected implementation before the transition starts, via the new internal `AudioProcessingOptions.requestsPlatformEchoNoisePath`.

The behavior follows the voice processing implementation unconditionally, no new public API. Apps needing the legacy chat mode config can disable automatic session configuration and manage the session directly.

## Companion example

livekit-examples/agent-starter-swift#48 adds an audio options panel to the agent example with a voice processing mode picker (automatic, platform, software), which is the UI used to validate and demo this fix on device.

## Validated on device

iPhone 17 Pro Max, agent-starter-swift against this branch: software mode with mic published is now loud, platform and automatic modes unchanged. Platform VP state confirmed off via `platformVoiceProcessingState` diagnostics during the test.

## Simplification once webrtc-sdk/webrtc#275 lands

The expectation push (`updateExpectedPlatformVoiceProcessing`, `setPlatformVoiceProcessingExpected`, `requestsPlatformEchoNoisePath`, and the `LocalAudioTrack` call site) exists only because the resolved voice processing state is not readable when `engineWillEnable` fires. webrtc-sdk/webrtc#275 passes that state through the `willEnableEngine` delegate callback. Once it ships in an xcframework release, all of the above gets deleted and the observer reads the value directly from the callback, with no Swift side resolution logic. This PR intentionally keeps the mechanism minimal and internal so that swap stays small.

## Known limitations / follow ups

- Separate bug found during investigation: runtime `setAudioProcessingOptions` switching platform to software on a published track does not tear down VPIO until the mic is republished (the reverse direction works). Tracked separately.
- Louder playout gives software AEC more echo to cancel. Echo behavior should be evaluated before enabling this by default in a release; the opt out exists for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

