### PR TITLE
Apply signal responses in the order the server sent them

### DIFF
--- a/.changes/signal-response-order
+++ b/.changes/signal-response-order
@@ -1,0 +1,1 @@
+patch type="fixed" "Apply signal messages in the order the server sent them: responses no longer overtake each other between the socket and the room, so participant, track and room updates cannot settle on a stale value"

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -340,14 +340,14 @@ private extension SignalClient {
         default: break
         }
 
-        Task.detached {
-            let alwaysProcess = switch response.message {
-            case .join, .reconnect, .leave: true
-            default: false
-            }
-            // Always process join or reconnect messages even if suspended...
-            await self._responseQueue.processIfResumed((response: response, encoded: rawData), or: alwaysProcess)
+        let alwaysProcess = switch response.message {
+        case .join, .reconnect, .leave: true
+        default: false
         }
+        // Awaited in place so responses enter the queue in socket order; a task per message would
+        // race to the queue actor. Nothing in `_process` waits on the network or on a later
+        // message, so the loop is not held up. Join, reconnect and leave bypass a suspended queue.
+        await _responseQueue.processIfResumed((response: response, encoded: rawData), or: alwaysProcess)
     }
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -109,20 +109,13 @@ actor SignalClient: Loggable {
         // Tracks whether the v0 signal path (/rtc) is in use, set during connect.
         // Reused by reconnect to avoid re-attempting the unsupported v1 path.
         var useV0SignalPath: Bool = false
+        // Advanced when `cleanUp` finishes. A message loop carries the value of its connection and
+        // the data-track notifications it queues check it at delivery, so a response from a
+        // torn-down connection is dropped instead of applied to the next.
+        var connectionGeneration = 0
     }
 
     let _state = StateSync(State())
-
-    // The data-track managers parse signal responses themselves, so the ones they consume are
-    // forwarded as raw protobuf bytes. They drain through a single consumer task per connection,
-    // so the managers see them in wire order — a detached task per message could reorder e.g. a
-    // publish/unpublish response pair. The path deliberately bypasses `_responseQueue`: the
-    // managers own their reconnect semantics (republish, subscription re-requests, sync state)
-    // and consume wire order directly. Connection-scoped — started in `connect`, stopped in
-    // `cleanUp` — so messages still buffered from a dead connection are dropped, not applied to
-    // the next.
-    private var _dataTrackResponses: AsyncStream<Data>.Continuation?
-    private var _dataTrackResponsesConsumer: AnyTaskCancellable?
 
     // Requests the SFU answers by echoing an id, keyed by it. The counter is shared so ids stay
     // unique per connection; data blobs are the only user today. (Data track publishes also
@@ -191,10 +184,9 @@ actor SignalClient: Loggable {
                                              connectOptions: connectOptions)
             connectSpan?.record("ws_open")
 
-            startDataTrackResponses()
-
+            let generation = _state.connectionGeneration
             let messageLoopTask = socket.subscribe(self) { observer, message in
-                await observer.onWebSocketMessage(message)
+                await observer.onWebSocketMessage(message, generation: generation)
             } onFailure: { observer, error in
                 await observer.cleanUp(withError: error)
             }
@@ -293,11 +285,11 @@ actor SignalClient: Loggable {
         _dataBlobCompleters.removeAll()
         await _requestQueue.clear()
         await _responseQueue.clear()
-        stopDataTrackResponses()
 
         _state.mutate {
             $0.disconnectError = LiveKitError.from(error: disconnectError)
             $0.connectionState = .disconnected
+            $0.connectionGeneration += 1
         }
     }
 }
@@ -315,27 +307,7 @@ private extension SignalClient {
         await _requestQueue.processIfResumed(request, elseEnqueue: request.canBeQueued())
     }
 
-    /// Starts delivering data-track responses for a new connection; see the property note.
-    func startDataTrackResponses() {
-        let (responses, continuation) = AsyncStream.makeStream(of: Data.self)
-        _dataTrackResponses = continuation
-        _dataTrackResponsesConsumer = Task { [weak self] in
-            for await data in responses {
-                guard let self else { break }
-                try? await _delegate.notifyAsync { await $0.signalClient(self, didReceiveDataTrackResponse: data) }
-            }
-        }.cancellable()
-    }
-
-    /// Stops delivery and drops anything still buffered from the connection being torn down
-    /// (releasing the consumer cancels it; finishing alone would let it drain the backlog).
-    func stopDataTrackResponses() {
-        _dataTrackResponses?.finish()
-        _dataTrackResponses = nil
-        _dataTrackResponsesConsumer = nil
-    }
-
-    func onWebSocketMessage(_ message: URLSessionWebSocketTask.Message) async {
+    func onWebSocketMessage(_ message: URLSessionWebSocketTask.Message, generation: Int) async {
         // The server mirrors the client's encoding and this SDK has sent
         // binary protobuf since 2021, so text (JSON) frames cannot occur
         // against livekit-server; they are unsupported here (as on Android).
@@ -351,12 +323,20 @@ private extension SignalClient {
             return
         }
 
-        // Forward only what the data-track managers consume; every other message would cross the
-        // FFI boundary just to be rejected as an unsupported type. `requestResponse` carries
-        // publish request errors, so it belongs here even though it isn't data-track-specific.
+        // The data-track managers parse signal responses themselves, so the ones they consume are
+        // forwarded as raw protobuf bytes. Only those: every other message would cross the FFI
+        // boundary just to be rejected as an unsupported type. `requestResponse` carries publish
+        // request errors, so it belongs here even though it isn't data-track-specific. The path
+        // deliberately bypasses `_responseQueue`: the managers own their reconnect semantics
+        // (republish, subscription re-requests, sync state) and consume wire order directly. A
+        // response still queued when its connection is torn down is dropped at delivery, not
+        // applied to the next.
         switch response.message {
         case .requestResponse, .publishDataTrackResponse, .dataTrackSubscriberHandles:
-            _dataTrackResponses?.yield(rawData)
+            _delegate.notifyDetached { delegate in
+                guard self._state.connectionGeneration == generation else { return }
+                await delegate.signalClient(self, didReceiveDataTrackResponse: rawData)
+            }
         default: break
         }
 
@@ -388,11 +368,11 @@ private extension SignalClient {
             // `SignalResponse`, and this is kept for the whole session
             _state.mutate { $0.lastJoinResponse = joinResponse.owned() }
             // The encoded form second: consumers that parse the wire format themselves must see
-            // it only once the room has applied the decoded one. Ordered but not awaited — this
-            // runs on the response queue, so waiting here would put app delegate code in front
-            // of every later signal message.
-            _delegate.notifyDetached(inOrder: { await $0.signalClient(self, didReceiveConnectResponse: .join(joinResponse)) },
-                                     { await $0.signalClient(self, didReceiveEncodedResponse: .join(encoded)) })
+            // it only once the room has applied the decoded one. Not awaited: this runs on the
+            // response queue, so waiting here would put app delegate code in front of every later
+            // signal message.
+            _delegate.notifyDetached { await $0.signalClient(self, didReceiveConnectResponse: .join(joinResponse)) }
+            _delegate.notifyDetached { await $0.signalClient(self, didReceiveEncodedResponse: .join(encoded)) }
             _connectResponseCompleter.resume(returning: .join(joinResponse))
             await _restartPingTimer()
 
@@ -417,8 +397,8 @@ private extension SignalClient {
             _delegate.notifyDetached { await $0.signalClient(self, didReceiveIceCandidate: rtcCandidate.toLKType(), target: trickle.target) }
 
         case let .update(update):
-            _delegate.notifyDetached(inOrder: { await $0.signalClient(self, didUpdateParticipants: update.participants) },
-                                     { await $0.signalClient(self, didReceiveEncodedResponse: .participantUpdate(encoded)) })
+            _delegate.notifyDetached { await $0.signalClient(self, didUpdateParticipants: update.participants) }
+            _delegate.notifyDetached { await $0.signalClient(self, didReceiveEncodedResponse: .participantUpdate(encoded)) }
 
         case let .roomUpdate(update):
             _delegate.notifyDetached { await $0.signalClient(self, didUpdateRoom: update.room) }

--- a/Sources/LiveKit/Support/Async/AsyncSerialDelegate.swift
+++ b/Sources/LiveKit/Support/Async/AsyncSerialDelegate.swift
@@ -16,42 +16,46 @@
 
 import Foundation
 
+/// Delivers notifications to one weakly held delegate, one at a time, in call order: every
+/// notification joins a single FIFO drained by one consumer task, so calls made in sequence reach
+/// the delegate in that sequence.
 final class AsyncSerialDelegate<T: Sendable>: Sendable {
     private struct State {
         weak var delegate: AnyObject?
     }
 
-    private let _state = StateSync(State())
-    private let _serialRunner = SerialRunnerActor<Void>()
+    private typealias Notify = @Sendable (T) async -> Void
+
+    private let _state: StateSync<State>
+    private let _notifications: AsyncStream<Notify>.Continuation
+
+    init() {
+        let state = StateSync(State())
+        let (notifications, continuation) = AsyncStream.makeStream(of: Notify.self)
+        _state = state
+        _notifications = continuation
+        // Captures the state and the stream, not self, so it cannot keep this object alive. It
+        // ends on its own once `deinit` finishes the stream and what was queued has been delivered;
+        // cancelling it instead would run those last deliveries on a cancelled task.
+        Task.detached {
+            for await notify in notifications {
+                guard let delegate = state.read({ $0.delegate }) as? T else { continue }
+                await notify(delegate)
+            }
+        }
+    }
+
+    deinit {
+        _notifications.finish()
+    }
 
     func set(delegate: T) {
         _state.mutate { $0.delegate = delegate as AnyObject }
     }
 
-    func notifyAsync(_ fnc: sending @escaping (T) async -> Void) async throws {
-        guard let delegate = _state.read({ $0.delegate }) as? T else { return }
-        try await _serialRunner.run {
-            await fnc(delegate)
-        }
-    }
-
+    /// Queues `fnc` behind every notification queued before it and returns at once. Skipped if the
+    /// delegate is gone by the time its turn comes.
     func notifyDetached(_ fnc: @Sendable @escaping (T) async -> Void) {
-        Task.detachedDiscarding {
-            try await self.notifyAsync(fnc)
-        }
-    }
-
-    /// Notifies in the given order, without waiting for any of it.
-    ///
-    /// One task awaiting each in turn, because a `notifyDetached` per closure would not order
-    /// them: each races to the serial runner in a task of its own. Use when a consumer must see
-    /// one notification only after another — and prefer it to awaiting `notifyAsync` from a
-    /// caller that shouldn't block, such as the signal response queue.
-    func notifyDetached(inOrder fncs: (@Sendable (T) async -> Void)...) {
-        Task.detachedDiscarding {
-            for fnc in fncs {
-                try await self.notifyAsync(fnc)
-            }
-        }
+        _notifications.yield(fnc)
     }
 }

--- a/Sources/LiveKit/Support/Schedulers/QueueActor.swift
+++ b/Sources/LiveKit/Support/Schedulers/QueueActor.swift
@@ -33,6 +33,7 @@ actor QueueActor<T: Sendable>: Loggable {
     // MARK: - Private
 
     private var queue = [T]()
+    private var isDraining = false
     private let onProcess: OnProcess
 
     init(onProcess: @escaping OnProcess) {
@@ -45,8 +46,14 @@ actor QueueActor<T: Sendable>: Loggable {
     }
 
     /// Only process if `.resumed` state, otherwise enqueue.
+    ///
+    /// While `resume()` is still draining, a value that may be enqueued joins the tail of the
+    /// queue instead of running ahead of the older ones; a value that may not (`elseEnqueue ==
+    /// false`) is processed at once, as it is whenever the state is `.resumed`. `condition`
+    /// bypasses the queue either way, for values that must never wait.
     func processIfResumed(_ value: T, or condition: Bool = false, elseEnqueue: Bool = true) async {
-        await process(value, if: state == .resumed || condition, elseEnqueue: elseEnqueue)
+        let isResumed = state == .resumed && !(isDraining && elseEnqueue)
+        await process(value, if: isResumed || condition, elseEnqueue: elseEnqueue)
     }
 
     /// Only process if `condition` is true, otherwise enqueue.
@@ -67,15 +74,20 @@ actor QueueActor<T: Sendable>: Loggable {
         state = .suspended
     }
 
-    /// Mark as `.resumed` and process each element with an async `block`.
+    /// Mark as `.resumed` and process the queued elements in arrival order, one at a time.
+    ///
+    /// The loop re-reads the live queue, so it also processes what arrives while it runs (see
+    /// `processIfResumed`), and it stops when `clear()` or `suspend()` changes the state. A
+    /// `resume()` that finds a drain already running returns after marking the state: that drain
+    /// will reach every queued element, and a second loop would put two elements in flight.
     func resume() async {
         state = .resumed
-        if queue.isEmpty { return }
-        for element in queue {
-            // Check cancellation before processing next block...
-            // try Task.checkCancellation()
+        guard !isDraining else { return }
+        isDraining = true
+        defer { isDraining = false }
+        while state == .resumed, !queue.isEmpty {
+            let element = queue.removeFirst()
             await onProcess(element)
         }
-        queue.removeAll()
     }
 }

--- a/Tests/LiveKitCoreTests/AsyncSerialDelegateTests.swift
+++ b/Tests/LiveKitCoreTests/AsyncSerialDelegateTests.swift
@@ -18,6 +18,7 @@ import Foundation
 @testable import LiveKit
 import Testing
 
+@Suite(.tags(.concurrency))
 struct AsyncSerialDelegateTests {
     final class Recorder: Sendable {
         let calls = StateSync<[Int]>([])
@@ -31,59 +32,69 @@ struct AsyncSerialDelegateTests {
         }
     }
 
-    /// Each batch is delivered in the order given. Only the guarantee is asserted: batches race
-    /// each other, so the relative order *within* a batch is what callers can rely on.
+    /// Calls made in sequence are delivered in that sequence.
     @Test
-    func notifyDetachedInOrderDeliversInOrder() async throws {
+    func deliversInCallOrder() async throws {
         let delegate = AsyncSerialDelegate<Recorder>()
         let recorder = Recorder()
         delegate.set(delegate: recorder)
 
-        let batches = 50
-        for batch in 0 ..< batches {
-            delegate.notifyDetached(inOrder: { $0.record(batch * 2) },
-                                    { $0.record(batch * 2 + 1) })
+        let count = 2000
+        for value in 0 ..< count {
+            delegate.notifyDetached { $0.record(value) }
         }
 
-        try await waitForCalls(recorder, count: batches * 2)
-        let calls = recorder.calls.copy()
-        #expect(calls.count == batches * 2)
-
-        for batch in 0 ..< batches {
-            let first = try #require(calls.firstIndex(of: batch * 2), "Missing first call of batch \(batch)")
-            let second = try #require(calls.firstIndex(of: batch * 2 + 1), "Missing second call of batch \(batch)")
-            #expect(first < second, "Batch \(batch) was delivered out of order")
-        }
+        try await waitForCalls(recorder, count: count)
+        #expect(recorder.calls.copy() == Array(0 ..< count))
     }
 
-    /// A batch waits for the previous notification to finish, so a slow one can't be overtaken.
+    /// A slow notification holds the ones queued after it; nothing overtakes it.
     @Test
-    func notifyDetachedInOrderWaitsForSlowNotifications() async throws {
+    func waitsForSlowNotifications() async throws {
         let delegate = AsyncSerialDelegate<Recorder>()
         let recorder = Recorder()
         delegate.set(delegate: recorder)
 
-        delegate.notifyDetached(inOrder: { recorder in
+        delegate.notifyDetached { recorder in
             try? await Task.sleep(nanoseconds: 300_000_000)
             recorder.record(0)
-        }, { $0.record(1) })
+        }
+        delegate.notifyDetached { $0.record(1) }
+        delegate.notifyDetached { $0.record(2) }
 
-        try await waitForCalls(recorder, count: 2)
-        #expect(recorder.calls.copy() == [0, 1])
+        try await waitForCalls(recorder, count: 3)
+        #expect(recorder.calls.copy() == [0, 1, 2])
     }
 
-    /// Nothing is delivered once the delegate is gone — it is held weakly.
+    /// Nothing is delivered once the delegate is gone; it is held weakly.
     @Test
-    func notifyDetachedInOrderDropsReleasedDelegate() async throws {
+    func dropsReleasedDelegate() async throws {
         let delegate = AsyncSerialDelegate<Recorder>()
         let recorder = Recorder()
         do {
             let transient = Recorder()
             delegate.set(delegate: transient)
         }
-        delegate.notifyDetached(inOrder: { $0.record(0) }, { $0.record(1) })
+        delegate.notifyDetached { $0.record(0) }
+        delegate.notifyDetached { $0.record(1) }
 
         try await Task.sleep(nanoseconds: 200_000_000)
         #expect(recorder.calls.copy().isEmpty)
+    }
+
+    /// Notifications queued before the object is released are still delivered.
+    @Test
+    func deliversQueueDrainedAfterRelease() async throws {
+        let recorder = Recorder()
+        do {
+            let delegate = AsyncSerialDelegate<Recorder>()
+            delegate.set(delegate: recorder)
+            for value in 0 ..< 100 {
+                delegate.notifyDetached { $0.record(value) }
+            }
+        }
+
+        try await waitForCalls(recorder, count: 100)
+        #expect(recorder.calls.copy() == Array(0 ..< 100))
     }
 }

--- a/Tests/LiveKitCoreTests/QueueActorTests.swift
+++ b/Tests/LiveKitCoreTests/QueueActorTests.swift
@@ -23,9 +23,26 @@ import LiveKitTestSupport
 
 @Suite(.tags(.concurrency))
 struct QueueActorTests {
-    private let queue = QueueActor<String> { print($0) }
+    /// Records what a queue processes and holds element 0 until the test opens `gate`, so the test
+    /// can act while a `resume()` drain is provably in progress.
+    final class Recorder: Sendable {
+        let processed = StateSync<[Int]>([])
+        let zeroStarted = Gate()
+        let gate = Gate()
+
+        func makeQueue() -> QueueActor<Int> {
+            QueueActor<Int> { [self] value in
+                if value == 0 {
+                    zeroStarted.open()
+                    await gate.wait()
+                }
+                processed.mutate { $0.append(value) }
+            }
+        }
+    }
 
     @Test func queueActor01() async {
+        let queue = QueueActor<String> { print($0) }
         await queue.processIfResumed("Value 0")
         await queue.suspend()
         await queue.processIfResumed("Value 1")
@@ -34,5 +51,78 @@ struct QueueActorTests {
         await print("Count: \(queue.count)")
         await queue.resume()
         await print("Count: \(queue.count)")
+    }
+
+    /// A value arriving while `resume()` drains the backlog is processed after it, not before.
+    @Test func arrivalsDuringDrainKeepArrivalOrder() async {
+        let recorder = Recorder()
+        let queue = recorder.makeQueue()
+        for value in 0 ..< 5 {
+            await queue.processIfResumed(value)
+        }
+        #expect(await queue.count == 5)
+
+        let drain = Task { await queue.resume() }
+        await recorder.zeroStarted.wait()
+        for value in 5 ..< 10 {
+            await queue.processIfResumed(value)
+        }
+        recorder.gate.open()
+        await drain.value
+
+        #expect(recorder.processed.copy() == Array(0 ..< 10))
+        #expect(await queue.count == 0)
+    }
+
+    /// A value that may not be enqueued is not held back by a drain.
+    @Test func nonQueueableValuesBypassTheDrain() async {
+        let recorder = Recorder()
+        let queue = recorder.makeQueue()
+        await queue.processIfResumed(0)
+        await queue.processIfResumed(1)
+
+        let drain = Task { await queue.resume() }
+        await recorder.zeroStarted.wait()
+        await queue.processIfResumed(2, elseEnqueue: false)
+        recorder.gate.open()
+        await drain.value
+
+        #expect(recorder.processed.copy() == [2, 0, 1])
+    }
+
+    /// A second `resume()` during a drain neither duplicates nor interleaves the backlog.
+    @Test func concurrentResumeProcessesEachElementOnce() async {
+        let recorder = Recorder()
+        let queue = recorder.makeQueue()
+        for value in 0 ..< 10 {
+            await queue.processIfResumed(value)
+        }
+
+        let drain = Task { await queue.resume() }
+        await recorder.zeroStarted.wait()
+        await queue.resume()
+        recorder.gate.open()
+        await drain.value
+
+        #expect(recorder.processed.copy() == Array(0 ..< 10))
+    }
+
+    /// `clear()` during a drain drops what is still queued and stops the drain.
+    @Test func clearStopsDrain() async {
+        let recorder = Recorder()
+        let queue = recorder.makeQueue()
+        for value in 0 ..< 10 {
+            await queue.processIfResumed(value)
+        }
+
+        let drain = Task { await queue.resume() }
+        await recorder.zeroStarted.wait()
+        await queue.clear()
+        recorder.gate.open()
+        await drain.value
+
+        #expect(recorder.processed.copy() == [0])
+        #expect(await queue.state == .suspended)
+        #expect(await queue.count == 0)
     }
 }

--- a/Tests/LiveKitTestSupport/Gate.swift
+++ b/Tests/LiveKitTestSupport/Gate.swift
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+@testable import LiveKit
+
+/// A signal that cannot be missed: `open()` may run before or after any number of `wait()` calls,
+/// and every waiter returns once it is open. Lets a test hold one step of the code under test
+/// until the test has acted. A waiter gives up after `timeout` so a broken build fails instead of
+/// hanging.
+public final class Gate: Sendable {
+    private struct State {
+        var isOpen = false
+        var waiters: [UUID: CheckedContinuation<Void, Never>] = [:]
+    }
+
+    private let _state = StateSync(State())
+
+    public init() {}
+
+    public func open() {
+        let waiters: [CheckedContinuation<Void, Never>] = _state.mutate { state in
+            state.isOpen = true
+            let waiters = Array(state.waiters.values)
+            state.waiters.removeAll()
+            return waiters
+        }
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    public func wait(timeout: TimeInterval = 10) async {
+        let id = UUID()
+        await withCheckedContinuation { continuation in
+            let isOpen: Bool = _state.mutate { state in
+                if state.isOpen { return true }
+                state.waiters[id] = continuation
+                return false
+            }
+            if isOpen {
+                continuation.resume()
+                return
+            }
+            Task {
+                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                let timedOut: CheckedContinuation<Void, Never>? = _state.mutate { state in
+                    state.waiters.removeValue(forKey: id)
+                }
+                timedOut?.resume()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Signal responses can be applied out of the order the server sent them. Three hops between the WebSocket and `Room` each fork a task per message and serialize behind the fork, so an adjacent pair of messages can swap:

1. `SignalClient.onWebSocketMessage` spawns `Task.detached` per response before the response queue actor; independent tasks reach the actor in scheduler order, and while one response's `_process` is suspended the next re-enters.
2. `QueueActor.resume()` flips to `.resumed` before its first `await`, so a response arriving mid-drain runs ahead of the queued backlog; the loop also iterates a snapshot and then `removeAll()`s, dropping what was appended during the drain, and two overlapping `resume()` calls process the snapshot twice.
3. `AsyncSerialDelegate.notifyDetached` spawns `Task.detachedDiscarding` per notification and lets them race into `SerialRunnerActor`; `_process` hands almost every message to `Room` this way (20 sites). `notifyDetached(inOrder:)` only pins the closures of one call, and the data-track responses got a consumer task of their own that awaits `notifyAsync` per message to keep that one path in wire order.

`Room` applies participant updates in delivery order and `RemoteParticipant.set(info:)` unpublishes anything missing from the update (there is no `ParticipantInfo.version` check), so an inverted pair makes a freshly published track disappear until the next update. Last-writer-wins messages (`speakersChanged`, `connectionQuality`, `streamStateUpdate`, `subscriptionPermissionUpdate`, `mute`, `roomUpdate`, `subscribedQualityUpdate`, `refreshToken`) settle on the stale value; so do successive `dataTrackSubscriberHandles` snapshots, which the manager applies entry by entry.

## Changes

- **AsyncSerialDelegate**: one `AsyncStream` FIFO drained by a single consumer task; `notifyDetached` yields, so call order is delivery order. The consumer captures only the state and the stream; `deinit` finishes the stream and the consumer ends once what was queued has been delivered. With ordering in the type, both workarounds for its absence go: `notifyDetached(inOrder:)` is removed (its two call sites issue two `notifyDetached` calls), and the data-track responses join the same FIFO straight from `onWebSocketMessage`. What the separate consumer also provided, dropping a dead connection's responses instead of applying them to the next, is kept by a connection generation: the message loop carries the value of its connection and each of those notifications checks it at delivery; `cleanUp` advances it as it finishes, so the cut-off point is the same as the old stream's. `notifyAsync` had no other caller and goes with its consumer.
- **QueueActor**: while `resume()` drains, a value that may be enqueued joins the tail (non-queueable values and `condition` bypass as before); the drain loop reads the live queue until it is empty or `clear()`/`suspend()` changes the state; a `resume()` that finds a drain running returns after marking the state.
- **SignalClient**: `onWebSocketMessage` awaits `processIfResumed` in place. The message loop already awaits per message, and nothing in `_process` waits on the network or on a later message, so the loop is not held up.

Behavior kept: join/reconnect/leave still bypass the queue; non-queueable requests are still sent immediately while suspended-or-draining; a dead connection's data-track responses are still dropped.

## Tests

- `AsyncSerialDelegateTests` (replaces the `inOrder` tests): call order across 2000 calls, slow notification not overtaken, released delegate, delivery of the queue after release.
- `QueueActorTests`: arrivals during a drain keep arrival order, non-queueable values bypass the drain, concurrent `resume()` neither duplicates nor interleaves, `clear()` stops the drain. `Gate` (test support) holds one step of the code under test.
- Against the unmodified sources, 5 of the 9 tests fail every run and one more intermittently (order lost, backlog overtaken, duplicated drain, drain not stopped); the other 3 pin unchanged behavior.

## Verification

- macOS `LiveKitCoreTests` via `xcodebuild` as in CI, against a local `livekit-server --dev` 1.13.5 with the CI config: 344/345 (the one failure is `AudioConverterTests.convertFormat`, an `ExtAudioFileOpenURL` error on this machine, identical on unmodified `main`). The data-track e2e suites (`DataTrackLifecycleTests` reconnect scenarios included) pass 32/32.
- iOS Simulator with ThreadSanitizer for `AsyncSerialDelegateTests`, `QueueActorTests`, `SerialRunnerActorTests`, `CompleterTests`: 19/19, no reports.
- swiftformat, swiftlint --strict: clean.
