### PR TITLE
Expose remote data track pipeline options

### DIFF
--- a/LiveKitClient.podspec
+++ b/LiveKitClient.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |spec|
   spec.pod_target_xcconfig = {"SWIFT_PACKAGE_NAME" => "livekit_client_sdk_swift"}
 
   spec.dependency("LiveKitWebRTC", "= 144.7559.13")
-  spec.dependency("LiveKitUniFFI", "= 0.1.8")
+  spec.dependency("LiveKitUniFFI", "= 0.1.9")
 
   spec.resource_bundles = {"Privacy" => ["Sources/LiveKit/PrivacyInfo.xcprivacy"]}
 end

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
         .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "144.7559.13"),
-        .package(url: "https://github.com/livekit/livekit-uniffi-xcframework.git", exact: "0.1.8"),
+        .package(url: "https://github.com/livekit/livekit-uniffi-xcframework.git", exact: "0.1.9"),
         // Test-only: conformance oracle for the nanopb facades.
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.0"),
         // Only used for DocC generation

--- a/Package@swift-6.2.swift
+++ b/Package@swift-6.2.swift
@@ -21,7 +21,7 @@ let package = Package(
     dependencies: [
         // LK-Prefixed Dynamic WebRTC XCFramework
         .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "144.7559.13"),
-        .package(url: "https://github.com/livekit/livekit-uniffi-xcframework.git", exact: "0.1.8"),
+        .package(url: "https://github.com/livekit/livekit-uniffi-xcframework.git", exact: "0.1.9"),
         // Test-only: conformance oracle for the nanopb facades.
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.0"),
         // Only used for DocC generation

--- a/Sources/LiveKit/DataTrack/RemoteDataTrack.swift
+++ b/Sources/LiveKit/DataTrack/RemoteDataTrack.swift
@@ -72,4 +72,19 @@ public final class RemoteDataTrack: NSObject, Sendable {
             throw DataTrackSubscribeError(error)
         }
     }
+
+    /// Configures how the incoming-frame pipeline reassembles packets for this track.
+    ///
+    /// The setting is track-level: it applies to every current and future subscription, can be
+    /// set at any time, and takes effect with the next received packet.
+    ///
+    /// - Parameter maxPartialFrames: Maximum number of partial frames the depacketizer tracks
+    ///   concurrently. Large frames are split across packets and reassembled by the receiver; the
+    ///   default of 1 drops an in-progress frame as soon as packets for the next one arrive. Raise
+    ///   it when payloads are large or high-frequency, at the cost of memory growing roughly with
+    ///   `maxPartialFrames` × average frame size. A value of 0 is clamped to 1.
+    @objc public func setPipelineOptions(maxPartialFrames: UInt32) {
+        let options = LiveKitUniFFI.RemoteDataTrackPipelineOptions(maxPartialFrames: maxPartialFrames)
+        track.setPipelineOptions(options: options)
+    }
 }

--- a/Tests/LiveKitCoreTests/DataTrack/DataTrackApiTests.swift
+++ b/Tests/LiveKitCoreTests/DataTrack/DataTrackApiTests.swift
@@ -148,4 +148,27 @@ struct DataTrackApiTests {
             #expect(first > 0, "A capacity-one buffer should have dropped the earliest frames")
         }
     }
+
+    // MARK: - Pipeline Options
+
+    /// `maxPartialFrames` can be set before and after subscribing, and a multi-packet frame
+    /// still reassembles. Zero is clamped to one rather than rejected.
+    @Test
+    func setPipelineOptionsReassemblesMultiPacketFrames() async throws {
+        try await TestEnvironment.withPublishedDataTrack(named: "partials") { fixture in
+            fixture.remoteTrack.setPipelineOptions(maxPartialFrames: 4)
+            let stream = try await fixture.remoteTrack.subscribe()
+            fixture.remoteTrack.setPipelineOptions(maxPartialFrames: 0)
+
+            // Spans several packets, so the depacketizer has to reassemble it. Delivery is lossy
+            // and losing one packet loses the whole frame, so retry rather than assert on one push.
+            let payload = Data(repeating: 0xFA, count: 32000)
+            var received: Data?
+            for _ in 0 ..< 3 where received == nil {
+                try fixture.track.tryPush(frame: DataTrackFrame(payload: payload))
+                received = await stream.next(within: 15)?.payload
+            }
+            #expect(received == payload)
+        }
+    }
 }


### PR DESCRIPTION
Bumps LiveKitUniFFI to 0.1.9 and surfaces `RemoteDataTrack.setPipelineOptions(maxPartialFrames:)`, the lever for reassembling large or high-frequency frames when packets arrive interleaved — Swift was the only SDK without it (livekit/rust-sdks#1339). The CocoaPods dependency is bumped to `= 0.1.9` alongside the SPM pin.

Depends on the LiveKitUniFFI 0.1.9 pod being published; rerun CI once it lands.