### PR TITLE
Fix data races on Room's lazy member initialization

### DIFF
--- a/.changes/fix-outgoing-stream-manager-race
+++ b/.changes/fix-outgoing-stream-manager-race
@@ -1,1 +1,0 @@
-patch type="fixed" "Fix a data race on Room.outgoingStreamManager: unsynchronized lazy initialization could run twice under concurrent first access, leaking or deallocating one instance mid-use"

--- a/.changes/fix-outgoing-stream-manager-race
+++ b/.changes/fix-outgoing-stream-manager-race
@@ -1,0 +1,1 @@
+patch type="fixed" "Fix a data race on Room.outgoingStreamManager: unsynchronized lazy initialization could run twice under concurrent first access, leaking or deallocating one instance mid-use"

--- a/.changes/fix-room-lazy-init-race
+++ b/.changes/fix-room-lazy-init-race
@@ -1,0 +1,1 @@
+patch type="fixed" "Fix data races on Room's lazily initialized members (localParticipant, data channels, outgoingStreamManager, preConnectBuffer, metricsManager): concurrent first access could run a lazy initializer twice; they are now initialized eagerly in Room's initializer"

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -32,7 +32,7 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
 
     // MARK: - Metrics
 
-    lazy var metricsManager = MetricsManager()
+    let metricsManager = MetricsManager()
 
     // MARK: - Public
 
@@ -123,24 +123,10 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
     lazy var publisherDataChannel = DataChannelPair(delegate: self)
 
     let incomingStreamManager = IncomingStreamManager()
-    private let _outgoingStreamManager = StateSync<OutgoingStreamManager?>(nil)
-
-    // Lazy properties are not initialized atomically, and this manager is
-    // reachable from isolation domains that do not serialize with each
-    // other (RPC client/server managers and app calls into
-    // LocalParticipant data stream methods), so initialization is guarded
-    // by the same StateSync pattern used for _e2eeManager.
-    var outgoingStreamManager: OutgoingStreamManager {
-        _outgoingStreamManager.mutate { state in
-            if let existing = state { return existing }
-            let manager = OutgoingStreamManager { [weak self] packet in
-                try await self?.send(dataPacket: packet)
-            } encryptionProvider: { [weak self] in
-                self?.e2eeManager?.dataChannelEncryptionType ?? .none
-            }
-            state = manager
-            return manager
-        }
+    lazy var outgoingStreamManager = OutgoingStreamManager { [weak self] packet in
+        try await self?.send(dataPacket: packet)
+    } encryptionProvider: { [weak self] in
+        self?.e2eeManager?.dataChannelEncryptionType ?? .none
     }
 
     // MARK: - PreConnect
@@ -283,6 +269,19 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
         super.init()
         // log sdk & os versions
         log("sdk: \(LiveKitSDK.version), ffi: \(LiveKitSDK.ffiVersion), os: \(String(describing: Utils.os()))(\(Utils.osVersionString())), modelId: \(String(describing: Utils.modelIdentifier() ?? "unknown"))")
+
+        // Force initialization of lazy members while `self` is still exclusively
+        // owned by this initializer. Lazy initialization is not atomic, and these
+        // members are reachable from isolation domains that do not serialize with
+        // each other, so a first touch after init could otherwise run an
+        // initializer twice. After this block every access is a plain read of
+        // already-initialized storage. The members stay `lazy` only because their
+        // initializers capture `self`, which a stored property cannot do.
+        _ = localParticipant
+        _ = subscriberDataChannel
+        _ = publisherDataChannel
+        _ = outgoingStreamManager
+        _ = preConnectBuffer
 
         signalClient._delegate.set(delegate: self)
 

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -123,10 +123,24 @@ public class Room: NSObject, @unchecked Sendable, ObservableObject, Loggable {
     lazy var publisherDataChannel = DataChannelPair(delegate: self)
 
     let incomingStreamManager = IncomingStreamManager()
-    lazy var outgoingStreamManager = OutgoingStreamManager { [weak self] packet in
-        try await self?.send(dataPacket: packet)
-    } encryptionProvider: { [weak self] in
-        self?.e2eeManager?.dataChannelEncryptionType ?? .none
+    private let _outgoingStreamManager = StateSync<OutgoingStreamManager?>(nil)
+
+    // Lazy properties are not initialized atomically, and this manager is
+    // reachable from isolation domains that do not serialize with each
+    // other (RPC client/server managers and app calls into
+    // LocalParticipant data stream methods), so initialization is guarded
+    // by the same StateSync pattern used for _e2eeManager.
+    var outgoingStreamManager: OutgoingStreamManager {
+        _outgoingStreamManager.mutate { state in
+            if let existing = state { return existing }
+            let manager = OutgoingStreamManager { [weak self] packet in
+                try await self?.send(dataPacket: packet)
+            } encryptionProvider: { [weak self] in
+                self?.e2eeManager?.dataChannelEncryptionType ?? .none
+            }
+            state = manager
+            return manager
+        }
     }
 
     // MARK: - PreConnect


### PR DESCRIPTION
## Problem

`Room.outgoingStreamManager` is an unsynchronized `lazy var` (Sources/LiveKit/Core/Room.swift). Swift does not guarantee once-only initialization for lazy stored properties under concurrent first access.

The property is reachable from isolation domains that do not serialize with each other:

- `RpcClientManager` (actor), via `LocalParticipant.streamText`, when sending RPC requests over data streams,
- `RpcServerManager` (actor), via `LocalParticipant.streamText`, when writing RPC responses to inbound RPCs,
- application code calling `LocalParticipant.sendText` / `sendFile` / `streamText` / `streamBytes`.

`LocalParticipant` is a plain class, so nothing orders these first touches. Thread Sanitizer reports the race in a live session where two concurrent stream sends hit the getter from two GCD worker threads (8-byte read/write race on the same slot, allocation site in `Room.init`; full TSan report available on request).

The same holds for `Room`'s other lazy members (`localParticipant`, `subscriberDataChannel`, `publisherDataChannel`, `preConnectBuffer`), each reachable from multiple isolation domains.

## Impact

Depending on interleaving, the losing `OutgoingStreamManager` instance either leaks while both instances keep working (benign), or is deallocated after a caller already captured it. `Destination.manager` holds the manager weakly, so a stream that already published its header can fail its first write with `StreamError.terminated`, leaving a half-open stream on the remote side.

## Fix

Eagerly initialize every lazy member of `Room` in `init`, while `self` is still exclusively owned by the initializer, so no lazy initializer can ever run concurrently. After init, every access is a plain read of already-initialized storage.

- `metricsManager` doesn't capture `self`, so it becomes a plain `let`.
- `localParticipant`, `subscriberDataChannel`, `publisherDataChannel`, `outgoingStreamManager`, and `preConnectBuffer` capture `self` in their initializers, which a stored property can't do; they stay `lazy` syntactically and are forced with `_ =` at the top of `init`, before `self` escapes (signal client delegate, app-state listener, metrics registration task).

## Notes

- #1075 replaces the stream managers entirely; this is a minimal fix for the current main / release line until that lands.
- Same-shape sites elsewhere, not changed here to keep this minimal (may be relevant to the broader `Room` DI work): `DeviceManager.discoverySession` (iOS/tvOS: two utility-queue blocks dispatched from `init` both first-touch it concurrently), `AudioManager.capturePostProcessingDelegateAdapter` / `renderPreProcessingDelegateAdapter` (public delegate setters and renderer add/remove APIs callable from arbitrary threads), `CameraCapturer.capturer` / `adapter` (public `captureSession` and multitasking accessors vs. the capture start path), and a narrow window on `E2EEManager.delegateAdapter` (`setup(room:)` iterating publications on the connect task vs. room-delegate-queue callbacks; `setup` adds the delegate before iterating). The lazy members of `SignalClient`, `Transport`, and `TranscriptionStreamReceiver` are actor-isolated and fine.
