### PR TITLE
Fix capturer state desync when startCapture fails after the base state transition

### DIFF
--- a/.changes/capturer-start-failure-balance
+++ b/.changes/capturer-start-failure-balance
@@ -1,0 +1,1 @@
+patch type="fixed" "Fix capturers permanently reporting started after a failed startCapture: the start/stop counter is now balanced on failure so a subsequent start attempt can retry"

--- a/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
+++ b/Sources/LiveKit/Broadcast/BroadcastScreenCapturer.swift
@@ -45,7 +45,14 @@ class BroadcastScreenCapturer: BufferCapturer, @unchecked Sendable {
             .toEncodeSafeDimensions()
 
         set(dimensions: targetDimensions)
-        return createReceiver()
+
+        guard createReceiver() else {
+            // Balance the counter so the capturer does not report `.started`
+            // while no capture is running.
+            _ = try? await stopCapture()
+            return false
+        }
+        return true
     }
 
     private func createReceiver() -> Bool {

--- a/Sources/LiveKit/Track/Capturers/ARCameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/ARCameraCapturer.swift
@@ -37,6 +37,16 @@ public class ARCameraCapturer: VideoCapturer, @unchecked Sendable {
     }
 
     override public func startCapture() async throws -> Bool {
+        do {
+            return try await performStartCapture()
+        } catch {
+            // Balance the counter so a subsequent startCapture() can retry.
+            try? await stopCapture()
+            throw error
+        }
+    }
+
+    private func performStartCapture() async throws -> Bool {
         let didStart = try await super.startCapture()
         // Already started
         guard didStart else { return false }

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -151,8 +151,18 @@ public class CameraCapturer: VideoCapturer, @unchecked Sendable {
         return try await restartCapture()
     }
 
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
     override public func startCapture() async throws -> Bool {
+        do {
+            return try await performStartCapture()
+        } catch {
+            // Balance the counter so a subsequent startCapture() can retry.
+            try? await stopCapture()
+            throw error
+        }
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    private func performStartCapture() async throws -> Bool {
         let didStart = try await super.startCapture()
 
         // Already started

--- a/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/InAppCapturer.swift
@@ -33,6 +33,16 @@ public class InAppScreenCapturer: VideoCapturer, @unchecked Sendable {
     }
 
     override public func startCapture() async throws -> Bool {
+        do {
+            return try await performStartCapture()
+        } catch {
+            // Balance the counter so a subsequent startCapture() can retry.
+            try? await stopCapture()
+            throw error
+        }
+    }
+
+    private func performStartCapture() async throws -> Bool {
         let didStart = try await super.startCapture()
 
         // Already started

--- a/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/MacOSScreenCapturer.swift
@@ -58,6 +58,16 @@ public class MacOSScreenCapturer: VideoCapturer, @unchecked Sendable {
     }
 
     override public func startCapture() async throws -> Bool {
+        do {
+            return try await performStartCapture()
+        } catch {
+            // Balance the counter so a subsequent startCapture() can retry.
+            try? await stopCapture()
+            throw error
+        }
+    }
+
+    private func performStartCapture() async throws -> Bool {
         let didStart = try await super.startCapture()
 
         // Already started

--- a/Tests/LiveKitCoreTests/VideoCapturerStartFailureTests.swift
+++ b/Tests/LiveKitCoreTests/VideoCapturerStartFailureTests.swift
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+@testable import LiveKit
+import LiveKitWebRTC
+import Testing
+
+/// Emulates a capturer whose device-level start work fails after
+/// `super.startCapture()` has already transitioned the state to `.started`,
+/// using the same balancing pattern as the built-in capturers.
+private final class StartFailingCapturer: VideoCapturer, @unchecked Sendable {
+    override func startCapture() async throws -> Bool {
+        do {
+            let didStart = try await super.startCapture()
+            guard didStart else { return false }
+            throw LiveKitError(.invalidState, message: "Simulated device failure")
+        } catch {
+            try? await stopCapture()
+            throw error
+        }
+    }
+}
+
+private final class NullCapturerDelegate: NSObject, LKRTCVideoCapturerDelegate {
+    func capturer(_: LKRTCVideoCapturer, didCapture _: LKRTCVideoFrame) {}
+}
+
+@Suite(.tags(.media))
+struct VideoCapturerStartFailureTests {
+    @Test func startFailureLeavesCapturerStopped() async throws {
+        let capturer = StartFailingCapturer(delegate: NullCapturerDelegate())
+        #expect(capturer.captureState == .stopped)
+
+        await #expect(throws: LiveKitError.self) {
+            try await capturer.startCapture()
+        }
+        // Without balancing the counter stays at 1: the capturer reports
+        // `.started` while nothing is capturing.
+        #expect(capturer.captureState == .stopped)
+    }
+
+    @Test func startCanRetryAfterFailure() async throws {
+        let capturer = StartFailingCapturer(delegate: NullCapturerDelegate())
+
+        await #expect(throws: LiveKitError.self) {
+            try await capturer.startCapture()
+        }
+        // Without balancing this second call would return `false` early
+        // ("already started") instead of reaching the subclass again.
+        await #expect(throws: LiveKitError.self) {
+            try await capturer.startCapture()
+        }
+        #expect(capturer.captureState == .stopped)
+    }
+}


### PR DESCRIPTION
## Problem

`VideoCapturer.startCapture()` increments the start/stop counter and
notifies `.started` before subclasses perform the actual device-level
start work. When that work throws, the counter is left incremented:

- The capturer permanently reports `.started` while nothing is
  capturing.
- Every subsequent `startCapture()` call returns `false` early
  ("already started") instead of retrying, and `Track.start()` does not
  inspect the return value, so the track keeps reporting
  started/unmuted with a dead capturer.

On iOS this is reachable on every foreground return: the background
suspend/resume path goes through `resume() → unmute → Track.start() →
startCapture()` and `Room.appWillEnterForeground` only logs the resume
error, so one transient `CameraCapturer` failure (no capture device,
unresolvable format, or an AVFoundation start error during the app
transition) leaves the camera dead for the rest of the session while
`track.isMuted == false`, with no error surfaced to the app. The only
recovery is unpublishing and republishing the track.

## Fix

Balance the counter on failure with `try? await stopCapture()` before
rethrowing (or before reporting failure): the capturer returns to
`.stopped`, and running the subclass stop body tears down any partially
configured device state. Applied to every start path that can fail
after the base call:

- `CameraCapturer`, `ARCameraCapturer`, `MacOSScreenCapturer`,
  `InAppScreenCapturer`: the start body moves into a private
  `performStartCapture()` and the override wraps it in do/catch.
- `BroadcastScreenCapturer`: the receiver-creation failure path
  returned `false` while leaving the counter incremented; it now
  balances the counter first (whether that path should throw instead of
  returning `false` is left unchanged). Balancing also resets the
  pre-filled dimensions completer, so publishing with a misconfigured
  broadcast bundle now fails at the publish-time dimensions wait
  instead of publishing a track that never produces frames.

No public API changes.

## Note

`MacOSScreenCapturer.stopCapture()` has the mirrored issue on the stop
side: throwing after the counter already decremented leaves a running
`SCStream` on a capturer that reports `.stopped`. Left out to keep this
PR focused on the start path; happy to follow up.

The structural alternative (base class transitions state only after the
subclass start work succeeds, template-method style) would also cover
third-party capturer subclasses, but it changes the public subclassing
contract, so this PR keeps the non-breaking per-subclass shape.

## Testing

- New `VideoCapturerStartFailureTests`: a capturer failing after the
  base transition returns to `.stopped`, and a second attempt reaches
  the subclass again instead of silently returning `false`.
- Verified both tests fail against the unbalanced behavior (state stays
  `.started`; the second call returns `false`).
- Built for iOS Simulator and macOS.
