### PR TITLE
Roll back the sender when publishing fails after AddTrack

### DIFF
--- a/.changes/publish-failure-rollback
+++ b/.changes/publish-failure-rollback
@@ -1,0 +1,1 @@
+patch type="fixed" "Roll back the sender when publishing fails after the track was added on the server (e.g. audio frame-watcher timeout), so the SFU no longer keeps an orphaned track that the client cannot mute or unpublish"

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -101,6 +101,7 @@ public class LocalParticipant: Participant, @unchecked Sendable {
             // Mark re-negotiation required...
             try await room.publisherShouldNegotiate()
         }
+        await track.set(transport: nil, rtpSender: nil)
 
         track._state.mutate { $0.rtpSenderForCodec.removeAll() }
 
@@ -509,10 +510,7 @@ extension LocalParticipant {
         guard let track = localTrackPublication.track as? LocalVideoTrack else {
             throw LiveKitError(.invalidState, message: "Track is nil")
         }
-
-        if !videoCodec.isBackup {
-            throw LiveKitError(.invalidState, message: "Attempted to publish a non-backup video codec as backup")
-        }
+        guard videoCodec.isBackup else { throw LiveKitError(.invalidState, message: "Attempted to publish a non-backup video codec as backup") }
 
         let publisher = try room.requirePublisher()
 
@@ -544,37 +542,41 @@ extension LocalParticipant {
         let sender = try await RTC.run {
             let transceiver = try publisher.addTransceiver(with: track.mediaTrack.raw, transceiverInit: transInit)
             try transceiver.set(preferredVideoCodec: videoCodec)
-            let sender = transceiver.sender
-            sender.set(degradationPreference: degradationPreference)
-            return RTCSender(sender)
+            transceiver.sender.set(degradationPreference: degradationPreference)
+            return RTCSender(transceiver.sender)
         }
         log("[Publish] Added transceiver...")
 
-        // Request a new track to the server
-        let trackInfo = try await room.signalClient.sendAddTrack(cid: sender.senderId,
-                                                                 name: track.name,
-                                                                 type: track.kind.toPBType(),
-                                                                 source: track.source.toPBType())
-        {
-            $0.sid = localTrackPublication.sid.stringValue
-            $0.simulcastCodecs = [
-                Livekit_SimulcastCodec.with { sc in
-                    sc.cid = sender.senderId
-                    sc.codec = videoCodec.name
-                },
-            ]
+        do {
+            // Request a new track to the server
+            let trackInfo = try await room.signalClient.sendAddTrack(cid: sender.senderId,
+                                                                     name: track.name,
+                                                                     type: track.kind.toPBType(),
+                                                                     source: track.source.toPBType())
+            {
+                $0.sid = localTrackPublication.sid.stringValue
+                $0.simulcastCodecs = [
+                    Livekit_SimulcastCodec.with { sc in
+                        sc.cid = sender.senderId
+                        sc.codec = videoCodec.name
+                    },
+                ]
 
-            $0.layers = layers
+                $0.layers = layers
+            }
+
+            log("[Publish] server responded trackInfo: \(trackInfo)")
+
+            await RTC.run { sender.raw._set(subscribedQualities: subscribedCodec.qualities) }
+
+            // Attach multi-codec sender...
+            track._state.mutate { $0.rtpSenderForCodec[videoCodec] = sender }
+
+            try await room.publisherShouldNegotiate()
+        } catch {
+            try? await publisher.remove(track: sender)
+            throw error
         }
-
-        log("[Publish] server responded trackInfo: \(trackInfo)")
-
-        await RTC.run { sender.raw._set(subscribedQualities: subscribedCodec.qualities) }
-
-        // Attach multi-codec sender...
-        track._state.mutate { $0.rtpSenderForCodec[videoCodec] = sender }
-
-        try await room.publisherShouldNegotiate()
     }
 }
 
@@ -811,11 +813,26 @@ extension LocalParticipant {
             return publication
         } catch {
             log("[publish] failed \(track), error: \(error)", .error)
+            await rollbackPublish(of: track, publisher: publisher, room: room)
             // Stop track when publish fails
             try await track.stop()
             // Rethrow
             throw error
         }
+    }
+
+    // The server only learns about a track going away through renegotiation, so a publish that
+    // fails after the sender was attached has to detach it or the SFU keeps the track alive
+    // with no local publication to mute or unpublish it.
+    private func rollbackPublish(of track: LocalTrack, publisher: Transport, room: Room) async {
+        guard let sender = track._state.read({ $0.transport === publisher ? $0.rtpSender : nil }) else { return }
+        do {
+            try await publisher.remove(track: sender)
+            try await room.publisherShouldNegotiate()
+        } catch {
+            log("[publish] failed to roll back sender, error: \(error)", .warning)
+        }
+        await track.set(transport: nil, rtpSender: nil)
     }
 
     private func checkPermissions(toPublish track: LocalTrack) throws {

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -507,9 +507,7 @@ extension LocalParticipant {
 
         log("[Publish/Backup] Additional video codec: \(videoCodec)...")
 
-        guard let track = localTrackPublication.track as? LocalVideoTrack else {
-            throw LiveKitError(.invalidState, message: "Track is nil")
-        }
+        guard let track = localTrackPublication.track as? LocalVideoTrack else { throw LiveKitError(.invalidState, message: "Track is nil") }
         guard videoCodec.isBackup else { throw LiveKitError(.invalidState, message: "Attempted to publish a non-backup video codec as backup") }
 
         let publisher = try room.requirePublisher()
@@ -574,6 +572,7 @@ extension LocalParticipant {
 
             try await room.publisherShouldNegotiate()
         } catch {
+            track._state.mutate { $0.rtpSenderForCodec[videoCodec] = nil }
             try? await publisher.remove(track: sender)
             throw error
         }

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -573,7 +573,7 @@ extension LocalParticipant {
             try await room.publisherShouldNegotiate()
         } catch {
             track._state.mutate { $0.rtpSenderForCodec[videoCodec] = nil }
-            try? await publisher.remove(track: sender)
+            await rollback(sender: sender, publisher: publisher, room: room)
             throw error
         }
     }
@@ -812,7 +812,10 @@ extension LocalParticipant {
             return publication
         } catch {
             log("[publish] failed \(track), error: \(error)", .error)
-            await rollbackPublish(of: track, publisher: publisher, room: room)
+            if let sender = track._state.read({ $0.transport === publisher ? $0.rtpSender : nil }) {
+                await rollback(sender: sender, publisher: publisher, room: room)
+                await track.set(transport: nil, rtpSender: nil)
+            }
             // Stop track when publish fails
             try await track.stop()
             // Rethrow
@@ -823,15 +826,13 @@ extension LocalParticipant {
     // The server only learns about a track going away through renegotiation, so a publish that
     // fails after the sender was attached has to detach it or the SFU keeps the track alive
     // with no local publication to mute or unpublish it.
-    private func rollbackPublish(of track: LocalTrack, publisher: Transport, room: Room) async {
-        guard let sender = track._state.read({ $0.transport === publisher ? $0.rtpSender : nil }) else { return }
+    private func rollback(sender: RTCSender, publisher: Transport, room: Room) async {
         do {
             try await publisher.remove(track: sender)
             try await room.publisherShouldNegotiate()
         } catch {
             log("[publish] failed to roll back sender, error: \(error)", .warning)
         }
-        await track.set(transport: nil, rtpSender: nil)
     }
 
     private func checkPermissions(toPublish track: LocalTrack) throws {

--- a/Tests/LiveKitCoreTests/PublishTrackTests.swift
+++ b/Tests/LiveKitCoreTests/PublishTrackTests.swift
@@ -23,6 +23,29 @@ import LiveKitTestSupport
 
 @Suite(.serialized, .tags(.media, .e2e))
 struct PublishTrackTests {
+    @Test func publishFailureAfterAddTrackRollsBack() async throws {
+        try await TestEnvironment.withRooms([RoomTestingOptions(canPublish: true), RoomTestingOptions(canSubscribe: true)]) { rooms in
+            let publisher = rooms[0].localParticipant
+            let publisherIdentity = try #require(publisher.identity)
+            let remote = try #require(rooms[1].remoteParticipants[publisherIdentity])
+
+            let failedTrack = FrameStarvedAudioTrack()
+            await #expect(throws: LiveKitError.self) {
+                try await publisher.publish(audioTrack: failedTrack)
+            }
+            #expect(publisher.audioTracks.isEmpty)
+            #expect(failedTrack._state.rtpSender == nil)
+
+            // A retry must leave exactly one track on the server, not a second one next to an orphan.
+            let publication = try await publisher.publish(audioTrack: TestAudioTrack())
+            let deadline = Date().addingTimeInterval(15)
+            while Date() < deadline, Set(remote.audioTracks.map(\.sid)) != [publication.sid] {
+                try await Task.sleep(nanoseconds: 200_000_000)
+            }
+            #expect(Set(remote.audioTracks.map(\.sid)) == [publication.sid])
+        }
+    }
+
     @Test func publishWithoutPermissions() async throws {
         try await TestEnvironment.withRoom(RoomTestingOptions(canPublish: false)) { room in
             let audioTrack = await LocalAudioTrack.createTrack()

--- a/Tests/LiveKitTestSupport/Tracks.swift
+++ b/Tests/LiveKitTestSupport/Tracks.swift
@@ -205,6 +205,17 @@ public class TestAudioTrack: LocalAudioTrack, @unchecked Sendable {
     }
 }
 
+/// Fails where a real audio track fails when its engine never delivers a frame:
+/// after `AddTrack` and negotiation, before the publication exists.
+public final class FrameStarvedAudioTrack: TestAudioTrack, @unchecked Sendable {
+    override public func startWaitingForFrames() async throws {
+        // Give negotiation time to reach the server so it holds a live publication when
+        // the failure hits, as it does with the real 5s frame-watcher timeout.
+        try await Task.sleep(nanoseconds: 2_000_000_000)
+        throw LiveKitError(.timedOut, message: "No audio frames")
+    }
+}
+
 public class AudioTrackWatcher: AudioRenderer, @unchecked Sendable {
     public let id: String
     public var didRenderFirstFrame: Bool { _state.didRenderFirstFrame }


### PR DESCRIPTION
Fixes #1098

When `_publish` failed after `AddTrack` and negotiation had completed — deterministically on the audio frame-watcher timeout, but also on any negotiation failure after a successful `AddTrack` — the catch only called `track.stop()`. The sender stayed attached to the publisher PC and the server kept the publication, while the client had no `LocalTrackPublication`: mute was a no-op, `isMicrophoneEnabled()` lied, and a retry published a second track. Since capture was never stopped either, frames arriving after the timeout streamed live mic audio to the room.

There is no remove-track signal for media tracks; the SFU only learns about a removal through renegotiation. So the failure path now does what `unpublish` does: remove the sender from the publisher, renegotiate, and clear the track's transport/sender state. The backup-codec publish gets the same treatment, and `unpublish` now clears the track's sender so a later publish attempt on the same track starts clean.

Mirrors the fix Android shipped in livekit/client-sdk-android#986.

Test: a `TestAudioTrack` subclass that throws from `startWaitingForFrames()` (after letting negotiation reach the server) reproduces the exact failure point headlessly; the test asserts no local publication or sender remains, and that a retry leaves exactly one track visible to a remote participant. Without the rollback it fails with two tracks on the remote and the sender still attached.

Local server log for the test run, publisher side:

```
11:35:30.519  addTrack              cid 89A563FB…
11:35:30.551  mediaTrack published  TR_AMm3gsZsx5Kcjv   <- server holds a live publication
11:35:32.569  addTrack (retry)      cid 1F9B83F0…
11:35:32.777  track unpublished     TR_AMm3gsZsx5Kcjv   <- rollback renegotiation, ~200ms after the failure
11:35:32.778  mediaTrack published  TR_AMSsuoSJQtVn3Z
11:35:32.990  participant closing
```
