### PR TITLE
Enable WARP (SPED + SNAP), gated by the server

### DIFF
--- a/Sources/LiveKit/Core/RTC.swift
+++ b/Sources/LiveKit/Core/RTC.swift
@@ -162,6 +162,13 @@ extension RTC {
 
         Room.log("Initializing PeerConnectionFactory...")
 
+        // WARP SPED (DTLS-in-STUN). Advertised in the offer/answer and engages
+        // only when the server negotiates it, otherwise the connection falls
+        // back to a plain DTLS handshake. Must be set before the factory is
+        // created. SNAP, the other half of WARP, is enabled on
+        // LKRTCConfiguration.liveKitDefault().
+        LKRTCPeerConnectionFactory.configureFieldTrials("\(kLKRTCFieldTrialIceHandshakeDtlsKey)/\(kLKRTCFieldTrialEnabledValue)/")
+
         return LKRTCPeerConnectionFactory(audioDeviceModuleType: admType.toRTCType(),
                                           bypassVoiceProcessing: bypassVoiceProcessing,
                                           encoderFactory: encoderFactory,

--- a/Sources/LiveKit/Extensions/RTCConfiguration.swift
+++ b/Sources/LiveKit/Extensions/RTCConfiguration.swift
@@ -26,6 +26,11 @@ extension LKRTCConfiguration {
         result.continualGatheringPolicy = .gatherContinually
         result.candidateNetworkPolicy = .all
         result.tcpCandidatePolicy = .enabled
+        // WARP SNAP (SCTP INIT in SDP). Engages only when the server
+        // negotiates it. This maps to an immutable field of the native
+        // configuration, so it must stay the same value here for both peer
+        // connection creation and set(configuration:) calls.
+        result.enableSctpSnap = true
 
         return result
     }


### PR DESCRIPTION
Enables WARP, negotiated with the SFU. SPED (DTLS-in-STUN) via the WebRTC-IceHandshakeDtls field trial, SNAP (SCTP INIT in SDP) via enableSctpSnap on the default configuration. Nothing engages unless the server enables warp, otherwise plain DTLS/SCTP. Mirrors livekit/rust-sdks#1342.

Blocked on an m150 webrtc-xcframework release including webrtc-sdk/webrtc#283, then both Package manifest pins need bumping.

Note: SPED re-enters the #929 crash surface that #1015 disabled. The m150 teardown path should be validated (or rust field data observed) before this lands. SNAP has no such history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)