### PR TITLE
Add LocalTrackPublication.set(videoPublishOptions:) to update encodings without republishing

### DIFF
--- a/.changes/publication-set-video-publish-options
+++ b/.changes/publication-set-video-publish-options
@@ -1,0 +1,1 @@
+minor type="added" "LocalTrackPublication.set(videoPublishOptions:) to re-apply encoding parameters of a published video track to the live RTP sender without republishing"

--- a/Sources/LiveKit/TrackPublications/LocalTrackPublication.swift
+++ b/Sources/LiveKit/TrackPublications/LocalTrackPublication.swift
@@ -58,6 +58,47 @@ public class LocalTrackPublication: TrackPublication, @unchecked Sendable {
         try await track._unmute()
     }
 
+    /// Updates the publish options of an already published local video track and applies the
+    /// re-computed encoding parameters (e.g. ``VideoEncoding/maxBitrate``,
+    /// ``VideoEncoding/maxFps``) to the RTP sender without re-publishing the track.
+    ///
+    /// The encoding layer structure (number of layers and their `rid`s) is fixed at publish
+    /// time and cannot change here: passing options that would produce a different layer
+    /// structure (e.g. toggling simulcast) throws ``LiveKitErrorType/invalidState``.
+    /// Only per-layer encoding parameters (`isActive`, `scaleResolutionDownBy`, `maxBitrate`,
+    /// `maxFps`) are re-applied; codec preferences, scalability mode, and
+    /// ``VideoPublishOptions/degradationPreference`` remain as published.
+    public func set(videoPublishOptions options: VideoPublishOptions) throws {
+        guard let track = track as? LocalVideoTrack else {
+            throw LiveKitError(.invalidState, message: "track is nil or not a LocalVideoTrack")
+        }
+
+        guard participant?._room != nil else {
+            throw LiveKitError(.invalidState, message: "Participant or room is not available")
+        }
+
+        guard let sender = track._state.rtpSender else {
+            throw LiveKitError(.invalidState, message: "RTP sender is not available")
+        }
+
+        guard let dimensions = track.capturer.dimensions else {
+            throw LiveKitError(.invalidState, message: "Capturer dimensions are not resolved")
+        }
+
+        let newEncodings = Utils.computeVideoEncodings(dimensions: dimensions,
+                                                       publishOptions: options,
+                                                       isScreenShare: track.source == .screenShareVideo)
+        let currentEncodings = sender.parameters.encodings
+        guard newEncodings.count == currentEncodings.count,
+              zip(newEncodings, currentEncodings).allSatisfy({ $0.rid == $1.rid })
+        else {
+            throw LiveKitError(.invalidState, message: "Encoding layer structure must match the published track")
+        }
+
+        track._state.mutate { $0.lastPublishOptions = options }
+        recomputeSenderParameters()
+    }
+
     @discardableResult
     override func set(track newValue: Track?) async -> Track? {
         let oldValue = await super.set(track: newValue)

--- a/Tests/LiveKitCoreTests/SetVideoPublishOptionsTests.swift
+++ b/Tests/LiveKitCoreTests/SetVideoPublishOptionsTests.swift
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+@testable import LiveKit
+import LiveKitWebRTC
+import Testing
+#if canImport(LiveKitTestSupport)
+import LiveKitTestSupport
+#endif
+
+@Suite(.serialized, .tags(.media, .e2e))
+struct SetVideoPublishOptionsTests {
+    @Test func updateEncodingWithoutRepublish() async throws {
+        try await TestEnvironment.withRoom(RoomTestingOptions(canPublish: true)) { room in
+            let bufferTrack = LocalVideoTrack.createBufferTrack(
+                name: Track.cameraName,
+                source: .camera,
+                options: BufferCaptureOptions(dimensions: .h720_169),
+            )
+            let bufferCapturer = try #require(bufferTrack.capturer as? BufferCapturer)
+
+            let captureTask = try await createSampleVideoTrack { buffer in
+                bufferCapturer.capture(buffer)
+            }
+            defer { captureTask.cancel() }
+
+            let publication = try await room.localParticipant.publish(
+                videoTrack: bufferTrack,
+                options: VideoPublishOptions(encoding: VideoEncoding(maxBitrate: 1_700_000, maxFps: 30),
+                                             simulcast: false),
+            )
+
+            let sender = try #require(bufferTrack._state.rtpSender)
+            let initialBitrate = try #require(sender.parameters.encodings.first?.maxBitrateBps)
+            #expect(initialBitrate.intValue == 1_700_000)
+            let sid = publication.sid
+
+            try publication.set(videoPublishOptions: VideoPublishOptions(encoding: VideoEncoding(maxBitrate: 1_200_000, maxFps: 30),
+                                                                         simulcast: false))
+
+            let updatedBitrate = try #require(sender.parameters.encodings.first?.maxBitrateBps)
+            #expect(updatedBitrate.intValue == 1_200_000)
+            // The track was not re-published: same publication, same sender.
+            #expect(publication.sid == sid)
+            #expect(room.localParticipant.videoTracks.count == 1)
+        }
+    }
+
+    @Test func rejectsLayerStructureChange() async throws {
+        try await TestEnvironment.withRoom(RoomTestingOptions(canPublish: true)) { room in
+            let bufferTrack = LocalVideoTrack.createBufferTrack(
+                name: Track.cameraName,
+                source: .camera,
+                options: BufferCaptureOptions(dimensions: .h720_169),
+            )
+            let bufferCapturer = try #require(bufferTrack.capturer as? BufferCapturer)
+
+            let captureTask = try await createSampleVideoTrack { buffer in
+                bufferCapturer.capture(buffer)
+            }
+            defer { captureTask.cancel() }
+
+            let publication = try await room.localParticipant.publish(
+                videoTrack: bufferTrack,
+                options: VideoPublishOptions(encoding: VideoEncoding(maxBitrate: 1_700_000, maxFps: 30),
+                                             simulcast: false),
+            )
+
+            // Toggling simulcast would change the encoding layer structure.
+            #expect(throws: LiveKitError.self) {
+                try publication.set(videoPublishOptions: VideoPublishOptions(simulcast: true))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Publish options are fixed at publish time.
`LocalParticipant.set(source:enabled:)` returns the existing
publication (unmute path) without applying newly passed
`publishOptions`, so the only way to change encoding parameters of a
published video track (e.g. lowering `maxBitrate` while the device is
under thermal pressure, then restoring it) is a full unpublish +
republish. That drops frames, churns the subscriber side, and re-runs
capture setup.

The SDK already updates sender encodings live when capture dimensions
change (`recomputeSenderParameters()`), so the machinery exists; it has
no public entry point.

## API

```swift
public func set(videoPublishOptions options: VideoPublishOptions) throws
```

on `LocalTrackPublication`:

- Stores the new options on the track, re-computes encodings for the
  current capture dimensions, applies them to the RTP sender, and
  reports the updated layers to the server (`sendUpdateVideoLayers`),
  same as the dimensions-change path.
- The encoding layer structure is fixed at publish time: options that
  would produce a different layer count or `rid` set (e.g. toggling
  simulcast) throw `.invalidState`. Without the guard such options
  would deactivate every non-matching layer in
  `recomputeSenderParameters()`'s rid-matched merge.
- Throws `.invalidState` when the publication is not a local video
  track, the participant or room is no longer available, the RTP sender
  is not available, or capture dimensions are not resolved yet.
- Only per-layer encoding parameters (`isActive`,
  `scaleResolutionDownBy`, `maxBitrate`, `maxFps`) are re-applied;
  codec preferences, scalability mode, and `degradationPreference`
  remain as published (documented on the API).

## Testing

- New e2e `SetVideoPublishOptionsTests` (local `livekit-server --dev`):
  `maxBitrate` of a published non-simulcast camera-source track changes
  from 1.7 Mbps to 1.2 Mbps on the live sender without republishing
  (same publication sid, still a single publication), and toggling
  simulcast is rejected with `.invalidState`.
- Verified the update test fails when the recompute step is removed.
- Built for iOS Simulator and macOS.
