### PR TITLE
Skip avoidable copies on the data packet and data stream paths

### DIFF
--- a/.changes/data-path-copies
+++ b/.changes/data-path-copies
@@ -1,0 +1,1 @@
+patch type="fixed" "Data packets and data streams no longer make avoidable copies of their payloads, and readAll() and text chunking are linear instead of quadratic in the payload"

--- a/Sources/LiveKit/Agent/Chat/Receive/TranscriptionStreamReceiver.swift
+++ b/Sources/LiveKit/Agent/Chat/Receive/TranscriptionStreamReceiver.swift
@@ -95,10 +95,15 @@ actor TranscriptionStreamReceiver: MessageReceiver, Loggable {
         // so the receiver works even if the `Room.reservedTopicPrefix` guard is
         // later widened to cover non-RPC `lk.*` topics like this one.
         try await room.incomingStreamManager.registerTextStreamHandler(for: topic, ordered: true) { [weak self] reader, participantIdentity in
+            // The attributes come from the stream header, so parse them once per stream.
+            let attributes = reader.info.attributes.mapped(to: TranscriptionAttributes.self)
+            if attributes == nil {
+                self?.log("Unable to read message attributes from \(reader.info.attributes)", .error)
+            }
             var lastMessage: ReceivedMessage?
             for try await message in reader where !message.isEmpty {
                 guard let self else { return }
-                let msg = await self.processIncoming(partialMessage: message, reader: reader, participantIdentity: participantIdentity)
+                let msg = await self.processIncoming(partialMessage: message, attributes: attributes, reader: reader, participantIdentity: participantIdentity)
                 lastMessage = msg
                 continuation.yield(msg)
             }
@@ -124,12 +129,7 @@ actor TranscriptionStreamReceiver: MessageReceiver, Loggable {
 
     /// Aggregates the incoming text into a message, storing the partial content in the `partialMessages` dictionary.
     /// - Note: When the message is finalized, or a new message is started, the dictionary is purged to limit memory usage.
-    private func processIncoming(partialMessage message: String, reader: TextStreamReader, participantIdentity: Participant.Identity) -> ReceivedMessage {
-        let attributes = reader.info.attributes.mapped(to: TranscriptionAttributes.self)
-        if attributes == nil {
-            log("Unable to read message attributes from \(reader.info.attributes)", .error)
-        }
-
+    private func processIncoming(partialMessage message: String, attributes: TranscriptionAttributes?, reader: TextStreamReader, participantIdentity: Participant.Identity) -> ReceivedMessage {
         let segmentID = attributes?.lkSegmentID ?? reader.info.id
         let participantID = participantIdentity
         let partialID = PartialMessageID(segmentID: segmentID, participantID: participantID)

--- a/Sources/LiveKit/Core/DataChannelPair.swift
+++ b/Sources/LiveKit/Core/DataChannelPair.swift
@@ -178,14 +178,14 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
 
         mutating func enqueue(_ request: PublishDataRequest) {
             queue.append(request.withoutContinuation())
-            currentAmount += UInt64(request.data.data.count)
+            currentAmount += request.byteCount
         }
 
         @discardableResult
         mutating func dequeue() -> PublishDataRequest? {
             guard !queue.isEmpty else { return nil }
             let first = queue.removeFirst()
-            currentAmount -= UInt64(first.data.data.count)
+            currentAmount -= first.byteCount
             return first
         }
 
@@ -198,11 +198,14 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
 
     private struct PublishDataRequest {
         let data: LKRTCDataBuffer
+        /// Size of `data`, kept here because `LKRTCDataBuffer.data` copies the
+        /// payload on every read.
+        let byteCount: UInt64
         let sequence: UInt32
         let continuation: CheckedContinuation<Void, any Error>?
 
         func withoutContinuation() -> Self {
-            .init(data: data, sequence: sequence, continuation: nil)
+            .init(data: data, byteCount: byteCount, sequence: sequence, continuation: nil)
         }
     }
 
@@ -372,6 +375,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
 
         return PublishDataRequest(
             data: RTC.createDataBuffer(data: bytes),
+            byteCount: UInt64(bytes.count),
             sequence: sequence,
             continuation: pending.continuation,
         )
@@ -407,7 +411,7 @@ class DataChannelPair: NSObject, @unchecked Sendable, Loggable {
             }
             // Bytes are now in WebRTC's SCTP queue; account for them so the
             // backpressure check below kicks in for subsequent iterations.
-            buffer.rtcAmount += UInt64(request.data.data.count)
+            buffer.rtcAmount += request.byteCount
             request.continuation?.resume()
 
             let event = ChannelEvent(channelKind: kind, detail: .sendDispatched(request))

--- a/Sources/LiveKit/Core/Room+EngineDelegate.swift
+++ b/Sources/LiveKit/Core/Room+EngineDelegate.swift
@@ -211,14 +211,18 @@ extension Room {
         let participant = _state.remoteParticipants[identity]
 
         if case .connected = engine._state.connectionState {
-            delegates.notify(label: { "room.didReceive data: \(packet.payload)" }) {
-                $0.room?(self, participant: participant, didReceiveData: packet.payload, forTopic: packet.topic, encryptionType: encryptionType)
+            // Proto getters copy out of nanopb storage on every read: read the
+            // payload once for all delegates.
+            let payload = packet.payload
+            let topic = packet.topic
+            delegates.notify(label: { "room.didReceive data: \(payload)" }) {
+                $0.room?(self, participant: participant, didReceiveData: payload, forTopic: topic, encryptionType: encryptionType)
             }
 
             if let participant {
-                participant.delegates.notify(label: { "participant.didReceive data: \(packet.payload)" }) { [weak participant] delegate in
+                participant.delegates.notify(label: { "participant.didReceive data: \(payload)" }) { [weak participant] delegate in
                     guard let participant else { return }
-                    delegate.participant?(participant, didReceiveData: packet.payload, forTopic: packet.topic, encryptionType: encryptionType)
+                    delegate.participant?(participant, didReceiveData: payload, forTopic: topic, encryptionType: encryptionType)
                 }
             }
         }

--- a/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
+++ b/Sources/LiveKit/DataStream/Incoming/IncomingStreamManager.swift
@@ -255,7 +255,11 @@ actor IncomingStreamManager: Loggable {
 
     /// Handles a data stream chunk.
     private func handle(chunk: Livekit_DataStream.Chunk, encryptionType: EncryptionType) {
-        guard !chunk.content.isEmpty, let descriptor = openStreams[chunk.streamID] else { return }
+        // Proto getters copy out of nanopb storage on every read: read the
+        // payload and the ID once.
+        let content = chunk.content
+        let streamID = chunk.streamID
+        guard !content.isEmpty, let descriptor = openStreams[streamID] else { return }
 
         // Error paths remove the descriptor synchronously for the same reason as
         // the trailer path: a header reusing this stream ID may be the next event.
@@ -264,29 +268,30 @@ actor IncomingStreamManager: Loggable {
                 expected: descriptor.info.encryptionType,
                 received: encryptionType,
             )
-            openStreams[chunk.streamID] = nil
+            openStreams[streamID] = nil
             streamDidClose(descriptor)
             descriptor.continuation.finish(throwing: error)
             return
         }
 
-        let readLength = descriptor.readLength + chunk.content.count
+        let readLength = descriptor.readLength + content.count
 
         if let totalLength = descriptor.info.totalLength {
             guard readLength <= totalLength else {
-                openStreams[chunk.streamID] = nil
+                openStreams[streamID] = nil
                 streamDidClose(descriptor)
                 descriptor.continuation.finish(throwing: StreamError.lengthExceeded)
                 return
             }
         }
-        openStreams[chunk.streamID]!.readLength = readLength
-        descriptor.continuation.yield(chunk.content)
+        openStreams[streamID]!.readLength = readLength
+        descriptor.continuation.yield(content)
     }
 
     /// Handles a data stream trailer.
     private func handle(trailer: Livekit_DataStream.Trailer, encryptionType: EncryptionType) {
-        guard let descriptor = openStreams[trailer.streamID] else {
+        let streamID = trailer.streamID
+        guard let descriptor = openStreams[streamID] else {
             return
         }
 
@@ -294,7 +299,7 @@ actor IncomingStreamManager: Loggable {
         // header is processed by this same event loop right after the trailer.
         // The reader's `onTermination` cleanup runs in its own task and can lose
         // that race, making `openStream` silently drop the new stream.
-        openStreams[trailer.streamID] = nil
+        openStreams[streamID] = nil
         streamDidClose(descriptor)
 
         if descriptor.info.encryptionType != encryptionType {
@@ -312,9 +317,10 @@ actor IncomingStreamManager: Loggable {
                 return
             }
         }
-        guard trailer.reason.isEmpty else {
+        let reason = trailer.reason
+        guard reason.isEmpty else {
             // According to protocol documentation, a non-empty reason string indicates an error
-            let error = StreamError.abnormalEnd(reason: trailer.reason)
+            let error = StreamError.abnormalEnd(reason: reason)
             descriptor.continuation.finish(throwing: error)
             return
         }

--- a/Sources/LiveKit/DataStream/Outgoing/StreamData.swift
+++ b/Sources/LiveKit/DataStream/Outgoing/StreamData.swift
@@ -38,21 +38,21 @@ extension String: StreamData {
     func chunks(of size: Int) -> [Data] {
         guard size > 0, !isEmpty else { return [] }
 
+        let encoded = Data(utf8)
         var chunks: [Data] = []
-        var encoded = Data(utf8)[...]
+        var start = encoded.startIndex
 
-        while encoded.count > size {
-            var k = size
-            while k > 0 {
-                guard encoded.indices.contains(k),
-                      encoded[k] & 0xC0 == 0x80 else { break }
-                k -= 1
+        while encoded.endIndex - start > size {
+            var end = start + size
+            // Back up to a scalar boundary: continuation bytes are 10xxxxxx.
+            while end > start, encoded[end] & 0xC0 == 0x80 {
+                end -= 1
             }
-            chunks.append(encoded.subdata(in: 0 ..< k))
-            encoded = encoded.subdata(in: k ..< encoded.count)
+            chunks.append(encoded[start ..< end])
+            start = end
         }
-        if !encoded.isEmpty {
-            chunks.append(encoded)
+        if start < encoded.endIndex {
+            chunks.append(encoded[start...])
         }
         return chunks
     }

--- a/Sources/LiveKit/Extensions/AsyncSequence.swift
+++ b/Sources/LiveKit/Extensions/AsyncSequence.swift
@@ -15,7 +15,9 @@
  */
 
 extension AsyncSequence where Element: RangeReplaceableCollection {
+    /// Concatenates every element into one collection, appending in place so
+    /// the total work is linear in the payload.
     func collect() async throws -> Element {
-        try await reduce(Element()) { $0 + $1 }
+        try await reduce(into: Element()) { $0.append(contentsOf: $1) }
     }
 }

--- a/Sources/LiveKit/Extensions/String.swift
+++ b/Sources/LiveKit/Extensions/String.swift
@@ -23,28 +23,25 @@ extension String {
     }
 
     var byteLength: Int {
-        data(using: .utf8)?.count ?? 0
+        utf8.count
     }
 
+    /// The longest prefix of characters whose UTF-8 encoding fits in `maxBytes`.
     func truncate(maxBytes: Int) -> String {
         if byteLength <= maxBytes {
             return self
         }
 
-        var low = 0
-        var high = count
-
-        while low < high {
-            let mid = (low + high + 1) / 2
-            let substring = String(prefix(mid))
-            if substring.byteLength <= maxBytes {
-                low = mid
-            } else {
-                high = mid - 1
-            }
+        var end = startIndex
+        var used = 0
+        while end < endIndex {
+            let next = index(after: end)
+            let width = utf8.distance(from: end, to: next)
+            if used + width > maxBytes { break }
+            used += width
+            end = next
         }
-
-        return String(prefix(low))
+        return String(self[..<end])
     }
 
     /// The path extension, if any, of the string as interpreted as a path.

--- a/Sources/LiveKitNanopb/Nanopb.swift
+++ b/Sources/LiveKitNanopb/Nanopb.swift
@@ -278,16 +278,23 @@ package struct NanopbMsg<S: NanopbStorage>: Equatable, Hashable, @unchecked Send
 
     package init(serializedBytes bytes: some Collection<UInt8>) throws(NanopbError) {
         self.init()
-        let array = Array(bytes)
         // see `nanopbEncodedBytes` on why the error is captured rather than
         // propagated straight through the stdlib's untyped `rethrows`
         var failure: NanopbError?
-        array.withUnsafeBytes { buffer in
+        let pointer = _pointer
+        func decode(_ buffer: UnsafeRawBufferPointer) {
             do throws(NanopbError) {
-                try nanopbDecode(into: _pointer, S.descriptor, buffer)
+                try nanopbDecode(into: pointer, S.descriptor, buffer)
             } catch {
                 failure = error
             }
+        }
+        // nanopb copies every string and bytes field out of the input, so the
+        // message never points into `bytes`: decode straight from the
+        // collection's own storage when it is contiguous, and copy only when
+        // it is not.
+        if bytes.withContiguousStorageIfAvailable({ decode(UnsafeRawBufferPointer($0)) }) == nil {
+            Array(bytes).withUnsafeBytes(decode)
         }
         if let failure { throw failure }
     }
@@ -301,7 +308,7 @@ package struct NanopbMsg<S: NanopbStorage>: Equatable, Hashable, @unchecked Send
     }
 
     package func serializedData() throws(NanopbError) -> Data {
-        try Data(serializedBytes())
+        try nanopbEncodedData(_pointer, S.descriptor)
     }
 
     // MARK: Equatable / Hashable

--- a/Sources/LiveKitNanopb/NanopbWire.swift
+++ b/Sources/LiveKitNanopb/NanopbWire.swift
@@ -91,3 +91,24 @@ package func nanopbEncodedBytes(
     if written != size { out.removeLast(size - written) }
     return out
 }
+
+/// Same as `nanopbEncodedBytes`, but encodes straight into a `Data` for
+/// callers that need one.
+package func nanopbEncodedData(
+    _ pointer: UnsafePointer<some Any>, _ descriptor: pb_msgdesc_t,
+) throws(NanopbError) -> Data {
+    let size = try nanopbEncodedSize(pointer, descriptor)
+    var out = Data(count: size)
+    var failure: NanopbError?
+    var written = 0
+    out.withUnsafeMutableBytes { buffer in
+        do throws(NanopbError) {
+            written = try nanopbEncode(pointer, descriptor, into: buffer)
+        } catch {
+            failure = error
+        }
+    }
+    if let failure { throw failure }
+    if written != size { out.removeLast(size - written) }
+    return out
+}


### PR DESCRIPTION
## Summary

The data packet and data stream paths copy payloads they do not need to copy, and two of them do work quadratic in the payload. None of it changes results; each commit removes one of them:

- `LKRTCDataBuffer.data` builds a fresh `NSData` from the native buffer on every read (webrtc-sdk `RTCDataChannel.mm`), and `DataChannelPair` read it just for `.count`: after `sendData`, entering the retry buffer, leaving it. `PublishDataRequest` now carries the encoded size.
- `NanopbMsg.init(serializedBytes:)` copied its input into an `Array` before decoding. nanopb copies every string and bytes field out of the input while decoding, so it now decodes on the collection's contiguous storage (`Data`, arrays, slices) and copies only for a collection without any. `serializedData()` encoded into `[UInt8]` and copied that into `Data`; it now encodes into `Data`.
- `collect()` behind `readAll()` folded with `+`, copying the accumulated prefix for every chunk. It appends in place.
- `IncomingStreamManager` read `chunk.content` three times per chunk (getters copy out of nanopb storage), so every stream chunk was copied three times to deliver one; `Room.engine(_:didReceiveUserPacket:)` read `packet.payload` once per delegate. Each reads once.
- `String.chunks(of:)` re-sliced the remainder with `subdata(in:)` on every step. It returns slices of one encoding, as `Data.chunks(of:)` does; the UTF-8 boundary rule is unchanged.
- `String.byteLength` encoded the string into `Data` to count it, and `truncate(maxBytes:)` built a prefix string plus that copy at every step of a binary search. They use `utf8.count` and one pass.
- `TranscriptionStreamReceiver` re-parsed the stream attributes (a JSON round trip) on every chunk. Once per stream.

## Measurements

Same test file run against `main` and this branch, `-O`, macOS 26 / Apple Silicon. Allocations are counted with libmalloc's `malloc_logger` hook and attributed by backtrace, so the counts are exact and deterministic; times are medians.

| | before | after |
|---|---|---|
| Decode `Livekit_DataPacket` from `Data`, 15,360 B payload | 0.91 µs, 2 payload-sized allocations | 0.73 µs, 1 |
| Decode, 61,440 B | 2.44 µs, 2 | 1.29 µs, 1 |
| `serializedData()`, 15,360 B | 1.08 µs, 2 | 0.85 µs, 1 |
| `serializedData()`, 61,440 B | 3.85 µs, 2 | 1.55 µs, 1 |
| `readAll()` of 256 × 15 KiB chunks (3.9 MB) | 22.7 ms, allocates 289× the payload | 0.49 ms, 4.8× |
| `readAll()` of 1024 chunks (15.7 MB) | 165 ms, 1153× | 3.0 ms, 6× |
| `String.chunks(of: 15 KiB)`, 4 MiB | 7.6 ms, 138× | 0.07 ms, 1× |
| `String.chunks(of: 15 KiB)`, 16 MiB | 120 ms, 548× | 0.27 ms, 1× |
| `byteLength`, 15 KiB | 0.30 µs, 1 allocation | 0.3 ns, 0 |
| `truncate(maxBytes: 8192)`, 15 KiB Korean | 305 µs, 26 large allocations | 27 µs, 1 |
| Transcription receiver, per chunk | 9.7 µs, 55 allocations | 3.8 µs, 12 |

End to end against a local `livekit-server` (two rooms in one process, plaintext), payload-sized allocations per `publish(data:)` round trip attributed to LiveKit frames: reliable 15,360 B goes from 14.5 to 9 per packet (the `LKRTCDataBuffer.data` reads, the `Array` copy on decode, the `Data` copy on encode, and the reliable sequence-stamp append's reallocation, which stops because `Data(count:)` leaves headroom). Counting every allocation of at least half the payload anywhere in the process, reliable 61,440 B goes from 16.8 to 11.0 per packet (1.07 MB to 0.70 MB). A 4 MiB byte stream: process CPU 207 ms to 157 ms, receiver allocation per chunk 5.7 MB to 0.9 MB. A 4 MiB text stream: `sendText` 105 ms to 87 ms.

## Verification

- `LiveKitNanopbTests` (conformance oracle, edge cases, fuzz, concurrency, leaks), `DataStream*`, `StreamDataTests`, `StringTests`, `TranscriptionTests`, `DataChannel*`, `PublishDataTests`, `Rpc*`, `IncomingStreamManagerTests`, `OutgoingStreamManagerTests`, `DataTrack*` pass against a local `livekit-server` 1.13.5.
- macOS `LiveKitCoreTests` + `LiveKitNanopbTests` + `LiveKitObjCTests` via `xcodebuild` as in CI: pass (one timing-based test unrelated to this change, `TaskObserveTests.streamFinishEndsTask`, failed once in the full run and passes in isolation).
- swiftformat, swiftlint --strict: clean.
