### PR TITLE
Update WebRTC to 144.7559.13

### DIFF
--- a/LiveKitClient.podspec
+++ b/LiveKitClient.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |spec|
   # identifier wherever those sources compile.
   spec.pod_target_xcconfig = {"SWIFT_PACKAGE_NAME" => "livekit_client_sdk_swift"}
 
-  spec.dependency("LiveKitWebRTC", "= 144.7559.11")
+  spec.dependency("LiveKitWebRTC", "= 144.7559.13")
   spec.dependency("LiveKitUniFFI", "= 0.0.6")
 
   spec.resource_bundles = {"Privacy" => ["Sources/LiveKit/PrivacyInfo.xcprivacy"]}

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "144.7559.11"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "144.7559.13"),
         .package(url: "https://github.com/livekit/livekit-uniffi-xcframework.git", exact: "0.0.6"),
         // Test-only: conformance oracle for the nanopb facades.
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.0"),

--- a/Package@swift-6.2.swift
+++ b/Package@swift-6.2.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
-        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "144.7559.11"),
+        .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "144.7559.13"),
         .package(url: "https://github.com/livekit/livekit-uniffi-xcframework.git", exact: "0.0.6"),
         // Test-only: conformance oracle for the nanopb facades.
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.0"),

--- a/Sources/LiveKit/Audio/AudioDeviceModuleDelegateAdapter.swift
+++ b/Sources/LiveKit/Audio/AudioDeviceModuleDelegateAdapter.swift
@@ -40,7 +40,10 @@ class AudioDeviceModuleDelegateAdapter: NSObject, LKRTCAudioDeviceModuleDelegate
         return entryPoint?.engineDidCreate(engine) ?? 0
     }
 
-    func audioDeviceModule(_: LKRTCAudioDeviceModule, willEnableEngine engine: AVAudioEngine, isPlayoutEnabled: Bool, isRecordingEnabled: Bool) -> Int {
+    func audioDeviceModule(_: LKRTCAudioDeviceModule, willEnableEngine engine: AVAudioEngine, isPlayoutEnabled: Bool, isRecordingEnabled: Bool, isVoiceProcessingEnabled _: Bool) -> Int {
+        // isVoiceProcessingEnabled is new in the ADM delegate (webrtc-sdk
+        // PR 275). Ignored for now, exposing it through AudioEngineObserver
+        // is a separate API addition.
         guard let audioManager else { return 0 }
         let entryPoint = audioManager.buildEngineObserverChain()
         return entryPoint?.engineWillEnable(engine, isPlayoutEnabled: isPlayoutEnabled, isRecordingEnabled: isRecordingEnabled) ?? 0


### PR DESCRIPTION
Fixes #1074 — picks up the WebRTC-side change so that TURN/TLS falls back to the operating system's trust store when the anchors compiled into WebRTC yield no path, which they do not for AWS ACM or Let's Encrypt.