### PR TITLE
Encapsulate SDP munging in a tested, line-preserving SDP module

### DIFF
--- a/.changes/sdp-munging-module
+++ b/.changes/sdp-munging-module
@@ -1,0 +1,1 @@
+patch type="changed" "Encapsulate SDP munging in a tested SDP module and fall back to the unmunged offer if libwebrtc rejects munged SDP"

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -190,13 +190,13 @@ actor Transport: NSObject, Loggable {
         func _negotiateSequence() async throws {
             _latestOfferId += 1
             var offer = try await createOffer(for: constraints)
-            if singlePCMode {
-                let mungedSDP = Self.mungeInactiveToRecvOnlyForMedia(offer.sdp)
-                if mungedSDP != offer.sdp {
-                    offer = RTC.createSessionDescription(type: offer.type, sdp: mungedSDP)
-                }
+            let mungedSDP = singlePCMode ? Self.mungeInactiveToRecvOnlyForMedia(offer.sdp) : offer.sdp
+            if mungedSDP != offer.sdp {
+                offer = try await set(mungedLocalDescription: RTC.createSessionDescription(type: offer.type, sdp: mungedSDP),
+                                      fallingBackTo: offer)
+            } else {
+                try await set(localDescription: offer)
             }
-            try await set(localDescription: offer)
             try await _onOffer(offer, _latestOfferId)
         }
 
@@ -232,31 +232,32 @@ extension Transport {
     /// WebRTC can generate inactive direction even when transceivers were configured as recvonly.
     /// Only rewrites RTP m-sections — non-RTP sections (e.g. data channel `m=application`) are preserved.
     static func mungeInactiveToRecvOnlyForMedia(_ sdp: String) -> String {
-        let usesCRLF = sdp.contains("\r\n")
-        let eol = usesCRLF ? "\r\n" : "\n"
-        let lines = sdp.components(separatedBy: usesCRLF ? "\r\n" : "\n")
-
-        var out: [String] = []
-        out.reserveCapacity(lines.count)
-        var inRTPMediaSection = false
-
-        for line in lines {
-            let l = line.trimmingCharacters(in: .whitespaces)
-            if l.hasPrefix("m=") {
-                inRTPMediaSection = l.contains("RTP/")
-            }
-            if inRTPMediaSection, l == "a=inactive" {
-                out.append("a=recvonly")
-            } else {
-                out.append(line)
+        var document = SDP(parsing: sdp)
+        for index in document.mediaSections.indices {
+            let section = document.mediaSections[index]
+            if section.isRTP, section.direction == .inactive {
+                document.mediaSections[index].set(direction: .recvonly)
             }
         }
+        return document.write()
+    }
 
-        var result = out.joined(separator: eol)
-        if sdp.hasSuffix(eol), !result.hasSuffix(eol) {
-            result.append(eol)
+    /// Sets `munged` as the local description, falling back to `original` when libwebrtc
+    /// rejects it — a rejected set leaves the peer connection state untouched, so
+    /// negotiation proceeds without the munge instead of failing. libwebrtc validates
+    /// munged SDP and rejects some munging types outright (`IsSdpMungingAllowed`,
+    /// expanding via field-trial kill switches). Returns the description that was applied.
+    func set(mungedLocalDescription munged: LKRTCSessionDescription,
+             fallingBackTo original: LKRTCSessionDescription) async throws -> LKRTCSessionDescription
+    {
+        do {
+            try await set(localDescription: munged)
+            return munged
+        } catch {
+            log("Munged local description was rejected, falling back to the original: \(error)", .warning)
+            try await set(localDescription: original)
+            return original
         }
-        return result
     }
 }
 
@@ -332,7 +333,9 @@ extension Transport: LKRTCPeerConnectionDelegate {
 
 // MARK: - Private
 
-private extension Transport {
+// MARK: - Internal
+
+extension Transport {
     func createOffer(for constraints: [String: String]? = nil) async throws -> LKRTCSessionDescription {
         let mediaConstraints = LKRTCMediaConstraints(mandatoryConstraints: constraints,
                                                      optionalConstraints: nil)
@@ -349,11 +352,7 @@ private extension Transport {
             }
         }
     }
-}
 
-// MARK: - Internal
-
-extension Transport {
     func createAnswer(for constraints: [String: String]? = nil) async throws -> LKRTCSessionDescription {
         let mediaConstraints = LKRTCMediaConstraints(mandatoryConstraints: constraints,
                                                      optionalConstraints: nil)

--- a/Sources/LiveKit/Support/SDP/SDP.swift
+++ b/Sources/LiveKit/Support/SDP/SDP.swift
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Direction attribute of a media section (RFC 8866 §6.7).
+enum SDPDirection: String {
+    case sendrecv, sendonly, recvonly, inactive
+
+    var line: String { "a=" + rawValue }
+
+    init?(line: String) {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("a=") else { return nil }
+        self.init(rawValue: String(trimmed.dropFirst(2)))
+    }
+}
+
+/// A parsed `a=rtpmap:<payload> <encoding>` attribute.
+struct SDPRtpmap: Equatable {
+    let payload: String
+    /// Full encoding value, e.g. `opus/48000/2`.
+    let encoding: String
+
+    /// Codec name, e.g. `opus`.
+    var codec: String { encoding.split(separator: "/").first.map(String.init) ?? encoding }
+}
+
+/// A parsed `a=fmtp:<payload> <config>` attribute.
+struct SDPFmtp: Equatable {
+    let payload: String
+    /// Raw config value, e.g. `minptime=10;useinbandfec=1`.
+    let config: String
+
+    /// Config split into `;`-separated parameters with surrounding whitespace removed.
+    var parameters: [String] {
+        config.split(separator: ";").map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+}
+
+/// One `m=` section of an SDP document: the `m=` line and every line up to the
+/// next `m=` line.
+///
+/// Lines are stored and written back verbatim — only explicit mutations change
+/// them. Typed accessors parse on demand.
+struct SDPMediaSection {
+    /// All lines of the section; the first is the `m=` line.
+    var lines: [String]
+
+    /// Media type from the `m=` line, e.g. `audio`, `video`, `application`.
+    var mediaType: String {
+        String(mLineParts.first?.dropFirst("m=".count) ?? "")
+    }
+
+    /// Whether the section's transport protocol carries RTP (e.g. `UDP/TLS/RTP/SAVPF`),
+    /// as opposed to e.g. a data channel's `UDP/DTLS/SCTP`.
+    var isRTP: Bool {
+        mLineParts.count > 2 && mLineParts[2].contains("RTP/")
+    }
+
+    var mid: String? { attributeValue("mid") }
+
+    /// The section's first direction attribute, if any.
+    var direction: SDPDirection? {
+        lines.dropFirst().lazy.compactMap(SDPDirection.init(line:)).first
+    }
+
+    var rtpmaps: [SDPRtpmap] { lines.compactMap(Self.rtpmap(fromLine:)) }
+
+    var fmtps: [SDPFmtp] { lines.compactMap(Self.fmtp(fromLine:)) }
+
+    /// Value of the first `a=<name>:<value>` attribute in the section.
+    func attributeValue(_ name: String) -> String? {
+        lines.dropFirst().lazy.compactMap { Self.attributeBody($0, name: name) }.first
+    }
+
+    /// Payload type mapped to `codec` (case-insensitive) by an `a=rtpmap` line.
+    func payload(forCodec codec: String) -> String? {
+        rtpmaps.first { $0.codec.caseInsensitiveCompare(codec) == .orderedSame }?.payload
+    }
+
+    func fmtp(forPayload payload: String) -> SDPFmtp? {
+        fmtps.first { $0.payload == payload }
+    }
+
+    /// Replaces the section's direction attribute in place, or appends one if absent.
+    mutating func set(direction: SDPDirection) {
+        if let index = lines.indices.dropFirst().first(where: { SDPDirection(line: lines[$0]) != nil }) {
+            lines[index] = direction.line
+        } else {
+            lines.append(direction.line)
+        }
+    }
+
+    /// Appends `parameter` to the fmtp config of `payload`, unless the exact parameter
+    /// is already present. Returns `true` if the section was modified; `false` when the
+    /// parameter already exists or the section has no fmtp line for `payload` (this
+    /// method never inserts a new fmtp line — use ``append(line:)`` for that).
+    @discardableResult
+    mutating func appendFmtpParameter(_ parameter: String, forPayload payload: String) -> Bool {
+        for (index, line) in lines.enumerated() {
+            guard let fmtp = Self.fmtp(fromLine: line), fmtp.payload == payload else { continue }
+            // Exact-parameter check: a substring test for e.g. "stereo=1" would also
+            // match "sprop-stereo=1" and skip the append.
+            guard !fmtp.parameters.contains(parameter) else { return false }
+            lines[index] = "a=fmtp:\(payload) \(fmtp.config);\(parameter)"
+            return true
+        }
+        return false
+    }
+
+    /// Appends a raw line at the end of the section.
+    mutating func append(line: String) {
+        lines.append(line)
+    }
+
+    // MARK: - Private
+
+    private var mLineParts: [Substring] {
+        (lines.first ?? "").trimmingCharacters(in: .whitespaces).split(separator: " ")
+    }
+
+    private static func rtpmap(fromLine line: String) -> SDPRtpmap? {
+        guard let (payload, value) = payloadAttribute(line, name: "rtpmap") else { return nil }
+        return SDPRtpmap(payload: payload, encoding: value)
+    }
+
+    private static func fmtp(fromLine line: String) -> SDPFmtp? {
+        guard let (payload, value) = payloadAttribute(line, name: "fmtp") else { return nil }
+        return SDPFmtp(payload: payload, config: value)
+    }
+
+    /// Splits an `a=<name>:<payload> <value>` line into payload and value.
+    private static func payloadAttribute(_ line: String, name: String) -> (payload: String, value: String)? {
+        guard let body = attributeBody(line, name: name),
+              let space = body.firstIndex(of: " ") else { return nil }
+        let payload = String(body[..<space])
+        let value = String(body[body.index(after: space)...])
+        guard !payload.isEmpty, !value.isEmpty else { return nil }
+        return (payload, value)
+    }
+
+    /// Returns the part after `a=<name>:` if `line` is that attribute.
+    private static func attributeBody(_ line: String, name: String) -> String? {
+        let prefix = "a=\(name):"
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix(prefix) else { return nil }
+        return String(trimmed.dropFirst(prefix.count))
+    }
+}
+
+/// A lossless, line-oriented model of an SDP document for munging.
+///
+/// Splits the document into its session-level prelude and `m=` sections while keeping
+/// every line verbatim, so `SDP(parsing: sdp).write() == sdp` holds for any
+/// input — only explicit mutations change the output. Typed accessors exist solely for
+/// the attributes the SDK munges; every other line passes through untouched, which is
+/// what makes munging safe against unknown or future SDP attributes.
+///
+/// This mirrors what sibling SDKs do (`sdp-transform` in client-sdk-js, hand-rolled
+/// line edits in rust-sdks) with a stronger round-trip guarantee than sdp-transform,
+/// which re-orders attributes on write.
+struct SDP {
+    /// Lines before the first `m=` line, verbatim.
+    var sessionLines: [String]
+    var mediaSections: [SDPMediaSection]
+
+    /// Line separator of the source document (`\r\n` per RFC 8866, but lone `\n` and
+    /// lone `\r` are tolerated and preserved).
+    let eol: String
+
+    private let endsWithEOL: Bool
+
+    init(parsing sdp: String) {
+        eol = if sdp.contains("\r\n") {
+            "\r\n"
+        } else if sdp.contains("\n") {
+            "\n"
+        } else if sdp.contains("\r") {
+            "\r"
+        } else {
+            "\n"
+        }
+        var lines = sdp.components(separatedBy: eol)
+        if lines.count > 1, lines.last == "" {
+            endsWithEOL = true
+            lines.removeLast()
+        } else {
+            endsWithEOL = false
+        }
+
+        var sessionLines: [String] = []
+        var sections: [SDPMediaSection] = []
+        for line in lines {
+            if line.hasPrefix("m=") {
+                sections.append(SDPMediaSection(lines: [line]))
+            } else if sections.isEmpty {
+                sessionLines.append(line)
+            } else {
+                sections[sections.count - 1].lines.append(line)
+            }
+        }
+        self.sessionLines = sessionLines
+        mediaSections = sections
+    }
+
+    func write() -> String {
+        var result = (sessionLines + mediaSections.flatMap(\.lines)).joined(separator: eol)
+        if endsWithEOL { result += eol }
+        return result
+    }
+}

--- a/Tests/LiveKitCoreTests/SDP/SDPFixture.swift
+++ b/Tests/LiveKitCoreTests/SDP/SDPFixture.swift
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// `normal`, `jsep` and `simulcast` are ported from the sdp-transform test suite
+/// (MIT): https://github.com/clux/sdp-transform/tree/master/test
+enum SDPFixture {
+    static let normal = """
+    v=0
+    o=- 20518 0 IN IP4 203.0.113.1
+    s=
+    t=0 0
+    c=IN IP4 203.0.113.1
+    a=ice-ufrag:F7gI
+    a=ice-pwd:x9cml/YzichV2+XlhiMu8g
+    a=fingerprint:sha-1 42:89:c5:c6:55:9d:6e:c8:e8:83:55:2a:39:f9:b6:eb:e9:a3:a9:e7
+    a=setup:actpass
+    m=audio 54400 RTP/SAVPF 0 96
+    a=rtpmap:0 PCMU/8000
+    a=rtpmap:96 opus/48000
+    a=extmap:1 URI-toffset
+    a=extmap:2/recvonly URI-gps-string
+    a=extmap-allow-mixed
+    a=ptime:20
+    a=sendrecv
+    a=candidate:0 1 UDP 2113667327 203.0.113.1 54400 typ host
+    a=candidate:1 2 UDP 2113667326 203.0.113.1 54401 typ host
+    m=video 55400 RTP/SAVPF 97 98
+    a=rtpmap:97 H264/90000
+    a=fmtp:97 profile-level-id=4d0028;packetization-mode=1;sprop-parameter-sets=Z0IAH5WoFAFuQA==,aM48gA==
+    a=fmtp:98 minptime=10; useinbandfec=1
+    a=rtpmap:98 VP8/90000
+    a=rtcp-fb:* nack
+    a=rtcp-fb:98 nack rpsi
+    a=rtcp-fb:98 trr-int 100
+    a=crypto:1 AES_CM_128_HMAC_SHA1_32 inline:keNcG3HezSNID7LmfDa9J4lfdUL8W1F7TNJKcbuy|2^20|1:32
+    a=sendrecv
+    a=ssrc:1399694169 foo:bar
+    a=ssrc:1399694169 baz
+    """
+
+    static let jsep = """
+    v=0
+    o=- 4962303333179871722 1 IN IP4 0.0.0.0
+    s=-
+    t=0 0
+    a=msid-semantic:WMS
+    a=group:BUNDLE a1 v1
+    m=audio 56500 UDP/TLS/RTP/SAVPF 96 0 8 97 98
+    c=IN IP4 192.0.2.1
+    a=mid:a1
+    a=rtcp:56501 IN IP4 192.0.2.1
+    a=msid:- f83006c5-a0ff-4e0a-9ed9-d3e6747be7d9
+    a=sendrecv
+    a=rtpmap:96 opus/48000/2
+    a=rtpmap:0 PCMU/8000
+    a=rtpmap:8 PCMA/8000
+    a=rtpmap:97 telephone-event/8000
+    a=rtpmap:98 telephone-event/48000
+    a=maxptime:120
+    a=ice-ufrag:ETEn1v9DoTMB9J4r
+    a=ice-pwd:OtSK0WpNtpUjkY4+86js7ZQl
+    a=ice-options:trickle
+    a=setup:actpass
+    a=rtcp-mux
+    a=rtcp-rsize
+    a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+    a=candidate:3348148302 1 udp 2113937151 192.0.2.1 56500 typ host
+    a=end-of-candidates
+    m=video 0 UDP/TLS/RTP/SAVPF 100 101
+    c=IN IP4 192.0.2.1
+    a=rtcp:56503 IN IP4 192.0.2.1
+    a=mid:v1
+    a=bundle-only
+    a=sendrecv
+    a=rtpmap:100 VP8/90000
+    a=rtpmap:101 rtx/90000
+    a=fmtp:101 apt=100
+    a=rtcp-fb:100 ccm fir
+    a=rtcp-fb:100 nack
+    a=rtcp-fb:100 nack pli
+    a=ssrc:1366781083 cname:EocUG1f0fcg/yvY7
+    a=ssrc-group:FID 1366781083 1366781084
+    a=end-of-candidates
+    """
+
+    static let simulcast = """
+    v=0
+    o=alice 2362969037 2362969040 IN IP4 192.0.2.156
+    s=Simulcast Enabled Client
+    t=0 0
+    c=IN IP4 192.0.2.156
+    m=audio 49200 RTP/AVP 0
+    a=rtpmap:0 PCMU/8000
+    m=video 49300 RTP/AVP 97 98 99 100
+    a=rtpmap:97 H264/90000
+    a=rtpmap:98 H264/90000
+    a=rtpmap:99 H264/90000
+    a=rtpmap:100 VP8/90000
+    a=fmtp:97 profile-level-id=42c01f; max-fs=3600; max-mbps=108000
+    a=fmtp:98 profile-level-id=42c00b; max-fs=240; max-mbps=3600
+    a=fmtp:99 profile-level-id=42c00b; max-fs=120; max-mbps=1800
+    a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:RtpStreamId
+    a=imageattr:97 send [x=1280,y=720] recv [x=1280,y=720] [x=320,y=180] [x=160,y=90]
+    a=imageattr:98 send [x=320,y=180]
+    a=imageattr:99 send [x=160,y=90]
+    a=imageattr:100 recv [x=1280,y=720] [x=320,y=180] send [x=1280,y=720]
+    a=imageattr:* recv *
+    a=rid:1 send pt=97;max-width=1280;max-height=720;max-fps=30
+    a=rid:2 send pt=98
+    a=rid:3 send pt=99
+    a=rid:4 send pt=100
+    a=rid:c recv pt=97
+    a=simulcast:send 1,~4;2;3 recv c
+    a=simulcast: send rid=1,4;2;3 paused=4 recv rid=c
+    """
+
+    /// libwebrtc-style offer with an audio section and a data channel section.
+    static let dataChannel = """
+    v=0
+    o=- 3828566255 3 IN IP4 127.0.0.1
+    s=-
+    t=0 0
+    a=group:BUNDLE 0 1
+    a=msid-semantic: WMS
+    m=audio 9 UDP/TLS/RTP/SAVPF 111 63
+    c=IN IP4 0.0.0.0
+    a=rtcp:9 IN IP4 0.0.0.0
+    a=ice-ufrag:someufrag
+    a=mid:0
+    a=inactive
+    a=rtpmap:111 opus/48000/2
+    a=fmtp:111 minptime=10;useinbandfec=1
+    m=application 9 UDP/DTLS/SCTP webrtc-datachannel
+    c=IN IP4 0.0.0.0
+    a=mid:1
+    a=sctp-port:5000
+    a=max-message-size:262144
+    """
+
+    /// Unknown line types and attributes that must survive munging untouched.
+    /// sdp-transform silently drops unknown line types (e.g. `y=`) and relocates
+    /// unknown `a=` lines after recognized ones — `SDP` deliberately does neither.
+    static let unknownLines = """
+    v=0
+    o=- 0 0 IN IP4 127.0.0.1
+    s=-
+    t=0 0
+    y=session-level-unknown-line-type
+    m=audio 9 UDP/TLS/RTP/SAVPF 111
+    b=AS:64
+    a=mid:0
+    a=x-custom-flag
+    a=x-google-flag:conference
+    a=rtpmap:111 opus/48000/2
+    a=sendonly
+    a=ssrc:42 cname:test
+    """
+
+    static let byName: [String: String] = [
+        "normal": normal,
+        "jsep": jsep,
+        "simulcast": simulcast,
+        "dataChannel": dataChannel,
+        "unknownLines": unknownLines,
+    ]
+}

--- a/Tests/LiveKitCoreTests/SDP/SDPTests.swift
+++ b/Tests/LiveKitCoreTests/SDP/SDPTests.swift
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+import Testing
+
+@Suite(.tags(.media))
+struct SDPTests {
+    /// LF/CRLF/lone-CR, with and without a trailing newline.
+    private static func eolVariants(of fixture: String) -> [String] {
+        let crlf = fixture.replacingOccurrences(of: "\n", with: "\r\n")
+        let cr = fixture.replacingOccurrences(of: "\n", with: "\r")
+        return [fixture, fixture + "\n", crlf, crlf + "\r\n", cr, cr + "\r"]
+    }
+
+    // MARK: - Round-trip
+
+    @Test(arguments: SDPFixture.byName.keys.sorted())
+    func roundTripIsIdentity(fixtureName: String) throws {
+        let fixture = try #require(SDPFixture.byName[fixtureName])
+        for sdp in Self.eolVariants(of: fixture) {
+            #expect(SDP(parsing: sdp).write() == sdp)
+        }
+    }
+
+    @Test(arguments: ["", "\n", "\r\n", "v=0", "v=0\r\ns=-\r\n"])
+    func roundTripOfDegenerateInputs(sdp: String) {
+        #expect(SDP(parsing: sdp).write() == sdp)
+    }
+
+    // MARK: - Parsing
+
+    @Test func splitsSessionAndMediaSections() {
+        let document = SDP(parsing: SDPFixture.jsep)
+
+        #expect(document.sessionLines.first == "v=0")
+        #expect(document.sessionLines.count == 6)
+        #expect(document.mediaSections.map(\.mediaType) == ["audio", "video"])
+        #expect(document.mediaSections.map(\.mid) == ["a1", "v1"])
+        #expect(document.mediaSections.allSatisfy { $0.direction == .sendrecv })
+    }
+
+    @Test func detectsRTPSections() {
+        #expect(SDP(parsing: SDPFixture.normal).mediaSections.map(\.isRTP) == [true, true])
+        #expect(SDP(parsing: SDPFixture.simulcast).mediaSections.map(\.isRTP) == [true, true])
+
+        let dataChannel = SDP(parsing: SDPFixture.dataChannel)
+        #expect(dataChannel.mediaSections.map(\.isRTP) == [true, false])
+        #expect(dataChannel.mediaSections.map(\.mediaType) == ["audio", "application"])
+    }
+
+    @Test func parsesRtpmaps() throws {
+        let document = SDP(parsing: SDPFixture.normal)
+        let audio = try #require(document.mediaSections.first)
+
+        #expect(audio.rtpmaps == [
+            SDPRtpmap(payload: "0", encoding: "PCMU/8000"),
+            SDPRtpmap(payload: "96", encoding: "opus/48000"),
+        ])
+        #expect(audio.rtpmaps.last?.codec == "opus")
+        #expect(audio.mid == nil)
+    }
+
+    @Test func parsesFmtps() throws {
+        let document = SDP(parsing: SDPFixture.normal)
+        let video = try #require(document.mediaSections.last)
+
+        #expect(video.fmtps.count == 2)
+        #expect(video.fmtps.first?.payload == "97")
+
+        let fmtp = video.fmtp(forPayload: "98")
+        #expect(fmtp?.config == "minptime=10; useinbandfec=1")
+        // Space-padded configs are normalized at the parameter level.
+        #expect(fmtp?.parameters == ["minptime=10", "useinbandfec=1"])
+    }
+
+    @Test func findsFmtpListedBeforeItsRtpmap() throws {
+        // In `normal`, `a=fmtp:98` appears before `a=rtpmap:98`.
+        let document = SDP(parsing: SDPFixture.normal)
+        let video = try #require(document.mediaSections.last)
+
+        #expect(video.payload(forCodec: "VP8") == "98")
+        #expect(video.fmtp(forPayload: "98") != nil)
+    }
+
+    @Test func findsPayloadForCodecCaseInsensitively() throws {
+        // RTP payload format names are case-insensitive media subtypes (RFC 4855 §4).
+        // client-sdk-js is inconsistent here (case-insensitive for video codecs,
+        // case-sensitive for opus); we are uniformly case-insensitive.
+        let video = try #require(SDP(parsing: SDPFixture.normal).mediaSections.last)
+        #expect(video.payload(forCodec: "h264") == "97")
+        #expect(video.payload(forCodec: "av1") == nil)
+
+        let audio = try #require(SDP(parsing: SDPFixture.jsep).mediaSections.first)
+        #expect(audio.payload(forCodec: "OPUS") == "96")
+    }
+
+    @Test func firstPayloadWinsWhenCodecHasMultiplePayloads() throws {
+        // `simulcast` maps H264 to payloads 97, 98 and 99 — the first rtpmap wins,
+        // matching client-sdk-js (`Array.find` in applyVideoStartBitrate).
+        let video = try #require(SDP(parsing: SDPFixture.simulcast).mediaSections.last)
+        #expect(video.payload(forCodec: "H264") == "97")
+    }
+
+    @Test func readsAttributeValues() throws {
+        let audio = try #require(SDP(parsing: SDPFixture.jsep).mediaSections.first)
+        #expect(audio.attributeValue("ice-ufrag") == "ETEn1v9DoTMB9J4r")
+        #expect(audio.attributeValue("nonexistent") == nil)
+    }
+
+    @Test func parsesLoneCarriageReturnEOL() throws {
+        let document = SDP(parsing: SDPFixture.dataChannel.replacingOccurrences(of: "\n", with: "\r"))
+
+        #expect(document.mediaSections.map(\.mid) == ["0", "1"])
+        let audio = try #require(document.mediaSections.first)
+        #expect(audio.direction == .inactive)
+        #expect(audio.payload(forCodec: "opus") == "111")
+    }
+
+    @Test func typedAccessorsIgnoreUnknownLines() throws {
+        let document = SDP(parsing: SDPFixture.unknownLines)
+
+        #expect(document.sessionLines.contains("y=session-level-unknown-line-type"))
+        let audio = try #require(document.mediaSections.first)
+        #expect(audio.mid == "0")
+        #expect(audio.direction == .sendonly)
+        #expect(audio.payload(forCodec: "opus") == "111")
+    }
+
+    @Test func skipsMalformedAttributeLines() throws {
+        let lines = [
+            "m=audio 9 UDP/TLS/RTP/SAVPF 111", // no session prelude
+            "a=rtpmap:111", // no value
+            "a=rtpmap: opus/48000/2", // empty payload
+            "a=fmtp:111 ", // empty config
+            "a=rtpmap:111 opus/48000/2", // valid
+        ]
+        let sdp = lines.joined(separator: "\r\n")
+        let document = SDP(parsing: sdp)
+
+        #expect(document.write() == sdp)
+        #expect(document.sessionLines.isEmpty)
+        let audio = try #require(document.mediaSections.first)
+        #expect(audio.rtpmaps == [SDPRtpmap(payload: "111", encoding: "opus/48000/2")])
+        #expect(audio.fmtps.isEmpty)
+    }
+
+    @Test func rtpmapCodecFallsBackToRawEncoding() {
+        #expect(SDPRtpmap(payload: "96", encoding: "/").codec == "/")
+    }
+
+    @Test func emptyMediaSectionBehavesGracefully() {
+        let section = SDPMediaSection(lines: [])
+        #expect(section.mediaType == "")
+        #expect(!section.isRTP)
+        #expect(section.direction == nil)
+    }
+
+    // MARK: - Mutation
+
+    @Test func setDirectionReplacesInPlace() throws {
+        var document = SDP(parsing: SDPFixture.dataChannel)
+        try #require(document.mediaSections.count == 2)
+        let inactiveIndex = document.mediaSections[0].lines.firstIndex(of: "a=inactive")
+
+        document.mediaSections[0].set(direction: .recvonly)
+
+        #expect(document.mediaSections[0].lines.firstIndex(of: "a=recvonly") == inactiveIndex)
+        let expected = SDPFixture.dataChannel.replacingOccurrences(of: "a=inactive", with: "a=recvonly")
+        #expect(document.write() == expected)
+    }
+
+    @Test func setDirectionAppendsWhenAbsent() throws {
+        var document = SDP(parsing: SDPFixture.simulcast)
+        try #require(document.mediaSections.count == 2)
+        #expect(document.mediaSections[0].direction == nil)
+
+        document.mediaSections[0].set(direction: .recvonly)
+
+        #expect(document.mediaSections[0].lines.last == "a=recvonly")
+        #expect(document.mediaSections[0].direction == .recvonly)
+    }
+
+    @Test func appendsFmtpParameter() throws {
+        var document = SDP(parsing: SDPFixture.jsep)
+        try #require(document.mediaSections.count == 2)
+
+        let changed = document.mediaSections[1].appendFmtpParameter("x-google-start-bitrate=1000", forPayload: "101")
+
+        #expect(changed)
+        #expect(document.mediaSections[1].fmtp(forPayload: "101")?.config == "apt=100;x-google-start-bitrate=1000")
+
+        // Exact parameter already present — no double append.
+        let changedAgain = document.mediaSections[1].appendFmtpParameter("x-google-start-bitrate=1000", forPayload: "101")
+        #expect(!changedAgain)
+        #expect(document.mediaSections[1].fmtp(forPayload: "101")?.config == "apt=100;x-google-start-bitrate=1000")
+    }
+
+    @Test(.spec("https://datatracker.ietf.org/doc/html/rfc7587#section-7.1"))
+    func appendFmtpParameterMatchesExactParameterOnly() throws {
+        // "sprop-stereo=1" must not satisfy a check for "stereo=1" — RFC 7587 defines
+        // them as distinct parameters (sender capability vs receiver preference).
+        // Deliberate non-parity: client-sdk-js uses a substring check and skips the
+        // append when only sprop-stereo=1 is present.
+        var document = SDP(parsing: SDPFixture.dataChannel)
+        try #require(document.mediaSections.count == 2)
+        document.mediaSections[0].appendFmtpParameter("sprop-stereo=1", forPayload: "111")
+
+        let changed = document.mediaSections[0].appendFmtpParameter("stereo=1", forPayload: "111")
+
+        #expect(changed)
+        #expect(document.mediaSections[0].fmtp(forPayload: "111")?.config
+            == "minptime=10;useinbandfec=1;sprop-stereo=1;stereo=1")
+    }
+
+    @Test func appendFmtpParameterHandlesSpacePaddedConfigs() throws {
+        var document = SDP(parsing: SDPFixture.normal)
+        try #require(document.mediaSections.count == 2)
+        // Already present as "minptime=10; useinbandfec=1" — must be recognized despite padding.
+        let changed = document.mediaSections[1].appendFmtpParameter("useinbandfec=1", forPayload: "98")
+        #expect(!changed)
+    }
+
+    @Test func appendFmtpParameterWithoutFmtpLineIsNoOp() throws {
+        var document = SDP(parsing: SDPFixture.normal)
+        try #require(!document.mediaSections.isEmpty)
+        let changed = document.mediaSections[0].appendFmtpParameter("stereo=1", forPayload: "0")
+        #expect(!changed)
+        #expect(document.write() == SDPFixture.normal)
+    }
+
+    @Test func appendsLineAtEndOfSection() throws {
+        var document = SDP(parsing: SDPFixture.jsep)
+        try #require(!document.mediaSections.isEmpty)
+
+        document.mediaSections[0].append(line: "a=rtcp-fb:96 nack")
+
+        let lines = document.write().components(separatedBy: "\n")
+        let appendedIndex = lines.firstIndex(of: "a=rtcp-fb:96 nack")
+        let videoMLineIndex = lines.firstIndex { $0.hasPrefix("m=video") }
+        #expect(appendedIndex != nil)
+        #expect(appendedIndex.map { $0 + 1 } == videoMLineIndex)
+    }
+}

--- a/Tests/LiveKitCoreTests/SDP/TransportMungeFallbackTests.swift
+++ b/Tests/LiveKitCoreTests/SDP/TransportMungeFallbackTests.swift
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+import LiveKitWebRTC
+import Testing
+
+/// Runs against a real (local, offline) peer connection to prove the fallback premise
+/// on the shipped libwebrtc binary: a rejected `setLocalDescription` reports an error
+/// without poisoning the peer connection, so retrying with the original SDP works.
+@Suite(.tags(.media))
+struct TransportMungeFallbackTests {
+    private final class StubTransportDelegate: TransportDelegate {
+        func transport(_: Transport, didUpdateState _: LKRTCPeerConnectionState) {}
+        func transport(_: Transport, didGenerateIceCandidate _: IceCandidate) {}
+        func transport(_: Transport, didOpenDataChannel _: LKRTCDataChannel) {}
+        func transport(_: Transport, didAddTrack _: LKRTCMediaStreamTrack, rtpReceiver _: LKRTCRtpReceiver, streams _: [LKRTCMediaStream]) {}
+        func transport(_: Transport, didRemoveTrack _: LKRTCMediaStreamTrack) {}
+        func transportShouldNegotiate(_: Transport) {}
+    }
+
+    /// Runs `body` with a live transport, closing it even when `body` throws so a
+    /// failed test doesn't leak a peer connection into the rest of the parallel run.
+    private func withTransport(_ body: (Transport) async throws -> Void) async throws {
+        let transport = try Transport(config: .liveKitDefault(),
+                                      target: .publisher,
+                                      primary: true,
+                                      delegate: StubTransportDelegate())
+        do {
+            try await body(transport)
+        } catch {
+            await transport.close()
+            throw error
+        }
+        await transport.close()
+    }
+
+    @Test func rejectedLocalDescriptionLeavesPeerConnectionUsable() async throws {
+        try await withTransport { transport in
+            let offer = try await transport.createOffer()
+            let garbage = RTC.createSessionDescription(type: .offer, sdp: "this is not sdp")
+
+            await #expect(throws: (any Error).self) {
+                try await transport.set(localDescription: garbage)
+            }
+            try await transport.set(localDescription: offer)
+        }
+    }
+
+    @Test func fallsBackToOriginalWhenMungedDescriptionIsRejected() async throws {
+        try await withTransport { transport in
+            let offer = try await transport.createOffer()
+            let garbage = RTC.createSessionDescription(type: .offer, sdp: "this is not sdp")
+
+            let applied = try await transport.set(mungedLocalDescription: garbage, fallingBackTo: offer)
+
+            #expect(applied.sdp == offer.sdp)
+        }
+    }
+
+    @Test func appliesMungedDescriptionWhenAccepted() async throws {
+        try await withTransport { transport in
+            let offer = try await transport.createOffer()
+            let munged = RTC.createSessionDescription(type: offer.type, sdp: offer.sdp)
+
+            let applied = try await transport.set(mungedLocalDescription: munged, fallingBackTo: offer)
+
+            #expect(applied === munged)
+        }
+    }
+}

--- a/Tests/LiveKitCoreTests/SDP/TransportSDPMungeTests.swift
+++ b/Tests/LiveKitCoreTests/SDP/TransportSDPMungeTests.swift
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+import Testing
+
+@Suite(.tags(.media))
+struct TransportSDPMungeTests {
+    /// Session-level `a=inactive`, an inactive RTP audio section, an active video
+    /// section, and an inactive non-RTP data channel section.
+    private static let offer = """
+    v=0
+    o=- 0 0 IN IP4 127.0.0.1
+    s=-
+    t=0 0
+    a=inactive
+    a=group:BUNDLE 0 1 2
+    m=audio 9 UDP/TLS/RTP/SAVPF 111
+    a=mid:0
+    a=rtpmap:111 opus/48000/2
+    a=inactive
+    m=video 9 UDP/TLS/RTP/SAVPF 96
+    a=mid:1
+    a=rtpmap:96 VP8/90000
+    a=sendrecv
+    m=application 9 UDP/DTLS/SCTP webrtc-datachannel
+    a=mid:2
+    a=inactive
+    """.replacingOccurrences(of: "\n", with: "\r\n") + "\r\n"
+
+    @Test func convertsInactiveToRecvOnlyInRTPSectionsOnly() {
+        let munged = Transport.mungeInactiveToRecvOnlyForMedia(Self.offer)
+        let sections = SDP(parsing: munged)
+
+        #expect(sections.mediaSections.map(\.direction) == [.recvonly, .sendrecv, .inactive])
+        // Session-level line is not a media direction — must be untouched.
+        #expect(sections.sessionLines.contains("a=inactive"))
+    }
+
+    @Test func preservesEOLStyleAndTrailingNewline() {
+        let munged = Transport.mungeInactiveToRecvOnlyForMedia(Self.offer)
+
+        #expect(munged == Self.offer.replacingOccurrences(of: "a=inactive\r\nm=video", with: "a=recvonly\r\nm=video"))
+        #expect(munged.hasSuffix("\r\n"))
+    }
+
+    @Test func leavesSDPWithoutInactiveSectionsIdentical() {
+        let sdp = Self.offer.replacingOccurrences(of: "a=inactive", with: "a=recvonly")
+        #expect(Transport.mungeInactiveToRecvOnlyForMedia(sdp) == sdp)
+    }
+}


### PR DESCRIPTION
Adds an internal `SDP` module (`Sources/LiveKit/Support/SDP/`) — a lossless, line-oriented SDP document model with typed accessors for only the attributes we munge (mid, direction, rtpmap, fmtp). Every other line passes through verbatim, so `parse ∘ write` is the identity for any input. The existing munging (`mungeInactiveToRecvOnlyForMedia`) is migrated onto it; PR #1068 and the start-bitrate work can follow.

Also adds a munge fallback: libwebrtc m144 actively validates munged SDP and can reject it outright (`IsSdpMungingAllowed`, expanding via field-trial kill switches; our munges are tracked upstream as `kDirection` / `kAudioCodecsFmtpOpusStereo`). Rejection happens before apply and leaves the peer connection untouched, so `Transport` now retries with the unmunged offer instead of failing negotiation — proven against a real peer connection in `TransportMungeFallbackTests`.

Tests: fixtures ported from sdp-transform's suite (MIT) plus crafted ones (data channel, unknown lines, malformed lines); 28 tests, 100% line coverage of `SDP.swift`.

Resolves CLT-3189.

### Differences from client-sdk-js (sdp-transform) behavior — all deliberate
- Exact-token fmtp parameter matching: JS uses a substring check, so an existing `sprop-stereo=1` defeats adding `stereo=1`; we match exact parameters.
- Uniformly case-insensitive codec lookup (RFC 4855): JS is case-insensitive for video codecs but exact-match for opus.
- `mid` is always a `String`: sdp-transform parses numeric mids as numbers (the reason for JS's `getMidString` workaround).
- Unknown lines are preserved verbatim and in place: sdp-transform drops unknown line types (e.g. `y=`) and re-emits unknown `a=` lines after the recognized ones.
- Round-trip is byte-exact including EOL style (`\r\n`/`\n`/`\r`): sdp-transform rewrites lines in canonical order.

### Parser alternatives considered
- **Parser generated from the spec (ANTLR etc.)** — SDP is line-oriented with attribute-value grammars scattered across many RFCs; generated parsers are strict where munging must be lenient, and the runtime is a new dependency.
- **Existing Swift SDP libraries** — nothing adoptable: abandoned, incomplete, or unlicensed.
- **Rust crate via LiveKitUniFFI** — best candidate measured ~286 KB compiled (over the size budget), adds release coupling with rust-sdks, and marshaling a mutable document model across FFI is clumsy for ops this small.
- **Full Swift port of sdp-transform** (grammar table + writer + fixture suite) — viable, but 51 of its 64 grammar rules cover attributes we never touch, and its writer reorders output. This remains the escalation path if our typed accessors grow past ~15 line kinds; the fixture suite carries over unchanged.