### PR TITLE
Add custom video encoder factory support via SDK-owned protocols

### DIFF
--- a/.changes/custom-video-encoder-factory
+++ b/.changes/custom-video-encoder-factory
@@ -1,0 +1,1 @@
+minor type="added" "Custom video encoder factories: set LiveKitSDK.set(videoEncoderFactory:) with an implementation of the new VideoEncoderFactory/VideoEncoder protocols to replace the default VideoToolbox backed encoders"

--- a/.changes/custom-video-encoder-factory
+++ b/.changes/custom-video-encoder-factory
@@ -1,1 +1,1 @@
-minor type="added" "Custom video encoder factories: set LiveKitSDK.set(videoEncoderFactory:) with an implementation of the new VideoEncoderFactory/VideoEncoder protocols to replace the default VideoToolbox backed encoders"
+minor type="added" "Custom video encoder factories: call LiveKitSDK.set(videoEncoderFactory:) before any other SDK API with an implementation of the new VideoEncoderFactory and VideoEncoder protocols to supply H264 or H265 encoders in place of the default VideoToolbox backed ones"

--- a/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
+++ b/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+public extension LiveKitSDK {
+    /// Sets a custom ``VideoEncoderFactory`` used to create video encoders,
+    /// replacing the SDK's default VideoToolbox backed encoders.
+    ///
+    /// The factory is wrapped in WebRTC's simulcast encoder adapter, so each
+    /// simulcast layer is encoded by an encoder created from this factory.
+    ///
+    /// Pass `nil` to restore the default factory.
+    ///
+    /// ```swift
+    /// try LiveKitSDK.set(videoEncoderFactory: MyEncoderFactory())
+    /// let room = Room()
+    /// try await room.connect(url: url, token: token)
+    /// ```
+    ///
+    /// - Warning: Must be called before the first `Room` connection or track
+    ///   creation. Throws ``LiveKitError`` with type `.invalidState` afterwards,
+    ///   since the underlying peer connection factory is created once per process.
+    static func set(videoEncoderFactory: (any VideoEncoderFactory)?) throws {
+        try RTC.pcFactoryState.mutate {
+            guard !$0.isInitialized else {
+                throw LiveKitError(.invalidState, message: "Cannot set videoEncoderFactory after the peer connection factory has been initialized")
+            }
+            $0.customVideoEncoderFactory = videoEncoderFactory
+        }
+    }
+}

--- a/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
+++ b/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
@@ -21,7 +21,9 @@ public extension LiveKitSDK {
     /// replacing the SDK's default VideoToolbox backed encoders.
     ///
     /// The factory is wrapped in WebRTC's simulcast encoder adapter, so each
-    /// simulcast layer is encoded by an encoder created from this factory.
+    /// simulcast layer is encoded by an encoder created from this factory, with
+    /// the SDK's built in encoders as the fallback when an encoder reports
+    /// ``VideoEncoderStatus/fallbackSoftware``.
     ///
     /// Pass `nil` to restore the default factory.
     ///

--- a/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
+++ b/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
@@ -33,10 +33,16 @@ public extension LiveKitSDK {
     /// try await room.connect(url: url, token: token)
     /// ```
     ///
-    /// - Warning: Must be called before the first `Room` connection or track
-    ///   creation. Throws ``LiveKitError`` with type `.invalidState` afterwards,
-    ///   since the underlying peer connection factory is created once per process.
+    /// - Warning: This method must be called before any other SDK API is used,
+    ///   e.g. in the `App.init()` or `application(_:didFinishLaunchingWithOptions:)`.
+    ///   Any access to the peer connection factory, such as connecting, creating a
+    ///   track, querying capabilities or setting up E2EE, initializes it once per
+    ///   process, and this method throws ``LiveKitError`` with type `.invalidState`
+    ///   afterwards.
     static func set(videoEncoderFactory: (any VideoEncoderFactory)?) throws {
+        if let videoEncoderFactory, videoEncoderFactory.supportedCodecs.isEmpty {
+            throw LiveKitError(.invalidParameter, message: "videoEncoderFactory must advertise at least one supported codec")
+        }
         try RTC.pcFactoryState.mutate {
             guard !$0.isInitialized else {
                 throw LiveKitError(.invalidState, message: "Cannot set videoEncoderFactory after the peer connection factory has been initialized")

--- a/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
+++ b/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
@@ -17,13 +17,18 @@
 import Foundation
 
 public extension LiveKitSDK {
-    /// Sets a custom ``VideoEncoderFactory`` used to create video encoders,
-    /// replacing the SDK's default VideoToolbox backed encoders.
+    /// Sets a custom ``VideoEncoderFactory`` used to create video encoders for
+    /// the codecs it supports, taking over from the SDK's default VideoToolbox
+    /// backed encoders for those codecs.
     ///
     /// The factory is wrapped in WebRTC's simulcast encoder adapter, so each
-    /// simulcast layer is encoded by an encoder created from this factory, with
-    /// the SDK's built in encoders as the fallback when an encoder reports
-    /// ``VideoEncoderStatus/fallbackSoftware``.
+    /// simulcast layer is encoded by an encoder created from this factory. The
+    /// SDK's built in encoders remain the fallback, both for codecs the factory
+    /// declines and when an encoder reports ``VideoEncoderStatus/fallbackSoftware``.
+    ///
+    /// Only H264, H265 and AV1 can be supplied by a custom factory. VP8 and VP9
+    /// require codec specific layer information that the bridge cannot carry
+    /// yet, so advertising them throws ``LiveKitError`` with type `.invalidParameter`.
     ///
     /// Pass `nil` to restore the default factory.
     ///
@@ -40,8 +45,15 @@ public extension LiveKitSDK {
     ///   process, and this method throws ``LiveKitError`` with type `.invalidState`
     ///   afterwards.
     static func set(videoEncoderFactory: (any VideoEncoderFactory)?) throws {
-        if let videoEncoderFactory, videoEncoderFactory.supportedCodecs.isEmpty {
-            throw LiveKitError(.invalidParameter, message: "videoEncoderFactory must advertise at least one supported codec")
+        if let videoEncoderFactory {
+            let codecs = videoEncoderFactory.supportedCodecs
+            guard !codecs.isEmpty else {
+                throw LiveKitError(.invalidParameter, message: "videoEncoderFactory must advertise at least one supported codec")
+            }
+            let unsupported = codecs.map(\.name).filter { !Self.bridgeableCodecNames.contains($0.uppercased()) }
+            guard unsupported.isEmpty else {
+                throw LiveKitError(.invalidParameter, message: "videoEncoderFactory cannot supply encoders for \(unsupported.joined(separator: ", ")), only H264, H265 and AV1 are supported")
+            }
         }
         try RTC.pcFactoryState.mutate {
             guard !$0.isInitialized else {
@@ -50,4 +62,8 @@ public extension LiveKitSDK {
             $0.customVideoEncoderFactory = videoEncoderFactory
         }
     }
+
+    /// Codecs whose RTP packetization needs no codec specific info beyond what
+    /// ``EncodedVideoFrame/CodecSpecificInfo`` can express.
+    private static let bridgeableCodecNames: Set<String> = ["H264", "H265", "AV1"]
 }

--- a/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
+++ b/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
@@ -45,8 +45,10 @@ public extension LiveKitSDK {
     ///   process, and this method throws ``LiveKitError`` with type `.invalidState`
     ///   afterwards.
     static func set(videoEncoderFactory: (any VideoEncoderFactory)?) throws {
-        if let videoEncoderFactory {
-            let codecs = videoEncoderFactory.supportedCodecs
+        // Read once and stored alongside the factory, so validation, the advertised
+        // list and the codecs the adapter will accept all come from the same snapshot.
+        let codecs = videoEncoderFactory?.supportedCodecs ?? []
+        if videoEncoderFactory != nil {
             guard !codecs.isEmpty else {
                 throw LiveKitError(.invalidParameter, message: "videoEncoderFactory must advertise at least one supported codec")
             }
@@ -60,6 +62,7 @@ public extension LiveKitSDK {
                 throw LiveKitError(.invalidState, message: "Cannot set videoEncoderFactory after the peer connection factory has been initialized")
             }
             $0.customVideoEncoderFactory = videoEncoderFactory
+            $0.customVideoEncoderCodecs = codecs
         }
     }
 

--- a/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
+++ b/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
@@ -47,7 +47,7 @@ public extension LiveKitSDK {
     static func set(videoEncoderFactory: (any VideoEncoderFactory)?) throws {
         // Read once and stored alongside the factory, so validation, the advertised
         // list and the codecs the adapter will accept all come from the same snapshot.
-        let codecs = videoEncoderFactory?.supportedCodecs ?? []
+        let codecs = (videoEncoderFactory?.supportedCodecs ?? []).map { $0.normalizedForAdvertising() }
         if videoEncoderFactory != nil {
             guard !codecs.isEmpty else {
                 throw LiveKitError(.invalidParameter, message: "videoEncoderFactory must advertise at least one supported codec")

--- a/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
+++ b/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
@@ -58,8 +58,8 @@ public extension LiveKitSDK {
             }
         }
         try RTC.pcFactoryState.mutate {
-            guard !$0.isInitialized else {
-                throw LiveKitError(.invalidState, message: "Cannot set videoEncoderFactory after the peer connection factory has been initialized")
+            guard !$0.isInitialized, !$0.isEncoderFactoryInitialized else {
+                throw LiveKitError(.invalidState, message: "Cannot set videoEncoderFactory after the encoder factory or peer connection factory has been initialized")
             }
             $0.customVideoEncoderFactory = videoEncoderFactory
             $0.customVideoEncoderCodecs = codecs

--- a/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
+++ b/Sources/LiveKit/Core/LiveKitSDK+VideoEncoderFactory.swift
@@ -26,9 +26,9 @@ public extension LiveKitSDK {
     /// SDK's built in encoders remain the fallback, both for codecs the factory
     /// declines and when an encoder reports ``VideoEncoderStatus/fallbackSoftware``.
     ///
-    /// Only H264, H265 and AV1 can be supplied by a custom factory. VP8 and VP9
-    /// require codec specific layer information that the bridge cannot carry
-    /// yet, so advertising them throws ``LiveKitError`` with type `.invalidParameter`.
+    /// Only H264 and H265 can be supplied by a custom factory. VP8, VP9 and AV1
+    /// need layer or dependency information that the bridge cannot carry yet, so
+    /// advertising them throws ``LiveKitError`` with type `.invalidParameter`.
     ///
     /// Pass `nil` to restore the default factory.
     ///
@@ -54,7 +54,7 @@ public extension LiveKitSDK {
             }
             let unsupported = codecs.map(\.name).filter { !Self.bridgeableCodecNames.contains($0.uppercased()) }
             guard unsupported.isEmpty else {
-                throw LiveKitError(.invalidParameter, message: "videoEncoderFactory cannot supply encoders for \(unsupported.joined(separator: ", ")), only H264, H265 and AV1 are supported")
+                throw LiveKitError(.invalidParameter, message: "videoEncoderFactory cannot supply encoders for \(unsupported.joined(separator: ", ")), only H264 and H265 are supported")
             }
         }
         try RTC.pcFactoryState.mutate {
@@ -66,7 +66,8 @@ public extension LiveKitSDK {
         }
     }
 
-    /// Codecs whose RTP packetization needs no codec specific info beyond what
-    /// ``EncodedVideoFrame/CodecSpecificInfo`` can express.
-    private static let bridgeableCodecNames: Set<String> = ["H264", "H265", "AV1"]
+    /// Codecs whose RTP packetization needs nothing beyond the H264 packetization
+    /// mode the bridge can express. VP8 and VP9 need per frame layer info and AV1
+    /// needs a dependency descriptor, none of which reach WebRTC from here.
+    private static let bridgeableCodecNames: Set<String> = ["H264", "H265"]
 }

--- a/Sources/LiveKit/Core/RTC.swift
+++ b/Sources/LiveKit/Core/RTC.swift
@@ -18,7 +18,7 @@ import Foundation
 
 internal import LiveKitWebRTC
 
-private final class VideoEncoderFactory: LKRTCDefaultVideoEncoderFactory, @unchecked Sendable {}
+private final class DefaultVideoEncoderFactory: LKRTCDefaultVideoEncoderFactory, @unchecked Sendable {}
 
 private final class VideoDecoderFactory: LKRTCDefaultVideoDecoderFactory, @unchecked Sendable {}
 
@@ -129,6 +129,7 @@ extension RTC {
         var isInitialized: Bool = false
         var admType: AudioDeviceModuleType = .audioEngine
         var bypassVoiceProcessing: Bool = false
+        var customVideoEncoderFactory: (any VideoEncoderFactory)?
     }
 
     static let pcFactoryState = StateSync(PeerConnectionFactoryState())
@@ -136,10 +137,13 @@ extension RTC {
     // global properties are already lazy
 
     static let encoderFactory: LKRTCVideoEncoderFactory & Sendable = {
-        let encoderFactory = VideoEncoderFactory()
+        let encoderFactory: LKRTCVideoEncoderFactory & Sendable = if let customFactory = pcFactoryState.read({ $0.customVideoEncoderFactory }) {
+            VideoEncoderFactoryAdapter(factory: customFactory)
+        } else {
+            DefaultVideoEncoderFactory()
+        }
         return VideoEncoderFactorySimulcast(primary: encoderFactory,
                                             fallback: encoderFactory)
-
     }()
 
     static let decoderFactory: LKRTCVideoDecoderFactory & Sendable = VideoDecoderFactory()

--- a/Sources/LiveKit/Core/RTC.swift
+++ b/Sources/LiveKit/Core/RTC.swift
@@ -136,14 +136,18 @@ extension RTC {
 
     // global properties are already lazy
 
+    // Must not be forced from inside a `pcFactoryState` read or mutate block, since
+    // its initializer reads that state and `StateSync` is not reentrant.
     static let encoderFactory: LKRTCVideoEncoderFactory & Sendable = {
-        let encoderFactory: LKRTCVideoEncoderFactory & Sendable = if let customFactory = pcFactoryState.read({ $0.customVideoEncoderFactory }) {
-            VideoEncoderFactoryAdapter(factory: customFactory)
-        } else {
-            DefaultVideoEncoderFactory()
+        guard let customFactory = pcFactoryState.read({ $0.customVideoEncoderFactory }) else {
+            let defaultFactory = DefaultVideoEncoderFactory()
+            return VideoEncoderFactorySimulcast(primary: defaultFactory,
+                                                fallback: defaultFactory)
         }
-        return VideoEncoderFactorySimulcast(primary: encoderFactory,
-                                            fallback: encoderFactory)
+        // A custom encoder reporting `.fallbackSoftware` falls back to the built in
+        // VideoToolbox encoders instead of failing the stream.
+        return VideoEncoderFactorySimulcast(primary: VideoEncoderFactoryAdapter(factory: customFactory),
+                                            fallback: DefaultVideoEncoderFactory())
     }()
 
     static let decoderFactory: LKRTCVideoDecoderFactory & Sendable = VideoDecoderFactory()

--- a/Sources/LiveKit/Core/RTC.swift
+++ b/Sources/LiveKit/Core/RTC.swift
@@ -130,6 +130,9 @@ extension RTC {
         var admType: AudioDeviceModuleType = .audioEngine
         var bypassVoiceProcessing: Bool = false
         var customVideoEncoderFactory: (any VideoEncoderFactory)?
+        // Snapshot of the factory's supported codecs taken when it was set, so the
+        // validated list is the one advertised and enforced.
+        var customVideoEncoderCodecs: [VideoCodecInfo] = []
     }
 
     static let pcFactoryState = StateSync(PeerConnectionFactoryState())
@@ -139,15 +142,18 @@ extension RTC {
     // Must not be forced from inside a `pcFactoryState` read or mutate block, since
     // its initializer reads that state and `StateSync` is not reentrant.
     static let encoderFactory: LKRTCVideoEncoderFactory & Sendable = {
-        guard let customFactory = pcFactoryState.read({ $0.customVideoEncoderFactory }) else {
+        let (customFactory, customCodecs) = pcFactoryState.read { ($0.customVideoEncoderFactory, $0.customVideoEncoderCodecs) }
+        guard let customFactory else {
             let defaultFactory = DefaultVideoEncoderFactory()
             return VideoEncoderFactorySimulcast(primary: defaultFactory,
                                                 fallback: defaultFactory)
         }
         // A custom encoder reporting `.fallbackSoftware` falls back to the built in
         // VideoToolbox encoders instead of failing the stream.
-        return VideoEncoderFactorySimulcast(primary: VideoEncoderFactoryAdapter(factory: customFactory),
+        return VideoEncoderFactorySimulcast(primary: VideoEncoderFactoryAdapter(factory: customFactory,
+                                                                                supportedCodecs: customCodecs),
                                             fallback: DefaultVideoEncoderFactory())
+
     }()
 
     static let decoderFactory: LKRTCVideoDecoderFactory & Sendable = VideoDecoderFactory()

--- a/Sources/LiveKit/Core/RTC.swift
+++ b/Sources/LiveKit/Core/RTC.swift
@@ -127,6 +127,10 @@ extension RTC {
 extension RTC {
     struct PeerConnectionFactoryState {
         var isInitialized: Bool = false
+        // Set once `encoderFactory` has resolved and captured the custom factory.
+        // Kept separate from `isInitialized`, which audio configuration guards read
+        // to mean the peer connection factory and its audio module exist.
+        var isEncoderFactoryInitialized: Bool = false
         var admType: AudioDeviceModuleType = .audioEngine
         var bypassVoiceProcessing: Bool = false
         var customVideoEncoderFactory: (any VideoEncoderFactory)?
@@ -140,9 +144,16 @@ extension RTC {
     // global properties are already lazy
 
     // Must not be forced from inside a `pcFactoryState` read or mutate block, since
-    // its initializer reads that state and `StateSync` is not reentrant.
+    // its initializer mutates that state and `StateSync` is not reentrant.
     static let encoderFactory: LKRTCVideoEncoderFactory & Sendable = {
-        let (customFactory, customCodecs) = pcFactoryState.read { ($0.customVideoEncoderFactory, $0.customVideoEncoderCodecs) }
+        // Resolving this captures the custom factory for the life of the process,
+        // so it records that itself. Otherwise a set() after this point but before
+        // the peer connection factory would succeed and do nothing.
+        let (customFactory, customCodecs) = pcFactoryState.mutate {
+            $0.isEncoderFactoryInitialized = true
+            return ($0.customVideoEncoderFactory, $0.customVideoEncoderCodecs)
+        }
+
         guard let customFactory else {
             let defaultFactory = DefaultVideoEncoderFactory()
             return VideoEncoderFactorySimulcast(primary: defaultFactory,

--- a/Sources/LiveKit/Core/VideoEncoderFactoryAdapter.swift
+++ b/Sources/LiveKit/Core/VideoEncoderFactoryAdapter.swift
@@ -32,7 +32,7 @@ final class VideoEncoderFactoryAdapter: NSObject, LKRTCVideoEncoderFactory, @unc
     func createEncoder(_ info: LKRTCVideoCodecInfo) -> (any LKRTCVideoEncoder)? {
         let codec = VideoCodecInfo(fromRTCType: info)
         guard let encoder = factory.createEncoder(for: codec) else { return nil }
-        return VideoEncoderAdapter(encoder: encoder, codecName: codec.name)
+        return VideoEncoderAdapter(encoder: encoder, codec: codec)
     }
 
     func supportedCodecs() -> [LKRTCVideoCodecInfo] {
@@ -82,12 +82,12 @@ final class VideoEncoderAdapter: NSObject, LKRTCVideoEncoder, @unchecked Sendabl
     }
 
     private let encoder: any VideoEncoder
-    private let codecName: String
+    private let codec: VideoCodecInfo
     private let callbackBox = CallbackBox()
 
-    init(encoder: any VideoEncoder, codecName: String) {
+    init(encoder: any VideoEncoder, codec: VideoCodecInfo) {
         self.encoder = encoder
-        self.codecName = codecName
+        self.codec = codec
         super.init()
     }
 
@@ -99,9 +99,9 @@ final class VideoEncoderAdapter: NSObject, LKRTCVideoEncoder, @unchecked Sendabl
         }
         guard callbackBox.set(callback) else { return }
         let box = callbackBox
-        let codecName = codecName
+        let codec = codec
         encoder.setCallback { frame in
-            let (image, info) = frame.toRTCType(codecName: codecName)
+            let (image, info) = frame.toRTCType(codec: codec)
             return box.invoke(image, info)
         }
     }

--- a/Sources/LiveKit/Core/VideoEncoderFactoryAdapter.swift
+++ b/Sources/LiveKit/Core/VideoEncoderFactoryAdapter.swift
@@ -21,9 +21,11 @@ internal import LiveKitWebRTC
 /// Bridges a public ``VideoEncoderFactory`` to WebRTC's `RTCVideoEncoderFactory`.
 final class VideoEncoderFactoryAdapter: NSObject, LKRTCVideoEncoderFactory, @unchecked Sendable {
     private let factory: any VideoEncoderFactory
+    private let supportedRTCCodecs: [LKRTCVideoCodecInfo]
 
     init(factory: any VideoEncoderFactory) {
         self.factory = factory
+        supportedRTCCodecs = factory.supportedCodecs.map { $0.toRTCType() }
         super.init()
     }
 
@@ -33,13 +35,53 @@ final class VideoEncoderFactoryAdapter: NSObject, LKRTCVideoEncoderFactory, @unc
     }
 
     func supportedCodecs() -> [LKRTCVideoCodecInfo] {
-        factory.supportedCodecs.map { $0.toRTCType() }
+        supportedRTCCodecs
     }
 }
 
 /// Bridges a public ``VideoEncoder`` to WebRTC's `RTCVideoEncoder`.
 final class VideoEncoderAdapter: NSObject, LKRTCVideoEncoder, @unchecked Sendable {
+    /// Holds the current WebRTC callback so the closure handed to the encoder can
+    /// stay the same object across `setCallback` calls, and so clearing it cannot
+    /// race with a frame being delivered from an encoder thread.
+    private final class CallbackBox: @unchecked Sendable {
+        private let lock: some Lock = createLock()
+        // WebRTC's encoded image callback is safe to invoke from any thread,
+        // and access to the stored block is serialized by the lock.
+        private nonisolated(unsafe) var callback: RTCVideoEncoderCallback?
+        private var isAttached = false
+
+        /// Stores `callback` and reports whether the encoder still needs to be
+        /// handed the forwarding closure.
+        func set(_ callback: RTCVideoEncoderCallback?) -> Bool {
+            lock.sync {
+                self.callback = callback
+                guard callback != nil, !isAttached else { return false }
+                isAttached = true
+                return true
+            }
+        }
+
+        func clear() {
+            lock.sync {
+                callback = nil
+                isAttached = false
+            }
+        }
+
+        // The callback runs under the lock so that clear() does not return while a
+        // frame is still being delivered. WebRTC never calls back into the encoder
+        // from inside this callback, so holding the lock here cannot deadlock.
+        func invoke(_ image: LKRTCEncodedImage, _ info: any LKRTCCodecSpecificInfo) -> Bool {
+            lock.sync {
+                guard let callback else { return false }
+                return callback(image, info)
+            }
+        }
+    }
+
     private let encoder: any VideoEncoder
+    private let callbackBox = CallbackBox()
 
     init(encoder: any VideoEncoder) {
         self.encoder = encoder
@@ -47,15 +89,16 @@ final class VideoEncoderAdapter: NSObject, LKRTCVideoEncoder, @unchecked Sendabl
     }
 
     func setCallback(_ callback: RTCVideoEncoderCallback?) {
-        guard let callback else {
+        guard callback != nil else {
+            callbackBox.clear()
             encoder.setCallback(nil)
             return
         }
-        // WebRTC's encoded image callback is safe to invoke from any thread.
-        nonisolated(unsafe) let rtcCallback = callback
+        guard callbackBox.set(callback) else { return }
+        let box = callbackBox
         encoder.setCallback { frame in
             let (image, info) = frame.toRTCType()
-            return rtcCallback(image, info)
+            return box.invoke(image, info)
         }
     }
 
@@ -65,7 +108,8 @@ final class VideoEncoderAdapter: NSObject, LKRTCVideoEncoder, @unchecked Sendabl
     }
 
     func release() -> Int {
-        encoder.releaseEncoder().rawValue
+        callbackBox.clear()
+        return encoder.releaseEncoder().rawValue
     }
 
     func encode(_ frame: LKRTCVideoFrame,
@@ -73,16 +117,21 @@ final class VideoEncoderAdapter: NSObject, LKRTCVideoEncoder, @unchecked Sendabl
                 frameTypes: [NSNumber]) -> Int
     {
         guard let lkFrame = frame.toLKType() else {
-            return VideoEncoderStatus.invalidParameter.rawValue
+            // Lets the simulcast adapter switch to the built in encoder instead of
+            // dropping every frame with a buffer the SDK cannot map.
+            return VideoEncoderStatus.fallbackSoftware.rawValue
         }
-        let types = frameTypes.compactMap {
-            LKRTCFrameType(rawValue: $0.uintValue).flatMap { EncodedVideoFrame.FrameType(fromRTCType: $0) }
+        // The array is positional, one entry per simulcast stream, so arity is
+        // preserved and anything not a known video frame type becomes a delta.
+        let types = frameTypes.map {
+            LKRTCFrameType(rawValue: $0.uintValue)
+                .flatMap { EncodedVideoFrame.FrameType(fromRTCType: $0) } ?? .delta
         }
         return encoder.encode(lkFrame, frameTypes: types).rawValue
     }
 
     func setBitrate(_ bitrateKbit: UInt32, framerate: UInt32) -> Int32 {
-        Int32(encoder.setBitrate(bitrateKbit, framerate: framerate).rawValue)
+        Int32(truncatingIfNeeded: encoder.setBitrate(bitrateKbit, framerate: framerate).rawValue)
     }
 
     func implementationName() -> String {

--- a/Sources/LiveKit/Core/VideoEncoderFactoryAdapter.swift
+++ b/Sources/LiveKit/Core/VideoEncoderFactoryAdapter.swift
@@ -30,8 +30,9 @@ final class VideoEncoderFactoryAdapter: NSObject, LKRTCVideoEncoderFactory, @unc
     }
 
     func createEncoder(_ info: LKRTCVideoCodecInfo) -> (any LKRTCVideoEncoder)? {
-        guard let encoder = factory.createEncoder(for: VideoCodecInfo(fromRTCType: info)) else { return nil }
-        return VideoEncoderAdapter(encoder: encoder)
+        let codec = VideoCodecInfo(fromRTCType: info)
+        guard let encoder = factory.createEncoder(for: codec) else { return nil }
+        return VideoEncoderAdapter(encoder: encoder, codecName: codec.name)
     }
 
     func supportedCodecs() -> [LKRTCVideoCodecInfo] {
@@ -81,10 +82,12 @@ final class VideoEncoderAdapter: NSObject, LKRTCVideoEncoder, @unchecked Sendabl
     }
 
     private let encoder: any VideoEncoder
+    private let codecName: String
     private let callbackBox = CallbackBox()
 
-    init(encoder: any VideoEncoder) {
+    init(encoder: any VideoEncoder, codecName: String) {
         self.encoder = encoder
+        self.codecName = codecName
         super.init()
     }
 
@@ -96,8 +99,9 @@ final class VideoEncoderAdapter: NSObject, LKRTCVideoEncoder, @unchecked Sendabl
         }
         guard callbackBox.set(callback) else { return }
         let box = callbackBox
+        let codecName = codecName
         encoder.setCallback { frame in
-            let (image, info) = frame.toRTCType()
+            let (image, info) = frame.toRTCType(codecName: codecName)
             return box.invoke(image, info)
         }
     }

--- a/Sources/LiveKit/Core/VideoEncoderFactoryAdapter.swift
+++ b/Sources/LiveKit/Core/VideoEncoderFactoryAdapter.swift
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+internal import LiveKitWebRTC
+
+/// Bridges a public ``VideoEncoderFactory`` to WebRTC's `RTCVideoEncoderFactory`.
+final class VideoEncoderFactoryAdapter: NSObject, LKRTCVideoEncoderFactory, @unchecked Sendable {
+    private let factory: any VideoEncoderFactory
+
+    init(factory: any VideoEncoderFactory) {
+        self.factory = factory
+        super.init()
+    }
+
+    func createEncoder(_ info: LKRTCVideoCodecInfo) -> (any LKRTCVideoEncoder)? {
+        guard let encoder = factory.createEncoder(for: VideoCodecInfo(fromRTCType: info)) else { return nil }
+        return VideoEncoderAdapter(encoder: encoder)
+    }
+
+    func supportedCodecs() -> [LKRTCVideoCodecInfo] {
+        factory.supportedCodecs.map { $0.toRTCType() }
+    }
+}
+
+/// Bridges a public ``VideoEncoder`` to WebRTC's `RTCVideoEncoder`.
+final class VideoEncoderAdapter: NSObject, LKRTCVideoEncoder, @unchecked Sendable {
+    private let encoder: any VideoEncoder
+
+    init(encoder: any VideoEncoder) {
+        self.encoder = encoder
+        super.init()
+    }
+
+    func setCallback(_ callback: RTCVideoEncoderCallback?) {
+        guard let callback else {
+            encoder.setCallback(nil)
+            return
+        }
+        // WebRTC's encoded image callback is safe to invoke from any thread.
+        nonisolated(unsafe) let rtcCallback = callback
+        encoder.setCallback { frame in
+            let (image, info) = frame.toRTCType()
+            return rtcCallback(image, info)
+        }
+    }
+
+    func startEncode(with settings: LKRTCVideoEncoderSettings, numberOfCores: Int32) -> Int {
+        encoder.startEncode(with: VideoEncoderSettings(fromRTCType: settings),
+                            numberOfCores: Int(numberOfCores)).rawValue
+    }
+
+    func release() -> Int {
+        encoder.releaseEncoder().rawValue
+    }
+
+    func encode(_ frame: LKRTCVideoFrame,
+                codecSpecificInfo _: (any LKRTCCodecSpecificInfo)?,
+                frameTypes: [NSNumber]) -> Int
+    {
+        guard let lkFrame = frame.toLKType() else {
+            return VideoEncoderStatus.invalidParameter.rawValue
+        }
+        let types = frameTypes.compactMap {
+            LKRTCFrameType(rawValue: $0.uintValue).flatMap { EncodedVideoFrame.FrameType(fromRTCType: $0) }
+        }
+        return encoder.encode(lkFrame, frameTypes: types).rawValue
+    }
+
+    func setBitrate(_ bitrateKbit: UInt32, framerate: UInt32) -> Int32 {
+        Int32(encoder.setBitrate(bitrateKbit, framerate: framerate).rawValue)
+    }
+
+    func implementationName() -> String {
+        encoder.implementationName
+    }
+
+    func scalingSettings() -> LKRTCVideoEncoderQpThresholds? {
+        encoder.scalingSettings?.toRTCType()
+    }
+
+    var resolutionAlignment: Int {
+        encoder.resolutionAlignment
+    }
+
+    var applyAlignmentToAllSimulcastLayers: Bool {
+        encoder.applyAlignmentToAllSimulcastLayers
+    }
+
+    var supportsNativeHandle: Bool {
+        encoder.supportsNativeHandle
+    }
+}

--- a/Sources/LiveKit/Core/VideoEncoderFactoryAdapter.swift
+++ b/Sources/LiveKit/Core/VideoEncoderFactoryAdapter.swift
@@ -165,13 +165,11 @@ final class VideoEncoderAdapter: NSObject, LKRTCVideoEncoder, @unchecked Sendabl
         encoder.scalingSettings?.toRTCType()
     }
 
-    var resolutionAlignment: Int {
-        encoder.resolutionAlignment
-    }
+    // Not exposed on the public protocol: the bridge always reports 1 to WebRTC
+    // regardless of this value, so encoders must accept any resolution.
+    var resolutionAlignment: Int { 1 }
 
-    var applyAlignmentToAllSimulcastLayers: Bool {
-        encoder.applyAlignmentToAllSimulcastLayers
-    }
+    var applyAlignmentToAllSimulcastLayers: Bool { false }
 
     var supportsNativeHandle: Bool {
         encoder.supportsNativeHandle

--- a/Sources/LiveKit/Core/VideoEncoderFactoryAdapter.swift
+++ b/Sources/LiveKit/Core/VideoEncoderFactoryAdapter.swift
@@ -53,42 +53,50 @@ final class VideoEncoderFactoryAdapter: NSObject, LKRTCVideoEncoderFactory, @unc
 
 /// Bridges a public ``VideoEncoder`` to WebRTC's `RTCVideoEncoder`.
 final class VideoEncoderAdapter: NSObject, LKRTCVideoEncoder, @unchecked Sendable {
-    /// Holds the current WebRTC callback so the closure handed to the encoder can
-    /// stay the same object across `setCallback` calls, and so clearing it cannot
-    /// race with a frame being delivered from an encoder thread.
+    /// Holds the current WebRTC callback behind one stable closure handed to the
+    /// encoder.
+    ///
+    /// WebRTC re-registers a fresh callback without an intervening nil whenever the
+    /// simulcast adapter's stream contexts are moved, so the closure stays the same
+    /// across consecutive non nil registrations and only the stored block changes.
+    /// After `clear()` a later registration attaches a new closure. A delivery that
+    /// finds the box cleared is dropped, while one that already copied the block out
+    /// may still finish, so teardown relies on the encoder honoring the
+    /// ``VideoEncoder/releaseEncoder()`` contract of delivering nothing afterwards.
+    /// The callback runs outside the lock: the block only holds a raw pointer to
+    /// WebRTC's native callback, so a lock could not extend its lifetime, and
+    /// holding one across the packetize and send path would make `release()` wait
+    /// on every frame.
     private final class CallbackBox: @unchecked Sendable {
-        private let lock: some Lock = createLock()
-        // WebRTC's encoded image callback is safe to invoke from any thread,
-        // and access to the stored block is serialized by the lock.
-        private nonisolated(unsafe) var callback: RTCVideoEncoderCallback?
-        private var isAttached = false
+        private struct State {
+            var callback: RTCVideoEncoderCallback?
+            var isAttached = false
+        }
+
+        private let state = StateSync(State())
 
         /// Stores `callback` and reports whether the encoder still needs to be
         /// handed the forwarding closure.
         func set(_ callback: RTCVideoEncoderCallback?) -> Bool {
-            lock.sync {
-                self.callback = callback
-                guard callback != nil, !isAttached else { return false }
-                isAttached = true
+            state.mutate {
+                $0.callback = callback
+                guard callback != nil, !$0.isAttached else { return false }
+                $0.isAttached = true
                 return true
             }
         }
 
         func clear() {
-            lock.sync {
-                callback = nil
-                isAttached = false
+            state.mutate {
+                $0.callback = nil
+                $0.isAttached = false
             }
         }
 
-        // The callback runs under the lock so that clear() does not return while a
-        // frame is still being delivered. WebRTC never calls back into the encoder
-        // from inside this callback, so holding the lock here cannot deadlock.
         func invoke(_ image: LKRTCEncodedImage, _ info: any LKRTCCodecSpecificInfo) -> Bool {
-            lock.sync {
-                guard let callback else { return false }
-                return callback(image, info)
-            }
+            // Copied out so the callback runs outside the lock.
+            guard let callback = state.read({ $0.callback }) else { return false }
+            return callback(image, info)
         }
     }
 

--- a/Sources/LiveKit/Core/VideoEncoderFactoryAdapter.swift
+++ b/Sources/LiveKit/Core/VideoEncoderFactoryAdapter.swift
@@ -22,16 +22,27 @@ internal import LiveKitWebRTC
 final class VideoEncoderFactoryAdapter: NSObject, LKRTCVideoEncoderFactory, @unchecked Sendable {
     private let factory: any VideoEncoderFactory
     private let supportedRTCCodecs: [LKRTCVideoCodecInfo]
+    private let supportedCodecNames: Set<String>
 
-    init(factory: any VideoEncoderFactory) {
+    /// - Parameter supportedCodecs: The codecs validated when the factory was set.
+    ///   Read once here rather than from the factory again, so the list that was
+    ///   checked is the list that gets advertised and enforced.
+    init(factory: any VideoEncoderFactory, supportedCodecs: [VideoCodecInfo]) {
         self.factory = factory
-        supportedRTCCodecs = factory.supportedCodecs.map { $0.toRTCType() }
+        supportedRTCCodecs = supportedCodecs.map { $0.toRTCType() }
+        supportedCodecNames = Set(supportedCodecs.map { $0.name.uppercased() })
         super.init()
     }
 
     func createEncoder(_ info: LKRTCVideoCodecInfo) -> (any LKRTCVideoEncoder)? {
         let codec = VideoCodecInfo(fromRTCType: info)
+        // The simulcast factory asks the primary for whatever codec was negotiated,
+        // including ones only the built in fallback advertised. Declining here
+        // routes those to the fallback and keeps unbridgeable codecs such as VP8
+        // away from the packetizer.
+        guard supportedCodecNames.contains(codec.name.uppercased()) else { return nil }
         guard let encoder = factory.createEncoder(for: codec) else { return nil }
+
         return VideoEncoderAdapter(encoder: encoder, codec: codec)
     }
 

--- a/Sources/LiveKit/Extensions/RTCI420Buffer.swift
+++ b/Sources/LiveKit/Extensions/RTCI420Buffer.swift
@@ -18,7 +18,7 @@ import Foundation
 
 internal import LiveKitWebRTC
 
-extension LKRTCI420Buffer {
+extension LKRTCI420BufferProtocol {
     // swiftlint:disable:next function_body_length
     func toPixelBuffer() -> CVPixelBuffer? {
         // default options

--- a/Sources/LiveKit/Protocols/VideoEncoder.swift
+++ b/Sources/LiveKit/Protocols/VideoEncoder.swift
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Result of a ``VideoEncoder`` operation, mirroring WebRTC's video codec error codes.
+public struct VideoEncoderStatus: RawRepresentable, Sendable, Equatable {
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    /// The operation completed successfully.
+    public static let ok = Self(rawValue: 0)
+    /// The operation failed with a generic error.
+    public static let error = Self(rawValue: -1)
+    /// The operation failed due to a memory allocation failure.
+    public static let memory = Self(rawValue: -3)
+    /// The operation failed due to an invalid parameter.
+    public static let invalidParameter = Self(rawValue: -4)
+    /// The operation timed out.
+    public static let timeout = Self(rawValue: -6)
+    /// The encoder has not been initialized via ``VideoEncoder/startEncode(with:numberOfCores:)``.
+    public static let uninitialized = Self(rawValue: -7)
+    /// Requests WebRTC to fall back to another encoder for this codec.
+    public static let fallbackSoftware = Self(rawValue: -13)
+    /// The encoder failed and should be released.
+    public static let encoderFailure = Self(rawValue: -16)
+}
+
+/// Delivers an ``EncodedVideoFrame`` produced by a custom ``VideoEncoder`` to WebRTC.
+///
+/// Returns `true` if the frame was accepted for packetization and transport.
+public typealias VideoEncoderCallback = @Sendable (EncodedVideoFrame) -> Bool
+
+/// A custom video encoder implementation, mirroring WebRTC's `VideoEncoder` interface.
+///
+/// Create instances from a ``VideoEncoderFactory`` registered via
+/// ``LiveKitSDK/set(videoEncoderFactory:)``. WebRTC drives the encoder lifecycle:
+/// `setCallback` and `startEncode` are called before the first frame, then `encode`
+/// per captured frame, with `setBitrate` adapting to network conditions, and
+/// finally `releaseEncoder`.
+public protocol VideoEncoder: Sendable {
+    /// Human readable name of the encoder implementation reported in stats.
+    var implementationName: String { get }
+
+    /// Encoded resolutions must be aligned to this value. Defaults to 1.
+    var resolutionAlignment: Int { get }
+
+    /// Whether ``resolutionAlignment`` is applied to all simulcast layers simultaneously.
+    /// Defaults to `false`.
+    var applyAlignmentToAllSimulcastLayers: Bool { get }
+
+    /// Whether the encoder accepts frames backed by `CVPixelBuffer` directly.
+    /// When `false`, frames are converted to I420 before ``encode(_:frameTypes:)``.
+    /// Defaults to `true`.
+    var supportsNativeHandle: Bool { get }
+
+    /// QP thresholds for WebRTC's quality scaler, or `nil` to disable quality scaling.
+    /// Defaults to `nil`.
+    var scalingSettings: VideoEncoderQpThresholds? { get }
+
+    /// Sets the callback used to deliver encoded frames. Pass `nil` to clear.
+    func setCallback(_ callback: VideoEncoderCallback?)
+
+    /// Prepares the encoder for the given settings.
+    func startEncode(with settings: VideoEncoderSettings, numberOfCores: Int) -> VideoEncoderStatus
+
+    /// Encodes a single frame. Deliver the result asynchronously via the callback
+    /// set in ``setCallback(_:)``.
+    /// - Parameter frameTypes: Requested frame types, one entry per stream. A `.key`
+    ///   entry requests a key frame.
+    func encode(_ frame: VideoFrame, frameTypes: [EncodedVideoFrame.FrameType]) -> VideoEncoderStatus
+
+    /// Updates the target bitrate (kilobits per second) and framerate.
+    func setBitrate(_ bitrateKbps: UInt32, framerate: UInt32) -> VideoEncoderStatus
+
+    /// Releases encoder resources. The encoder may be started again afterwards.
+    func releaseEncoder() -> VideoEncoderStatus
+}
+
+public extension VideoEncoder {
+    var resolutionAlignment: Int { 1 }
+    var applyAlignmentToAllSimulcastLayers: Bool { false }
+    var supportsNativeHandle: Bool { true }
+    var scalingSettings: VideoEncoderQpThresholds? { nil }
+}

--- a/Sources/LiveKit/Protocols/VideoEncoder.swift
+++ b/Sources/LiveKit/Protocols/VideoEncoder.swift
@@ -28,6 +28,12 @@ public struct VideoEncoderStatus: RawRepresentable, Sendable, Equatable, Hashabl
 
     /// The operation completed successfully.
     public static let ok = Self(rawValue: 0)
+    /// The frame was consumed but produced no output.
+    public static let noOutput = Self(rawValue: 1)
+    /// The operation completed and the encoder requests a key frame next.
+    public static let okRequestKeyframe = Self(rawValue: 4)
+    /// The encoder produced significantly more bits than the target bitrate.
+    public static let targetBitrateOvershoot = Self(rawValue: 5)
     /// The operation failed with a generic error.
     public static let error = Self(rawValue: -1)
     /// The operation failed due to a memory allocation failure.
@@ -40,8 +46,6 @@ public struct VideoEncoderStatus: RawRepresentable, Sendable, Equatable, Hashabl
     public static let uninitialized = Self(rawValue: -7)
     /// Requests WebRTC to fall back to another encoder for this codec.
     public static let fallbackSoftware = Self(rawValue: -13)
-    /// The encoder produced significantly more bits than the target bitrate.
-    public static let targetBitrateOvershoot = Self(rawValue: -14)
     /// The encoder cannot honor the requested simulcast configuration.
     public static let simulcastParametersNotSupported = Self(rawValue: -15)
     /// The encoder failed and should be released.
@@ -52,6 +56,8 @@ extension VideoEncoderStatus: CustomStringConvertible {
     public var description: String {
         switch self {
         case .ok: "ok"
+        case .noOutput: "noOutput"
+        case .okRequestKeyframe: "okRequestKeyframe"
         case .error: "error"
         case .memory: "memory"
         case .invalidParameter: "invalidParameter"
@@ -75,18 +81,28 @@ public typealias VideoEncoderCallback = @Sendable (EncodedVideoFrame) -> Bool
 ///
 /// Create instances from a ``VideoEncoderFactory`` registered via
 /// ``LiveKitSDK/set(videoEncoderFactory:)``. WebRTC drives the encoder lifecycle:
-/// `setCallback` and `startEncode` are called before the first frame, then `encode`
-/// per captured frame, with `setBitrate` adapting to network conditions, and
-/// finally `releaseEncoder`.
+/// `startEncode` and `setCallback` are both called before the first frame, in
+/// either order, then `encode` per captured frame, with `setBitrate` adapting to
+/// network conditions, and finally `releaseEncoder`. The callback must not be
+/// required until the first `encode`.
+///
+/// - Note: The underlying WebRTC bridge reports every encoder as hardware
+///   accelerated, so CPU overuse detection uses the more permissive thresholds
+///   meant for hardware encoders. A software encoder should keep its own CPU
+///   usage in check.
 public protocol VideoEncoder: Sendable {
     /// Human readable name of the encoder implementation reported in stats.
     var implementationName: String { get }
 
     /// Encoded resolutions must be aligned to this value. Defaults to 1.
+    ///
+    /// - Note: The current WebRTC bridge always reports an alignment of 1, so
+    ///   values other than 1 are not honored yet. Encoders must handle
+    ///   unaligned input themselves until that is fixed.
     var resolutionAlignment: Int { get }
 
     /// Whether ``resolutionAlignment`` is applied to all simulcast layers simultaneously.
-    /// Defaults to `false`.
+    /// Defaults to `false`. Has no effect while ``resolutionAlignment`` is not honored.
     var applyAlignmentToAllSimulcastLayers: Bool { get }
 
     /// Whether the encoder accepts frames backed by `CVPixelBuffer` directly.

--- a/Sources/LiveKit/Protocols/VideoEncoder.swift
+++ b/Sources/LiveKit/Protocols/VideoEncoder.swift
@@ -17,9 +17,11 @@
 import Foundation
 
 /// Result of a ``VideoEncoder`` operation, mirroring WebRTC's video codec error codes.
-public struct VideoEncoderStatus: RawRepresentable, Sendable, Equatable {
+public struct VideoEncoderStatus: RawRepresentable, Sendable, Equatable, Hashable {
+    /// The underlying WebRTC video codec error code.
     public let rawValue: Int
 
+    /// Creates a status from a WebRTC video codec error code.
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }
@@ -38,8 +40,30 @@ public struct VideoEncoderStatus: RawRepresentable, Sendable, Equatable {
     public static let uninitialized = Self(rawValue: -7)
     /// Requests WebRTC to fall back to another encoder for this codec.
     public static let fallbackSoftware = Self(rawValue: -13)
+    /// The encoder produced significantly more bits than the target bitrate.
+    public static let targetBitrateOvershoot = Self(rawValue: -14)
+    /// The encoder cannot honor the requested simulcast configuration.
+    public static let simulcastParametersNotSupported = Self(rawValue: -15)
     /// The encoder failed and should be released.
     public static let encoderFailure = Self(rawValue: -16)
+}
+
+extension VideoEncoderStatus: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .ok: "ok"
+        case .error: "error"
+        case .memory: "memory"
+        case .invalidParameter: "invalidParameter"
+        case .timeout: "timeout"
+        case .uninitialized: "uninitialized"
+        case .fallbackSoftware: "fallbackSoftware"
+        case .targetBitrateOvershoot: "targetBitrateOvershoot"
+        case .simulcastParametersNotSupported: "simulcastParametersNotSupported"
+        case .encoderFailure: "encoderFailure"
+        default: "unknown(\(rawValue))"
+        }
+    }
 }
 
 /// Delivers an ``EncodedVideoFrame`` produced by a custom ``VideoEncoder`` to WebRTC.

--- a/Sources/LiveKit/Protocols/VideoEncoder.swift
+++ b/Sources/LiveKit/Protocols/VideoEncoder.swift
@@ -81,7 +81,8 @@ public protocol VideoEncoder: Sendable {
     func startEncode(with settings: VideoEncoderSettings, numberOfCores: Int) -> VideoEncoderStatus
 
     /// Encodes a single frame. Deliver the result asynchronously via the callback
-    /// set in ``setCallback(_:)``.
+    /// set in ``setCallback(_:)``. The encoded output must carry the frame's
+    /// ``VideoFrame/rtpTimestamp``.
     /// - Parameter frameTypes: Requested frame types, one entry per stream. A `.key`
     ///   entry requests a key frame.
     func encode(_ frame: VideoFrame, frameTypes: [EncodedVideoFrame.FrameType]) -> VideoEncoderStatus

--- a/Sources/LiveKit/Protocols/VideoEncoder.swift
+++ b/Sources/LiveKit/Protocols/VideoEncoder.swift
@@ -90,7 +90,8 @@ public protocol VideoEncoder: Sendable {
     /// Updates the target bitrate (kilobits per second) and framerate.
     func setBitrate(_ bitrateKbps: UInt32, framerate: UInt32) -> VideoEncoderStatus
 
-    /// Releases encoder resources. The encoder may be started again afterwards.
+    /// Releases encoder resources. No frames may be delivered to the callback
+    /// after this returns. The encoder may be started again afterwards.
     func releaseEncoder() -> VideoEncoderStatus
 }
 

--- a/Sources/LiveKit/Protocols/VideoEncoder.swift
+++ b/Sources/LiveKit/Protocols/VideoEncoder.swift
@@ -90,8 +90,11 @@ public protocol VideoEncoder: Sendable {
     var applyAlignmentToAllSimulcastLayers: Bool { get }
 
     /// Whether the encoder accepts frames backed by `CVPixelBuffer` directly.
-    /// When `false`, frames are converted to I420 before ``encode(_:frameTypes:)``.
-    /// Defaults to `true`.
+    ///
+    /// Returning `false` only affects how WebRTC crops and scales frames for
+    /// simulcast layers. Frames are still delivered in their native format,
+    /// typically NV12, so an encoder needing planar data must call
+    /// ``VideoFrame/toI420()`` itself. Defaults to `true`.
     var supportsNativeHandle: Bool { get }
 
     /// QP thresholds for WebRTC's quality scaler, or `nil` to disable quality scaling.

--- a/Sources/LiveKit/Protocols/VideoEncoder.swift
+++ b/Sources/LiveKit/Protocols/VideoEncoder.swift
@@ -17,6 +17,11 @@
 import Foundation
 
 /// Result of a ``VideoEncoder`` operation, mirroring WebRTC's video codec error codes.
+///
+/// Only codes WebRTC acts on are named. Any other negative value is logged and
+/// the frame dropped. Positive values are not exposed: the stream encoder treats
+/// them as success, but the simulcast adapter stops encoding the remaining
+/// layers of a frame on anything other than ``ok``.
 public struct VideoEncoderStatus: RawRepresentable, Sendable, Equatable, Hashable {
     /// The underlying WebRTC video codec error code.
     public let rawValue: Int
@@ -28,12 +33,6 @@ public struct VideoEncoderStatus: RawRepresentable, Sendable, Equatable, Hashabl
 
     /// The operation completed successfully.
     public static let ok = Self(rawValue: 0)
-    /// The frame was consumed but produced no output.
-    public static let noOutput = Self(rawValue: 1)
-    /// The operation completed and the encoder requests a key frame next.
-    public static let okRequestKeyframe = Self(rawValue: 4)
-    /// The encoder produced significantly more bits than the target bitrate.
-    public static let targetBitrateOvershoot = Self(rawValue: 5)
     /// The operation failed with a generic error.
     public static let error = Self(rawValue: -1)
     /// The operation failed due to a memory allocation failure.
@@ -56,15 +55,12 @@ extension VideoEncoderStatus: CustomStringConvertible {
     public var description: String {
         switch self {
         case .ok: "ok"
-        case .noOutput: "noOutput"
-        case .okRequestKeyframe: "okRequestKeyframe"
         case .error: "error"
         case .memory: "memory"
         case .invalidParameter: "invalidParameter"
         case .timeout: "timeout"
         case .uninitialized: "uninitialized"
         case .fallbackSoftware: "fallbackSoftware"
-        case .targetBitrateOvershoot: "targetBitrateOvershoot"
         case .simulcastParametersNotSupported: "simulcastParametersNotSupported"
         case .encoderFailure: "encoderFailure"
         default: "unknown(\(rawValue))"

--- a/Sources/LiveKit/Protocols/VideoEncoder.swift
+++ b/Sources/LiveKit/Protocols/VideoEncoder.swift
@@ -89,21 +89,11 @@ public typealias VideoEncoderCallback = @Sendable (EncodedVideoFrame) -> Bool
 /// - Note: The underlying WebRTC bridge reports every encoder as hardware
 ///   accelerated, so CPU overuse detection uses the more permissive thresholds
 ///   meant for hardware encoders. A software encoder should keep its own CPU
-///   usage in check.
+///   usage in check. Encoders must also accept any input resolution, since
+///   alignment requirements cannot be communicated to WebRTC yet.
 public protocol VideoEncoder: Sendable {
     /// Human readable name of the encoder implementation reported in stats.
     var implementationName: String { get }
-
-    /// Encoded resolutions must be aligned to this value. Defaults to 1.
-    ///
-    /// - Note: The current WebRTC bridge always reports an alignment of 1, so
-    ///   values other than 1 are not honored yet. Encoders must handle
-    ///   unaligned input themselves until that is fixed.
-    var resolutionAlignment: Int { get }
-
-    /// Whether ``resolutionAlignment`` is applied to all simulcast layers simultaneously.
-    /// Defaults to `false`. Has no effect while ``resolutionAlignment`` is not honored.
-    var applyAlignmentToAllSimulcastLayers: Bool { get }
 
     /// Whether the encoder accepts frames backed by `CVPixelBuffer` directly.
     ///
@@ -139,8 +129,6 @@ public protocol VideoEncoder: Sendable {
 }
 
 public extension VideoEncoder {
-    var resolutionAlignment: Int { 1 }
-    var applyAlignmentToAllSimulcastLayers: Bool { false }
     var supportsNativeHandle: Bool { true }
     var scalingSettings: VideoEncoderQpThresholds? { nil }
 }

--- a/Sources/LiveKit/Protocols/VideoEncoderFactory.swift
+++ b/Sources/LiveKit/Protocols/VideoEncoderFactory.swift
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Provides custom video encoders to the SDK, mirroring WebRTC's `VideoEncoderFactory`.
+///
+/// Register a factory via ``LiveKitSDK/set(videoEncoderFactory:)`` before connecting
+/// to a ``Room`` to replace the SDK's default VideoToolbox backed encoders.
+///
+/// ```swift
+/// final class MyEncoderFactory: VideoEncoderFactory {
+///     var supportedCodecs: [VideoCodecInfo] { [VideoCodecInfo(name: "VP8")] }
+///
+///     func createEncoder(for codec: VideoCodecInfo) -> (any VideoEncoder)? {
+///         codec.name == "VP8" ? MyVP8Encoder() : nil
+///     }
+/// }
+///
+/// try LiveKitSDK.set(videoEncoderFactory: MyEncoderFactory())
+/// ```
+public protocol VideoEncoderFactory: Sendable {
+    /// The codecs this factory can create encoders for. Determines which codecs
+    /// are advertised for publishing.
+    var supportedCodecs: [VideoCodecInfo] { get }
+
+    /// Creates an encoder for the given codec, or `nil` if the codec is not supported.
+    func createEncoder(for codec: VideoCodecInfo) -> (any VideoEncoder)?
+}

--- a/Sources/LiveKit/Protocols/VideoEncoderFactory.swift
+++ b/Sources/LiveKit/Protocols/VideoEncoderFactory.swift
@@ -33,8 +33,9 @@ import Foundation
 /// try LiveKitSDK.set(videoEncoderFactory: MyEncoderFactory())
 /// ```
 public protocol VideoEncoderFactory: Sendable {
-    /// The codecs this factory can create encoders for. Determines which codecs
-    /// are advertised for publishing.
+    /// The codecs this factory takes over from the SDK's built in encoders. The
+    /// built in encoders continue to serve every other codec, so this list can
+    /// only add to what is advertised for publishing, never narrow it.
     var supportedCodecs: [VideoCodecInfo] { get }
 
     /// Creates an encoder for the given codec, or `nil` if the codec is not supported.

--- a/Sources/LiveKit/Protocols/VideoEncoderFactory.swift
+++ b/Sources/LiveKit/Protocols/VideoEncoderFactory.swift
@@ -23,11 +23,12 @@ import Foundation
 ///
 /// ```swift
 /// final class MyEncoderFactory: VideoEncoderFactory {
-///     var supportedCodecs: [VideoCodecInfo] { [VideoCodecInfo(name: "VP8")] }
+///     var supportedCodecs: [VideoCodecInfo] { [VideoCodecInfo(name: "H264")] }
 ///
 ///     func createEncoder(for codec: VideoCodecInfo) -> (any VideoEncoder)? {
-///         codec.name == "VP8" ? MyVP8Encoder() : nil
+///         codec.name == "H264" ? MyH264Encoder() : nil
 ///     }
+
 /// }
 ///
 /// try LiveKitSDK.set(videoEncoderFactory: MyEncoderFactory())

--- a/Sources/LiveKit/Protocols/VideoEncoderFactory.swift
+++ b/Sources/LiveKit/Protocols/VideoEncoderFactory.swift
@@ -28,7 +28,6 @@ import Foundation
 ///     func createEncoder(for codec: VideoCodecInfo) -> (any VideoEncoder)? {
 ///         codec.name == "H264" ? MyH264Encoder() : nil
 ///     }
-
 /// }
 ///
 /// try LiveKitSDK.set(videoEncoderFactory: MyEncoderFactory())

--- a/Sources/LiveKit/Protocols/VideoEncoderFactory.swift
+++ b/Sources/LiveKit/Protocols/VideoEncoderFactory.swift
@@ -37,6 +37,11 @@ public protocol VideoEncoderFactory: Sendable {
     /// The codecs this factory takes over from the SDK's built in encoders. The
     /// built in encoders continue to serve every other codec, so this list can
     /// only add to what is advertised for publishing, never narrow it.
+    ///
+    /// H264 entries without a `packetization-mode` parameter are advertised as
+    /// mode 1, matching how frames are packetized by default. Include the
+    /// `profile-level-id` parameter to advertise a specific profile, otherwise
+    /// the remote side assumes constrained baseline level 1.
     var supportedCodecs: [VideoCodecInfo] { get }
 
     /// Creates an encoder for the given codec, or `nil` if the codec is not supported.

--- a/Sources/LiveKit/Types/EncodedVideoFrame.swift
+++ b/Sources/LiveKit/Types/EncodedVideoFrame.swift
@@ -23,14 +23,19 @@ internal import LiveKitWebRTC
 public struct EncodedVideoFrame: Sendable {
     /// The role of a frame within the encoded stream.
     public enum FrameType: Sendable {
+        /// A frame carrying no payload, used to signal a dropped frame.
         case empty
+        /// A frame that can be decoded on its own.
         case key
+        /// A frame that depends on previously decoded frames.
         case delta
     }
 
     /// The kind of content carried by the frame.
     public enum ContentType: Sendable {
+        /// Camera or application video.
         case unspecified
+        /// Screen content, which the receiver may render and buffer differently.
         case screenshare
     }
 
@@ -44,8 +49,14 @@ public struct EncodedVideoFrame: Sendable {
 
     /// Codec specific packetization details attached to an encoded frame.
     /// Omit for codecs other than H264/H265.
+    ///
+    /// - Note: Codecs other than H264 and H265 currently receive generic codec
+    ///   info, so the layer indices VP8, VP9 and AV1 use for temporal and spatial
+    ///   scalability cannot be reported yet.
     public enum CodecSpecificInfo: Sendable {
+        /// H264 packetization details.
         case h264(packetizationMode: PacketizationMode)
+        /// H265 packetization details.
         case h265(packetizationMode: PacketizationMode)
     }
 
@@ -77,6 +88,18 @@ public struct EncodedVideoFrame: Sendable {
     /// Codec specific packetization details, required for correct H264/H265 packetization.
     public let codecSpecificInfo: CodecSpecificInfo?
 
+    /// Wall clock time in milliseconds at which encoding of this frame began,
+    /// reported in encode time stats.
+    public let encodeStartMs: Int64?
+
+    /// Wall clock time in milliseconds at which encoding of this frame finished,
+    /// reported in encode time stats.
+    public let encodeFinishMs: Int64?
+
+    /// NTP timestamp of the frame in milliseconds, if known.
+    public let ntpTimeMs: Int64?
+
+    /// Creates an encoded frame to deliver to the SDK.
     public init(data: Data,
                 dimensions: Dimensions,
                 rtpTimestamp: UInt32,
@@ -85,7 +108,10 @@ public struct EncodedVideoFrame: Sendable {
                 rotation: VideoRotation = ._0,
                 qp: Int? = nil,
                 contentType: ContentType = .unspecified,
-                codecSpecificInfo: CodecSpecificInfo? = nil)
+                codecSpecificInfo: CodecSpecificInfo? = nil,
+                encodeStartMs: Int64? = nil,
+                encodeFinishMs: Int64? = nil,
+                ntpTimeMs: Int64? = nil)
     {
         self.data = data
         self.dimensions = dimensions
@@ -96,6 +122,9 @@ public struct EncodedVideoFrame: Sendable {
         self.qp = qp
         self.contentType = contentType
         self.codecSpecificInfo = codecSpecificInfo
+        self.encodeStartMs = encodeStartMs
+        self.encodeFinishMs = encodeFinishMs
+        self.ntpTimeMs = ntpTimeMs
     }
 }
 
@@ -137,6 +166,15 @@ extension EncodedVideoFrame {
         image.frameType = frameType.toRTCType()
         image.rotation = rotation.toRTCType()
         image.contentType = contentType == .screenshare ? .screenshare : .unspecified
+        if let encodeStartMs {
+            image.encodeStartMs = encodeStartMs
+        }
+        if let encodeFinishMs {
+            image.encodeFinishMs = encodeFinishMs
+        }
+        if let ntpTimeMs {
+            image.ntpTimeMs = ntpTimeMs
+        }
         // Always set: the native side reads `intValue`, so a nil would land as 0,
         // while -1 is what the quality scaler treats as unknown.
         image.qp = NSNumber(value: qp ?? -1)

--- a/Sources/LiveKit/Types/EncodedVideoFrame.swift
+++ b/Sources/LiveKit/Types/EncodedVideoFrame.swift
@@ -121,7 +121,11 @@ extension EncodedVideoFrame.FrameType {
 }
 
 extension EncodedVideoFrame {
-    private final class GenericCodecSpecificInfo: NSObject, LKRTCCodecSpecificInfo {}
+    private final class GenericCodecSpecificInfo: NSObject, LKRTCCodecSpecificInfo, @unchecked Sendable {}
+
+    // Stateless, so one instance is shared by every frame that carries no codec
+    // specific info instead of allocating one per encoded frame.
+    private static let genericCodecSpecificInfo = GenericCodecSpecificInfo()
 
     func toRTCType() -> (LKRTCEncodedImage, LKRTCCodecSpecificInfo) {
         let image = LKRTCEncodedImage()
@@ -133,9 +137,9 @@ extension EncodedVideoFrame {
         image.frameType = frameType.toRTCType()
         image.rotation = rotation.toRTCType()
         image.contentType = contentType == .screenshare ? .screenshare : .unspecified
-        if let qp {
-            image.qp = NSNumber(value: qp)
-        }
+        // Always set: the native side reads `intValue`, so a nil would land as 0,
+        // while -1 is what the quality scaler treats as unknown.
+        image.qp = NSNumber(value: qp ?? -1)
 
         switch codecSpecificInfo {
         case let .h264(packetizationMode):
@@ -147,7 +151,7 @@ extension EncodedVideoFrame {
             h265Info.packetizationMode = packetizationMode == .singleNalUnit ? .singleNalUnit : .nonInterleaved
             return (image, h265Info)
         case nil:
-            return (image, GenericCodecSpecificInfo())
+            return (image, Self.genericCodecSpecificInfo)
         }
     }
 }

--- a/Sources/LiveKit/Types/EncodedVideoFrame.swift
+++ b/Sources/LiveKit/Types/EncodedVideoFrame.swift
@@ -48,11 +48,11 @@ public struct EncodedVideoFrame: Sendable {
     }
 
     /// Codec specific packetization details attached to an encoded frame.
-    /// Omit for codecs other than H264/H265.
     ///
-    /// - Note: Codecs other than H264 and H265 currently receive generic codec
-    ///   info, so the layer indices VP8, VP9 and AV1 use for temporal and spatial
-    ///   scalability cannot be reported yet.
+    /// When omitted, H264 and H265 frames default to ``PacketizationMode/nonInterleaved``
+    /// based on the codec the encoder was created for. AV1 needs no codec
+    /// specific info. VP8 and VP9 cannot be bridged yet, see
+    /// ``LiveKitSDK/set(videoEncoderFactory:)``.
     public enum CodecSpecificInfo: Sendable {
         /// H264 packetization details.
         case h264(packetizationMode: PacketizationMode)
@@ -85,7 +85,8 @@ public struct EncodedVideoFrame: Sendable {
     /// The kind of content carried by the frame.
     public let contentType: ContentType
 
-    /// Codec specific packetization details, required for correct H264/H265 packetization.
+    /// Codec specific packetization details. Defaults to non interleaved
+    /// packetization for H264 and H265 when `nil`.
     public let codecSpecificInfo: CodecSpecificInfo?
 
     /// Creates an encoded frame to deliver to the SDK.
@@ -139,7 +140,11 @@ extension EncodedVideoFrame {
     // specific info instead of allocating one per encoded frame.
     private static let genericCodecSpecificInfo = GenericCodecSpecificInfo()
 
-    func toRTCType() -> (LKRTCEncodedImage, LKRTCCodecSpecificInfo) {
+    /// - Parameter codecName: SDP name of the codec the encoder was created for,
+    ///   used to synthesize H264/H265 packetization info when the frame has none.
+    ///   The RTP packetizer for those codecs requires the typed header and
+    ///   aborts on a generic one.
+    func toRTCType(codecName: String) -> (LKRTCEncodedImage, LKRTCCodecSpecificInfo) {
         let image = LKRTCEncodedImage()
         image.buffer = data
         image.encodedWidth = dimensions.width
@@ -156,7 +161,17 @@ extension EncodedVideoFrame {
         // while -1 is what the quality scaler treats as unknown.
         image.qp = NSNumber(value: qp ?? -1)
 
-        switch codecSpecificInfo {
+        let info: CodecSpecificInfo? = switch codecSpecificInfo {
+        case let .some(info): info
+        case nil:
+            switch codecName.uppercased() {
+            case "H264": .h264(packetizationMode: .nonInterleaved)
+            case "H265": .h265(packetizationMode: .nonInterleaved)
+            default: nil
+            }
+        }
+
+        switch info {
         case let .h264(packetizationMode):
             let h264Info = LKRTCCodecSpecificInfoH264()
             h264Info.packetizationMode = packetizationMode == .singleNalUnit ? .singleNalUnit : .nonInterleaved

--- a/Sources/LiveKit/Types/EncodedVideoFrame.swift
+++ b/Sources/LiveKit/Types/EncodedVideoFrame.swift
@@ -49,10 +49,13 @@ public struct EncodedVideoFrame: Sendable {
 
     /// Codec specific packetization details attached to an encoded frame.
     ///
-    /// When omitted, H264 and H265 frames default to ``PacketizationMode/nonInterleaved``
-    /// based on the codec the encoder was created for. AV1 needs no codec
-    /// specific info. VP8 and VP9 cannot be bridged yet, see
-    /// ``LiveKitSDK/set(videoEncoderFactory:)``.
+    /// When omitted, H264 and H265 frames default to the packetization mode
+    /// negotiated for the codec the encoder was created for, which is
+    /// ``PacketizationMode/nonInterleaved`` unless the codec's
+    /// `packetization-mode` parameter is `0`. Info for a different codec than
+    /// the encoder was created for is normalized to that codec, keeping only
+    /// the packetization mode. AV1 needs no codec specific info. VP8 and VP9
+    /// cannot be bridged yet, see ``LiveKitSDK/set(videoEncoderFactory:)``.
     public enum CodecSpecificInfo: Sendable {
         /// H264 packetization details.
         case h264(packetizationMode: PacketizationMode)
@@ -85,8 +88,8 @@ public struct EncodedVideoFrame: Sendable {
     /// The kind of content carried by the frame.
     public let contentType: ContentType
 
-    /// Codec specific packetization details. Defaults to non interleaved
-    /// packetization for H264 and H265 when `nil`.
+    /// Codec specific packetization details. Defaults to the negotiated
+    /// packetization mode for H264 and H265 when `nil`.
     public let codecSpecificInfo: CodecSpecificInfo?
 
     /// Creates an encoded frame to deliver to the SDK.
@@ -140,11 +143,12 @@ extension EncodedVideoFrame {
     // specific info instead of allocating one per encoded frame.
     private static let genericCodecSpecificInfo = GenericCodecSpecificInfo()
 
-    /// - Parameter codecName: SDP name of the codec the encoder was created for,
-    ///   used to synthesize H264/H265 packetization info when the frame has none.
-    ///   The RTP packetizer for those codecs requires the typed header and
-    ///   aborts on a generic one.
-    func toRTCType(codecName: String) -> (LKRTCEncodedImage, LKRTCCodecSpecificInfo) {
+    /// - Parameter codec: The codec the encoder was created for. The RTP
+    ///   packetizer for H264 requires a matching typed header and aborts on a
+    ///   generic or mismatched one, so the codec specific info is always derived
+    ///   from this codec, using the frame's packetization mode when given and
+    ///   the negotiated mode otherwise.
+    func toRTCType(codec: VideoCodecInfo) -> (LKRTCEncodedImage, LKRTCCodecSpecificInfo) {
         let image = LKRTCEncodedImage()
         image.buffer = data
         image.encodedWidth = dimensions.width
@@ -161,14 +165,15 @@ extension EncodedVideoFrame {
         // while -1 is what the quality scaler treats as unknown.
         image.qp = NSNumber(value: qp ?? -1)
 
-        let info: CodecSpecificInfo? = switch codecSpecificInfo {
-        case let .some(info): info
-        case nil:
-            switch codecName.uppercased() {
-            case "H264": .h264(packetizationMode: .nonInterleaved)
-            case "H265": .h265(packetizationMode: .nonInterleaved)
-            default: nil
-            }
+        let packetizationMode: PacketizationMode = switch codecSpecificInfo {
+        case let .h264(mode), let .h265(mode): mode
+        case nil: codec.negotiatedPacketizationMode
+        }
+
+        let info: CodecSpecificInfo? = switch codec.name.uppercased() {
+        case "H264": .h264(packetizationMode: packetizationMode)
+        case "H265": .h265(packetizationMode: packetizationMode)
+        default: nil
         }
 
         switch info {

--- a/Sources/LiveKit/Types/EncodedVideoFrame.swift
+++ b/Sources/LiveKit/Types/EncodedVideoFrame.swift
@@ -142,17 +142,9 @@ extension EncodedVideoFrame {
             h264Info.packetizationMode = packetizationMode == .singleNalUnit ? .singleNalUnit : .nonInterleaved
             return (image, h264Info)
         case let .h265(packetizationMode):
-            // The prebuilt macOS slice does not expose RTCCodecSpecificInfoH265 in its
-            // public headers, unlike all other platform slices. Falls back to generic
-            // info until a WebRTC release ships the header on macOS.
-            #if os(macOS)
-            _ = packetizationMode
-            return (image, GenericCodecSpecificInfo())
-            #else
             let h265Info = LKRTCCodecSpecificInfoH265()
             h265Info.packetizationMode = packetizationMode == .singleNalUnit ? .singleNalUnit : .nonInterleaved
             return (image, h265Info)
-            #endif
         case nil:
             return (image, GenericCodecSpecificInfo())
         }

--- a/Sources/LiveKit/Types/EncodedVideoFrame.swift
+++ b/Sources/LiveKit/Types/EncodedVideoFrame.swift
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+internal import LiveKitWebRTC
+
+/// An encoded frame produced by a custom ``VideoEncoder`` and delivered
+/// to the SDK via ``VideoEncoderCallback``.
+public struct EncodedVideoFrame: Sendable {
+    /// The role of a frame within the encoded stream.
+    public enum FrameType: Sendable {
+        case empty
+        case key
+        case delta
+    }
+
+    /// The kind of content carried by the frame.
+    public enum ContentType: Sendable {
+        case unspecified
+        case screenshare
+    }
+
+    /// NAL unit packetization arrangement for H264/H265 payloads.
+    public enum PacketizationMode: Sendable {
+        /// Mode 1, STAP-A and FU-A allowed.
+        case nonInterleaved
+        /// Mode 0, only single NAL units allowed.
+        case singleNalUnit
+    }
+
+    /// Codec specific packetization details attached to an encoded frame.
+    /// Omit for codecs other than H264/H265.
+    public enum CodecSpecificInfo: Sendable {
+        case h264(packetizationMode: PacketizationMode)
+        case h265(packetizationMode: PacketizationMode)
+    }
+
+    /// The encoded bitstream.
+    public let data: Data
+
+    /// Resolution of the encoded frame.
+    public let dimensions: Dimensions
+
+    /// RTP timestamp in 90kHz clock, typically derived from the source frame's `timeStampNs`.
+    public let rtpTimestamp: UInt32
+
+    /// Capture time in milliseconds.
+    public let captureTimeMs: Int64
+
+    /// Whether this is a key or delta frame.
+    public let frameType: FrameType
+
+    /// Rotation of the source frame.
+    public let rotation: VideoRotation
+
+    /// Quantization parameter the frame was encoded with, if known.
+    public let qp: Int?
+
+    /// The kind of content carried by the frame.
+    public let contentType: ContentType
+
+    /// Codec specific packetization details, required for correct H264/H265 packetization.
+    public let codecSpecificInfo: CodecSpecificInfo?
+
+    public init(data: Data,
+                dimensions: Dimensions,
+                rtpTimestamp: UInt32,
+                captureTimeMs: Int64,
+                frameType: FrameType,
+                rotation: VideoRotation = ._0,
+                qp: Int? = nil,
+                contentType: ContentType = .unspecified,
+                codecSpecificInfo: CodecSpecificInfo? = nil)
+    {
+        self.data = data
+        self.dimensions = dimensions
+        self.rtpTimestamp = rtpTimestamp
+        self.captureTimeMs = captureTimeMs
+        self.frameType = frameType
+        self.rotation = rotation
+        self.qp = qp
+        self.contentType = contentType
+        self.codecSpecificInfo = codecSpecificInfo
+    }
+}
+
+// MARK: - Internal
+
+extension EncodedVideoFrame.FrameType {
+    init?(fromRTCType rtcType: LKRTCFrameType) {
+        switch rtcType {
+        case .emptyFrame: self = .empty
+        case .videoFrameKey: self = .key
+        case .videoFrameDelta: self = .delta
+        default: return nil
+        }
+    }
+
+    func toRTCType() -> LKRTCFrameType {
+        switch self {
+        case .empty: .emptyFrame
+        case .key: .videoFrameKey
+        case .delta: .videoFrameDelta
+        }
+    }
+}
+
+extension EncodedVideoFrame {
+    private final class GenericCodecSpecificInfo: NSObject, LKRTCCodecSpecificInfo {}
+
+    func toRTCType() -> (LKRTCEncodedImage, LKRTCCodecSpecificInfo) {
+        let image = LKRTCEncodedImage()
+        image.buffer = data
+        image.encodedWidth = dimensions.width
+        image.encodedHeight = dimensions.height
+        image.timeStamp = rtpTimestamp
+        image.captureTimeMs = captureTimeMs
+        image.frameType = frameType.toRTCType()
+        image.rotation = rotation.toRTCType()
+        image.contentType = contentType == .screenshare ? .screenshare : .unspecified
+        if let qp {
+            image.qp = NSNumber(value: qp)
+        }
+
+        switch codecSpecificInfo {
+        case let .h264(packetizationMode):
+            let h264Info = LKRTCCodecSpecificInfoH264()
+            h264Info.packetizationMode = packetizationMode == .singleNalUnit ? .singleNalUnit : .nonInterleaved
+            return (image, h264Info)
+        case let .h265(packetizationMode):
+            // The prebuilt macOS slice does not expose RTCCodecSpecificInfoH265 in its
+            // public headers, unlike all other platform slices. Falls back to generic
+            // info until a WebRTC release ships the header on macOS.
+            #if os(macOS)
+            _ = packetizationMode
+            return (image, GenericCodecSpecificInfo())
+            #else
+            let h265Info = LKRTCCodecSpecificInfoH265()
+            h265Info.packetizationMode = packetizationMode == .singleNalUnit ? .singleNalUnit : .nonInterleaved
+            return (image, h265Info)
+            #endif
+        case nil:
+            return (image, GenericCodecSpecificInfo())
+        }
+    }
+}

--- a/Sources/LiveKit/Types/EncodedVideoFrame.swift
+++ b/Sources/LiveKit/Types/EncodedVideoFrame.swift
@@ -88,17 +88,6 @@ public struct EncodedVideoFrame: Sendable {
     /// Codec specific packetization details, required for correct H264/H265 packetization.
     public let codecSpecificInfo: CodecSpecificInfo?
 
-    /// Wall clock time in milliseconds at which encoding of this frame began,
-    /// reported in encode time stats.
-    public let encodeStartMs: Int64?
-
-    /// Wall clock time in milliseconds at which encoding of this frame finished,
-    /// reported in encode time stats.
-    public let encodeFinishMs: Int64?
-
-    /// NTP timestamp of the frame in milliseconds, if known.
-    public let ntpTimeMs: Int64?
-
     /// Creates an encoded frame to deliver to the SDK.
     public init(data: Data,
                 dimensions: Dimensions,
@@ -108,10 +97,7 @@ public struct EncodedVideoFrame: Sendable {
                 rotation: VideoRotation = ._0,
                 qp: Int? = nil,
                 contentType: ContentType = .unspecified,
-                codecSpecificInfo: CodecSpecificInfo? = nil,
-                encodeStartMs: Int64? = nil,
-                encodeFinishMs: Int64? = nil,
-                ntpTimeMs: Int64? = nil)
+                codecSpecificInfo: CodecSpecificInfo? = nil)
     {
         self.data = data
         self.dimensions = dimensions
@@ -122,9 +108,6 @@ public struct EncodedVideoFrame: Sendable {
         self.qp = qp
         self.contentType = contentType
         self.codecSpecificInfo = codecSpecificInfo
-        self.encodeStartMs = encodeStartMs
-        self.encodeFinishMs = encodeFinishMs
-        self.ntpTimeMs = ntpTimeMs
     }
 }
 
@@ -166,15 +149,9 @@ extension EncodedVideoFrame {
         image.frameType = frameType.toRTCType()
         image.rotation = rotation.toRTCType()
         image.contentType = contentType == .screenshare ? .screenshare : .unspecified
-        if let encodeStartMs {
-            image.encodeStartMs = encodeStartMs
-        }
-        if let encodeFinishMs {
-            image.encodeFinishMs = encodeFinishMs
-        }
-        if let ntpTimeMs {
-            image.ntpTimeMs = ntpTimeMs
-        }
+        // Encode timing, NTP time and timing flags are filled in by WebRTC itself
+        // once the encoded image is matched to its source frame by RTP timestamp,
+        // so they are intentionally not part of the public type.
         // Always set: the native side reads `intValue`, so a nil would land as 0,
         // while -1 is what the quality scaler treats as unknown.
         image.qp = NSNumber(value: qp ?? -1)

--- a/Sources/LiveKit/Types/EncodedVideoFrame.swift
+++ b/Sources/LiveKit/Types/EncodedVideoFrame.swift
@@ -55,7 +55,8 @@ public struct EncodedVideoFrame: Sendable {
     /// Resolution of the encoded frame.
     public let dimensions: Dimensions
 
-    /// RTP timestamp in 90kHz clock, typically derived from the source frame's `timeStampNs`.
+    /// RTP timestamp in the 90kHz clock, which must be copied from the source
+    /// ``VideoFrame/rtpTimestamp`` and not derived from `timeStampNs`.
     public let rtpTimestamp: UInt32
 
     /// Capture time in milliseconds.

--- a/Sources/LiveKit/Types/EncodedVideoFrame.swift
+++ b/Sources/LiveKit/Types/EncodedVideoFrame.swift
@@ -20,6 +20,10 @@ internal import LiveKitWebRTC
 
 /// An encoded frame produced by a custom ``VideoEncoder`` and delivered
 /// to the SDK via ``VideoEncoderCallback``.
+///
+/// Only fields WebRTC actually reads from the encoder are exposed. Capture time,
+/// rotation, content type, NTP time and encode timing are filled in by WebRTC
+/// from its own record of the source frame, matched by ``rtpTimestamp``.
 public struct EncodedVideoFrame: Sendable {
     /// The role of a frame within the encoded stream.
     public enum FrameType: Sendable {
@@ -31,36 +35,12 @@ public struct EncodedVideoFrame: Sendable {
         case delta
     }
 
-    /// The kind of content carried by the frame.
-    public enum ContentType: Sendable {
-        /// Camera or application video.
-        case unspecified
-        /// Screen content, which the receiver may render and buffer differently.
-        case screenshare
-    }
-
-    /// NAL unit packetization arrangement for H264/H265 payloads.
+    /// NAL unit packetization arrangement for H264 payloads.
     public enum PacketizationMode: Sendable {
         /// Mode 1, STAP-A and FU-A allowed.
         case nonInterleaved
         /// Mode 0, only single NAL units allowed.
         case singleNalUnit
-    }
-
-    /// Codec specific packetization details attached to an encoded frame.
-    ///
-    /// When omitted, H264 and H265 frames default to the packetization mode
-    /// negotiated for the codec the encoder was created for, which is
-    /// ``PacketizationMode/nonInterleaved`` unless the codec's
-    /// `packetization-mode` parameter is `0`. Info for a different codec than
-    /// the encoder was created for is normalized to that codec, keeping only
-    /// the packetization mode. AV1 needs no codec specific info. VP8 and VP9
-    /// cannot be bridged yet, see ``LiveKitSDK/set(videoEncoderFactory:)``.
-    public enum CodecSpecificInfo: Sendable {
-        /// H264 packetization details.
-        case h264(packetizationMode: PacketizationMode)
-        /// H265 packetization details.
-        case h265(packetizationMode: PacketizationMode)
     }
 
     /// The encoded bitstream.
@@ -73,45 +53,34 @@ public struct EncodedVideoFrame: Sendable {
     /// ``VideoFrame/rtpTimestamp`` and not derived from `timeStampNs`.
     public let rtpTimestamp: UInt32
 
-    /// Capture time in milliseconds.
-    public let captureTimeMs: Int64
-
     /// Whether this is a key or delta frame.
     public let frameType: FrameType
-
-    /// Rotation of the source frame.
-    public let rotation: VideoRotation
 
     /// Quantization parameter the frame was encoded with, if known.
     public let qp: Int?
 
-    /// The kind of content carried by the frame.
-    public let contentType: ContentType
-
-    /// Codec specific packetization details. Defaults to the negotiated
-    /// packetization mode for H264 and H265 when `nil`.
-    public let codecSpecificInfo: CodecSpecificInfo?
+    /// How the H264 bitstream is arranged for RTP packetization.
+    ///
+    /// When `nil`, the mode negotiated for the codec is used, which is
+    /// ``PacketizationMode/nonInterleaved`` unless the codec's
+    /// `packetization-mode` parameter is `0`. Ignored for H265, whose packetizer
+    /// takes no mode.
+    public let packetizationMode: PacketizationMode?
 
     /// Creates an encoded frame to deliver to the SDK.
     public init(data: Data,
                 dimensions: Dimensions,
                 rtpTimestamp: UInt32,
-                captureTimeMs: Int64,
                 frameType: FrameType,
-                rotation: VideoRotation = ._0,
                 qp: Int? = nil,
-                contentType: ContentType = .unspecified,
-                codecSpecificInfo: CodecSpecificInfo? = nil)
+                packetizationMode: PacketizationMode? = nil)
     {
         self.data = data
         self.dimensions = dimensions
         self.rtpTimestamp = rtpTimestamp
-        self.captureTimeMs = captureTimeMs
         self.frameType = frameType
-        self.rotation = rotation
         self.qp = qp
-        self.contentType = contentType
-        self.codecSpecificInfo = codecSpecificInfo
+        self.packetizationMode = packetizationMode
     }
 }
 
@@ -136,11 +105,19 @@ extension EncodedVideoFrame.FrameType {
     }
 }
 
+extension EncodedVideoFrame.PacketizationMode {
+    func toRTCType() -> LKRTCH264PacketizationMode {
+        switch self {
+        case .nonInterleaved: .nonInterleaved
+        case .singleNalUnit: .singleNalUnit
+        }
+    }
+}
+
 extension EncodedVideoFrame {
     private final class GenericCodecSpecificInfo: NSObject, LKRTCCodecSpecificInfo, @unchecked Sendable {}
 
-    // Stateless, so one instance is shared by every frame that carries no codec
-    // specific info instead of allocating one per encoded frame.
+    // Stateless, so one instance is shared instead of allocating one per frame.
     private static let genericCodecSpecificInfo = GenericCodecSpecificInfo()
 
     /// - Parameter codec: The codec the encoder was created for. The RTP
@@ -154,38 +131,24 @@ extension EncodedVideoFrame {
         image.encodedWidth = dimensions.width
         image.encodedHeight = dimensions.height
         image.timeStamp = rtpTimestamp
-        image.captureTimeMs = captureTimeMs
         image.frameType = frameType.toRTCType()
-        image.rotation = rotation.toRTCType()
-        image.contentType = contentType == .screenshare ? .screenshare : .unspecified
-        // Encode timing, NTP time and timing flags are filled in by WebRTC itself
-        // once the encoded image is matched to its source frame by RTP timestamp,
-        // so they are intentionally not part of the public type.
         // Always set: the native side reads `intValue`, so a nil would land as 0,
         // while -1 is what the quality scaler treats as unknown.
         image.qp = NSNumber(value: qp ?? -1)
 
-        let packetizationMode: PacketizationMode = switch codecSpecificInfo {
-        case let .h264(mode), let .h265(mode): mode
-        case nil: codec.negotiatedPacketizationMode
-        }
+        let mode = (packetizationMode ?? codec.negotiatedPacketizationMode).toRTCType()
 
-        let info: CodecSpecificInfo? = switch codec.name.uppercased() {
-        case "H264": .h264(packetizationMode: packetizationMode)
-        case "H265": .h265(packetizationMode: packetizationMode)
-        default: nil
-        }
-
-        switch info {
-        case let .h264(packetizationMode):
+        switch codec.name.uppercased() {
+        case "H264":
             let h264Info = LKRTCCodecSpecificInfoH264()
-            h264Info.packetizationMode = packetizationMode == .singleNalUnit ? .singleNalUnit : .nonInterleaved
+            h264Info.packetizationMode = mode
             return (image, h264Info)
-        case let .h265(packetizationMode):
+        case "H265":
+            // Separate ObjC enum with the same cases. The H265 packetizer ignores it.
             let h265Info = LKRTCCodecSpecificInfoH265()
-            h265Info.packetizationMode = packetizationMode == .singleNalUnit ? .singleNalUnit : .nonInterleaved
+            h265Info.packetizationMode = mode == .singleNalUnit ? .singleNalUnit : .nonInterleaved
             return (image, h265Info)
-        case nil:
+        default:
             return (image, Self.genericCodecSpecificInfo)
         }
     }

--- a/Sources/LiveKit/Types/VideoCodecInfo.swift
+++ b/Sources/LiveKit/Types/VideoCodecInfo.swift
@@ -54,6 +54,19 @@ public struct VideoCodecInfo: Hashable, Sendable {
 // MARK: - Internal
 
 extension VideoCodecInfo {
+    /// The H264/H265 packetization mode negotiated through the SDP
+    /// `packetization-mode` parameter.
+    ///
+    /// RFC 6184 treats an absent parameter as mode 0, but non interleaved is
+    /// used here instead. In single NAL unit mode WebRTC drops any frame
+    /// whose NAL unit exceeds the packet size, so a factory that omits the
+    /// parameter would silently lose most key frames, while receivers
+    /// depacketize both modes regardless of what was negotiated. The built
+    /// in encoders make the same choice.
+    var negotiatedPacketizationMode: EncodedVideoFrame.PacketizationMode {
+        parameters["packetization-mode"] == "0" ? .singleNalUnit : .nonInterleaved
+    }
+
     init(fromRTCType rtcType: LKRTCVideoCodecInfo) {
         self.init(name: rtcType.name,
                   parameters: rtcType.parameters,

--- a/Sources/LiveKit/Types/VideoCodecInfo.swift
+++ b/Sources/LiveKit/Types/VideoCodecInfo.swift
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+internal import LiveKitWebRTC
+
+/// Identifies a video codec together with its SDP format parameters.
+///
+/// Corresponds to WebRTC's `SdpVideoFormat`. A custom ``VideoEncoderFactory`` receives
+/// a `VideoCodecInfo` describing which codec an encoder should be created for, and
+/// advertises the codecs it supports as a list of `VideoCodecInfo`.
+public struct VideoCodecInfo: Hashable, Sendable {
+    /// The codec name as used in SDP, e.g. `H264`, `VP8`, `VP9`, `AV1`.
+    public let name: String
+
+    /// SDP format parameters, e.g. the H264 `profile-level-id`.
+    public let parameters: [String: String]
+
+    /// Supported scalability modes, e.g. `L1T3`.
+    public let scalabilityModes: [String]
+
+    public init(name: String,
+                parameters: [String: String] = [:],
+                scalabilityModes: [String] = [])
+    {
+        self.name = name
+        self.parameters = parameters
+        self.scalabilityModes = scalabilityModes
+    }
+}
+
+// MARK: - Internal
+
+extension VideoCodecInfo {
+    init(fromRTCType rtcType: LKRTCVideoCodecInfo) {
+        self.init(name: rtcType.name,
+                  parameters: rtcType.parameters,
+                  scalabilityModes: rtcType.scalabilityModes)
+    }
+
+    func toRTCType() -> LKRTCVideoCodecInfo {
+        LKRTCVideoCodecInfo(name: name,
+                            parameters: parameters,
+                            scalabilityModes: scalabilityModes)
+    }
+}

--- a/Sources/LiveKit/Types/VideoCodecInfo.swift
+++ b/Sources/LiveKit/Types/VideoCodecInfo.swift
@@ -25,6 +25,9 @@ internal import LiveKitWebRTC
 /// advertises the codecs it supports as a list of `VideoCodecInfo`.
 public struct VideoCodecInfo: Hashable, Sendable {
     /// The codec name as used in SDP, e.g. `H264`, `VP8`, `VP9`, `AV1`.
+    ///
+    /// SDP casing is used, so this is `H264` rather than `h264`. Compare against
+    /// ``videoCodec`` instead of matching the string.
     public let name: String
 
     /// SDP format parameters, e.g. the H264 `profile-level-id`.
@@ -33,6 +36,11 @@ public struct VideoCodecInfo: Hashable, Sendable {
     /// Supported scalability modes, e.g. `L1T3`.
     public let scalabilityModes: [String]
 
+    /// The codec ``name`` resolved to a ``VideoCodec``, or `nil` if the SDK does
+    /// not know the codec.
+    public var videoCodec: VideoCodec? { VideoCodec.from(name: name) }
+
+    /// Creates a codec description for a custom ``VideoEncoderFactory``.
     public init(name: String,
                 parameters: [String: String] = [:],
                 scalabilityModes: [String] = [])

--- a/Sources/LiveKit/Types/VideoCodecInfo.swift
+++ b/Sources/LiveKit/Types/VideoCodecInfo.swift
@@ -24,7 +24,7 @@ internal import LiveKitWebRTC
 /// a `VideoCodecInfo` describing which codec an encoder should be created for, and
 /// advertises the codecs it supports as a list of `VideoCodecInfo`.
 public struct VideoCodecInfo: Hashable, Sendable {
-    /// The codec name as used in SDP, e.g. `H264`, `VP8`, `VP9`, `AV1`.
+    /// The codec name as used in SDP, e.g. `H264` or `H265`.
     ///
     /// SDP casing is used, so this is `H264` rather than `h264`. Compare against
     /// ``videoCodec`` instead of matching the string.
@@ -33,21 +33,16 @@ public struct VideoCodecInfo: Hashable, Sendable {
     /// SDP format parameters, e.g. the H264 `profile-level-id`.
     public let parameters: [String: String]
 
-    /// Supported scalability modes, e.g. `L1T3`.
-    public let scalabilityModes: [String]
-
     /// The codec ``name`` resolved to a ``VideoCodec``, or `nil` if the SDK does
     /// not know the codec.
     public var videoCodec: VideoCodec? { VideoCodec.from(name: name) }
 
     /// Creates a codec description for a custom ``VideoEncoderFactory``.
     public init(name: String,
-                parameters: [String: String] = [:],
-                scalabilityModes: [String] = [])
+                parameters: [String: String] = [:])
     {
         self.name = name
         self.parameters = parameters
-        self.scalabilityModes = scalabilityModes
     }
 }
 
@@ -69,13 +64,14 @@ extension VideoCodecInfo {
 
     init(fromRTCType rtcType: LKRTCVideoCodecInfo) {
         self.init(name: rtcType.name,
-                  parameters: rtcType.parameters,
-                  scalabilityModes: rtcType.scalabilityModes)
+                  parameters: rtcType.parameters)
     }
 
+    // Scalability modes are not advertised: without a codec support query on the
+    // factory, WebRTC reports every mode as unsupported anyway.
     func toRTCType() -> LKRTCVideoCodecInfo {
         LKRTCVideoCodecInfo(name: name,
                             parameters: parameters,
-                            scalabilityModes: scalabilityModes)
+                            scalabilityModes: [])
     }
 }

--- a/Sources/LiveKit/Types/VideoCodecInfo.swift
+++ b/Sources/LiveKit/Types/VideoCodecInfo.swift
@@ -78,8 +78,9 @@ extension VideoCodecInfo {
                   parameters: rtcType.parameters)
     }
 
-    // Scalability modes are not advertised: without a codec support query on the
-    // factory, WebRTC reports every mode as unsupported anyway.
+    // Scalability modes are not advertised. WebRTC only enforces them when a
+    // sender sets scalabilityMode, which the SDK does for SVC codecs alone, and
+    // neither H264 nor H265 is one.
     func toRTCType() -> LKRTCVideoCodecInfo {
         LKRTCVideoCodecInfo(name: name,
                             parameters: parameters,

--- a/Sources/LiveKit/Types/VideoCodecInfo.swift
+++ b/Sources/LiveKit/Types/VideoCodecInfo.swift
@@ -49,17 +49,28 @@ public struct VideoCodecInfo: Hashable, Sendable {
 // MARK: - Internal
 
 extension VideoCodecInfo {
-    /// The H264/H265 packetization mode negotiated through the SDP
-    /// `packetization-mode` parameter.
-    ///
-    /// RFC 6184 treats an absent parameter as mode 0, but non interleaved is
-    /// used here instead. In single NAL unit mode WebRTC drops any frame
-    /// whose NAL unit exceeds the packet size, so a factory that omits the
-    /// parameter would silently lose most key frames, while receivers
-    /// depacketize both modes regardless of what was negotiated. The built
-    /// in encoders make the same choice.
+    static let packetizationModeParameter = "packetization-mode"
+
+    /// The H264 packetization mode negotiated through the SDP
+    /// `packetization-mode` parameter. Absent means mode 0 per RFC 6184, but
+    /// ``normalizedForAdvertising()`` fills the parameter in before anything is
+    /// advertised, so for a negotiated codec it is always present.
     var negotiatedPacketizationMode: EncodedVideoFrame.PacketizationMode {
-        parameters["packetization-mode"] == "0" ? .singleNalUnit : .nonInterleaved
+        parameters[Self.packetizationModeParameter] == "0" ? .singleNalUnit : .nonInterleaved
+    }
+
+    /// Makes what is advertised match what the bridge packetizes.
+    ///
+    /// An H264 format without `packetization-mode` negotiates as mode 0, but
+    /// frames without an explicit mode are packetized non interleaved, so the
+    /// parameter is set to `1` when absent. This also matches the built in
+    /// factory, which only ever advertises mode 1. Single NAL unit mode is
+    /// still available by advertising `packetization-mode` `0` explicitly.
+    func normalizedForAdvertising() -> VideoCodecInfo {
+        guard name.uppercased() == "H264", parameters[Self.packetizationModeParameter] == nil else { return self }
+        var parameters = parameters
+        parameters[Self.packetizationModeParameter] = "1"
+        return VideoCodecInfo(name: name, parameters: parameters)
     }
 
     init(fromRTCType rtcType: LKRTCVideoCodecInfo) {

--- a/Sources/LiveKit/Types/VideoEncoderSettings.swift
+++ b/Sources/LiveKit/Types/VideoEncoderSettings.swift
@@ -22,7 +22,9 @@ internal import LiveKitWebRTC
 public struct VideoEncoderSettings: Sendable {
     /// The kind of content being encoded, which encoders may use to tune rate control.
     public enum Mode: Sendable {
+        /// Live camera or application video, where latency matters most.
         case realtimeVideo
+        /// Screen content, which is often static and benefits from higher quality.
         case screensharing
     }
 
@@ -49,6 +51,27 @@ public struct VideoEncoderSettings: Sendable {
 
     /// The kind of content being encoded.
     public let mode: Mode
+
+    /// Creates encoder settings, which is useful for testing an encoder without
+    /// a live connection.
+    public init(name: String,
+                dimensions: Dimensions,
+                startBitrateKbps: UInt32,
+                maxBitrateKbps: UInt32,
+                minBitrateKbps: UInt32,
+                maxFramerate: UInt32,
+                qpMax: UInt32,
+                mode: Mode)
+    {
+        self.name = name
+        self.dimensions = dimensions
+        self.startBitrateKbps = startBitrateKbps
+        self.maxBitrateKbps = maxBitrateKbps
+        self.minBitrateKbps = minBitrateKbps
+        self.maxFramerate = maxFramerate
+        self.qpMax = qpMax
+        self.mode = mode
+    }
 }
 
 /// QP thresholds controlling WebRTC's quality scaler, see ``VideoEncoder/scalingSettings``.
@@ -59,6 +82,7 @@ public struct VideoEncoderQpThresholds: Sendable {
     /// Above this QP the resolution may be decreased.
     public let high: Int
 
+    /// Creates QP thresholds for the quality scaler.
     public init(low: Int, high: Int) {
         self.low = low
         self.high = high

--- a/Sources/LiveKit/Types/VideoEncoderSettings.swift
+++ b/Sources/LiveKit/Types/VideoEncoderSettings.swift
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+internal import LiveKitWebRTC
+
+/// Configuration passed to ``VideoEncoder/startEncode(with:numberOfCores:)``.
+public struct VideoEncoderSettings: Sendable {
+    /// The kind of content being encoded, which encoders may use to tune rate control.
+    public enum Mode: Sendable {
+        case realtimeVideo
+        case screensharing
+    }
+
+    /// The codec name this encoder was created for, e.g. `H264`.
+    public let name: String
+
+    /// Resolution of the stream to encode.
+    public let dimensions: Dimensions
+
+    /// Initial target bitrate in kilobits per second.
+    public let startBitrateKbps: UInt32
+
+    /// Maximum bitrate in kilobits per second.
+    public let maxBitrateKbps: UInt32
+
+    /// Minimum bitrate in kilobits per second.
+    public let minBitrateKbps: UInt32
+
+    /// Maximum framerate in frames per second.
+    public let maxFramerate: UInt32
+
+    /// Maximum allowed quantization parameter.
+    public let qpMax: UInt32
+
+    /// The kind of content being encoded.
+    public let mode: Mode
+}
+
+/// QP thresholds controlling WebRTC's quality scaler, see ``VideoEncoder/scalingSettings``.
+public struct VideoEncoderQpThresholds: Sendable {
+    /// Below this QP the resolution may be increased.
+    public let low: Int
+
+    /// Above this QP the resolution may be decreased.
+    public let high: Int
+
+    public init(low: Int, high: Int) {
+        self.low = low
+        self.high = high
+    }
+}
+
+// MARK: - Internal
+
+extension VideoEncoderSettings {
+    init(fromRTCType rtcType: LKRTCVideoEncoderSettings) {
+        name = rtcType.name
+        dimensions = Dimensions(width: Int32(rtcType.width), height: Int32(rtcType.height))
+        startBitrateKbps = rtcType.startBitrate
+        maxBitrateKbps = rtcType.maxBitrate
+        minBitrateKbps = rtcType.minBitrate
+        maxFramerate = rtcType.maxFramerate
+        qpMax = rtcType.qpMax
+        mode = rtcType.mode == .screensharing ? .screensharing : .realtimeVideo
+    }
+}
+
+extension VideoEncoderQpThresholds {
+    func toRTCType() -> LKRTCVideoEncoderQpThresholds {
+        LKRTCVideoEncoderQpThresholds(thresholdsLow: low, high: high)
+    }
+}

--- a/Sources/LiveKit/Types/VideoFrame.swift
+++ b/Sources/LiveKit/Types/VideoFrame.swift
@@ -53,6 +53,15 @@ public class CVPixelVideoBuffer: VideoBuffer, RTCCompatibleVideoBuffer {
     func toRTCType() -> LKRTCVideoFrameBuffer {
         _rtcType
     }
+
+    // Formats the underlying conversion handles. Anything else is a debug
+    // assertion in WebRTC and undefined pixel data in release builds.
+    static let i420ConvertiblePixelFormats: Set<OSType> = [
+        kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+        kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+        kCVPixelFormatType_32BGRA,
+        kCVPixelFormatType_32ARGB,
+    ]
 }
 
 /// A ``VideoBuffer`` holding I420 planar data, with one full resolution luma
@@ -108,10 +117,18 @@ public struct I420VideoBuffer: VideoBuffer, RTCCompatibleVideoBuffer {
 
 public extension VideoBuffer {
     /// Converts the buffer to I420 planar format, copying pixel data if the
-    /// underlying buffer is not already I420. Returns `nil` if the buffer is
-    /// not backed by a format the SDK can convert.
+    /// underlying buffer is not already I420.
+    ///
+    /// Returns `nil` if the buffer is not backed by a format the SDK can
+    /// convert. Pixel buffers must be NV12 (video or full range), 32BGRA or
+    /// 32ARGB.
     func toI420() -> I420VideoBuffer? {
         guard let rtcBuffer = self as? RTCCompatibleVideoBuffer else { return nil }
+        if let pixelBuffer = (self as? CVPixelVideoBuffer)?.pixelBuffer,
+           !CVPixelVideoBuffer.i420ConvertiblePixelFormats.contains(CVPixelBufferGetPixelFormatType(pixelBuffer))
+        {
+            return nil
+        }
         return I420VideoBuffer(rtcI420Buffer: rtcBuffer.toRTCType().toI420())
     }
 }

--- a/Sources/LiveKit/Types/VideoFrame.swift
+++ b/Sources/LiveKit/Types/VideoFrame.swift
@@ -18,21 +18,29 @@ import CoreMedia
 
 internal import LiveKitWebRTC
 
+/// A container for the pixel data of a ``VideoFrame``.
+///
+/// The SDK provides two implementations, ``CVPixelVideoBuffer`` and
+/// ``I420VideoBuffer``. Use ``toI420()`` to read planar data regardless of
+/// which one a frame arrived with.
 public protocol VideoBuffer {}
 
 protocol RTCCompatibleVideoBuffer {
     func toRTCType() -> LKRTCVideoFrameBuffer
 }
 
+/// A ``VideoBuffer`` backed by a `CVPixelBuffer`, usually in a native camera
+/// format such as bi planar NV12.
 public class CVPixelVideoBuffer: VideoBuffer, RTCCompatibleVideoBuffer {
     // Internal RTC type
     private let _rtcType: LKRTCCVPixelBuffer
 
-    // Returns the underlying CVPixelBuffer
+    /// The underlying pixel buffer.
     public var pixelBuffer: CVPixelBuffer {
         _rtcType.pixelBuffer
     }
 
+    /// Wraps an existing pixel buffer without copying it.
     public init(pixelBuffer: CVPixelBuffer) {
         _rtcType = LKRTCCVPixelBuffer(pixelBuffer: pixelBuffer)
     }
@@ -47,11 +55,13 @@ public class CVPixelVideoBuffer: VideoBuffer, RTCCompatibleVideoBuffer {
     }
 }
 
+/// A ``VideoBuffer`` holding I420 planar data, with one full resolution luma
+/// plane and two half resolution chroma planes.
 public struct I420VideoBuffer: VideoBuffer, RTCCompatibleVideoBuffer {
     // Internal RTC type
-    private let _rtcType: LKRTCI420Buffer
+    private let _rtcType: any LKRTCI420BufferProtocol
 
-    init(rtcI420Buffer: LKRTCI420Buffer) {
+    init(rtcI420Buffer: any LKRTCI420BufferProtocol) {
         _rtcType = rtcI420Buffer
     }
 
@@ -59,24 +69,63 @@ public struct I420VideoBuffer: VideoBuffer, RTCCompatibleVideoBuffer {
         _rtcType
     }
 
-    // Converts to CVPixelBuffer
+    /// Converts the planar data to a `CVPixelBuffer`, or returns `nil` if the
+    /// conversion fails.
     public func toPixelBuffer() -> CVPixelBuffer? {
         _rtcType.toPixelBuffer()
     }
 
+    /// Width of the luma plane in pixels.
+    public var width: Int32 { _rtcType.width }
+
+    /// Height of the luma plane in pixels.
+    public var height: Int32 { _rtcType.height }
+
+    /// Width of each chroma plane in pixels, half of ``width`` rounded up.
     public var chromaWidth: Int32 { _rtcType.chromaWidth }
+
+    /// Height of each chroma plane in pixels, half of ``height`` rounded up.
     public var chromaHeight: Int32 { _rtcType.chromaHeight }
+
+    /// Pointer to the start of the luma plane. Valid only while the buffer is alive.
     public var dataY: UnsafePointer<UInt8> { _rtcType.dataY }
+
+    /// Pointer to the start of the U chroma plane. Valid only while the buffer is alive.
     public var dataU: UnsafePointer<UInt8> { _rtcType.dataU }
+
+    /// Pointer to the start of the V chroma plane. Valid only while the buffer is alive.
     public var dataV: UnsafePointer<UInt8> { _rtcType.dataV }
+
+    /// Number of bytes per row of the luma plane, which may exceed ``width``.
     public var strideY: Int32 { _rtcType.strideY }
+
+    /// Number of bytes per row of the U chroma plane.
     public var strideU: Int32 { _rtcType.strideU }
+
+    /// Number of bytes per row of the V chroma plane.
     public var strideV: Int32 { _rtcType.strideV }
 }
 
+public extension VideoBuffer {
+    /// Converts the buffer to I420 planar format, copying pixel data if the
+    /// underlying buffer is not already I420. Returns `nil` if the buffer is
+    /// not backed by a format the SDK can convert.
+    func toI420() -> I420VideoBuffer? {
+        guard let rtcBuffer = self as? RTCCompatibleVideoBuffer else { return nil }
+        return I420VideoBuffer(rtcI420Buffer: rtcBuffer.toRTCType().toI420())
+    }
+}
+
+/// A single raw video frame, either captured locally or received from a remote
+/// participant.
 public class VideoFrame: NSObject, @unchecked Sendable {
+    /// Resolution of the frame, before ``rotation`` is applied.
     public let dimensions: Dimensions
+
+    /// Rotation to apply when rendering the frame.
     public let rotation: VideoRotation
+
+    /// Capture time in nanoseconds, on the system's monotonic clock.
     public let timeStampNs: Int64
 
     /// The RTP timestamp of this frame in the 90kHz clock used on the wire.
@@ -86,6 +135,7 @@ public class VideoFrame: NSObject, @unchecked Sendable {
     /// ``VideoEncoder``, and is 0 for frames the application creates itself.
     public let rtpTimestamp: UInt32
 
+    /// The pixel data of the frame.
     public let buffer: VideoBuffer
 
     /// Creates a frame without an RTP timestamp, which is set to 0.
@@ -122,7 +172,7 @@ extension LKRTCVideoFrame: Loggable {
 
         if let rtcBuffer = buffer as? LKRTCCVPixelBuffer {
             lkBuffer = CVPixelVideoBuffer(rtcCVPixelBuffer: rtcBuffer)
-        } else if let rtcI420Buffer = buffer as? LKRTCI420Buffer {
+        } else if let rtcI420Buffer = buffer as? any LKRTCI420BufferProtocol {
             lkBuffer = I420VideoBuffer(rtcI420Buffer: rtcI420Buffer)
         } else {
             log("RTCVideoFrame.buffer is not a known type (\(type(of: buffer)))", .error)
@@ -151,6 +201,13 @@ extension VideoFrame {
 }
 
 public extension VideoFrame {
+    /// Converts the frame's buffer to I420 planar format, copying pixel data if
+    /// it is not already I420. Returns `nil` if the buffer cannot be converted.
+    func toI420() -> I420VideoBuffer? {
+        buffer.toI420()
+    }
+
+    /// Returns the frame as a `CVPixelBuffer`, converting from I420 if needed.
     func toCVPixelBuffer() -> CVPixelBuffer? {
         if let cvPixelVideoBuffer = buffer as? CVPixelVideoBuffer {
             return cvPixelVideoBuffer.pixelBuffer
@@ -160,6 +217,7 @@ public extension VideoFrame {
         return nil
     }
 
+    /// Returns the frame wrapped in a `CMSampleBuffer`.
     func toCMSampleBuffer() -> CMSampleBuffer? {
         guard let cvPixelBuffer = toCVPixelBuffer() else { return nil }
         return CMSampleBuffer.from(cvPixelBuffer)

--- a/Sources/LiveKit/Types/VideoFrame.swift
+++ b/Sources/LiveKit/Types/VideoFrame.swift
@@ -78,10 +78,17 @@ public class VideoFrame: NSObject, @unchecked Sendable {
     public let dimensions: Dimensions
     public let rotation: VideoRotation
     public let timeStampNs: Int64
+
+    /// The RTP timestamp of this frame in the 90kHz clock used on the wire.
+    ///
+    /// Assigned by the transport, and distinct from ``timeStampNs``, which is a
+    /// capture time in nanoseconds. It is populated for frames handed to a
+    /// ``VideoEncoder``, and is 0 for frames the application creates itself.
+    public let rtpTimestamp: UInt32
+
     public let buffer: VideoBuffer
 
-    // TODO: Implement
-
+    /// Creates a frame without an RTP timestamp, which is set to 0.
     public init(dimensions: Dimensions,
                 rotation: VideoRotation,
                 timeStampNs: Int64,
@@ -90,6 +97,21 @@ public class VideoFrame: NSObject, @unchecked Sendable {
         self.dimensions = dimensions
         self.rotation = rotation
         self.timeStampNs = timeStampNs
+        rtpTimestamp = 0
+        self.buffer = buffer
+    }
+
+    /// Creates a frame, carrying the RTP timestamp of the stream it belongs to.
+    public init(dimensions: Dimensions,
+                rotation: VideoRotation,
+                timeStampNs: Int64,
+                rtpTimestamp: UInt32,
+                buffer: VideoBuffer)
+    {
+        self.dimensions = dimensions
+        self.rotation = rotation
+        self.timeStampNs = timeStampNs
+        self.rtpTimestamp = rtpTimestamp
         self.buffer = buffer
     }
 }
@@ -110,6 +132,7 @@ extension LKRTCVideoFrame: Loggable {
         return VideoFrame(dimensions: Dimensions(width: width, height: height),
                           rotation: rotation.toLKType(),
                           timeStampNs: timeStampNs,
+                          rtpTimestamp: UInt32(bitPattern: timeStamp),
                           buffer: lkBuffer)
     }
 }
@@ -119,9 +142,11 @@ extension VideoFrame {
         // This should never happen
         guard let buffer = buffer as? RTCCompatibleVideoBuffer else { fatalError("Buffer must be a RTCCompatibleVideoBuffer") }
 
-        return LKRTCVideoFrame(buffer: buffer.toRTCType(),
-                               rotation: rotation.toRTCType(),
-                               timeStampNs: timeStampNs)
+        let rtcFrame = LKRTCVideoFrame(buffer: buffer.toRTCType(),
+                                       rotation: rotation.toRTCType(),
+                                       timeStampNs: timeStampNs)
+        rtcFrame.timeStamp = Int32(bitPattern: rtpTimestamp)
+        return rtcFrame
     }
 }
 

--- a/Sources/LiveKit/Views/SampleBufferVideoRenderer.swift
+++ b/Sources/LiveKit/Views/SampleBufferVideoRenderer.swift
@@ -125,7 +125,7 @@ private final class SampleBufferDisplayPixelBufferProvider: @unchecked Sendable,
             return makePixelBuffer(from: rtcPixelBuffer)
         }
 
-        if let rtcI420Buffer = buffer as? LKRTCI420Buffer {
+        if let rtcI420Buffer = buffer as? any LKRTCI420BufferProtocol {
             return rtcI420Buffer.toPixelBuffer()
         }
 

--- a/Tests/LiveKitCoreTests/VideoEncoderFactoryTests.swift
+++ b/Tests/LiveKitCoreTests/VideoEncoderFactoryTests.swift
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import CoreVideo
+import Foundation
+@testable import LiveKit
+import LiveKitWebRTC
+import Testing
+
+@Suite(.tags(.media))
+struct VideoEncoderFactoryTests {
+    final class FakeEncoder: VideoEncoder, @unchecked Sendable {
+        let implementationName = "FakeEncoder"
+        private(set) var callback: VideoEncoderCallback?
+        private(set) var setCallbackCount = 0
+        private(set) var releaseCount = 0
+        private(set) var lastFrameTypes: [EncodedVideoFrame.FrameType] = []
+
+        func setCallback(_ callback: VideoEncoderCallback?) {
+            self.callback = callback
+            setCallbackCount += 1
+        }
+
+        func startEncode(with _: VideoEncoderSettings, numberOfCores _: Int) -> VideoEncoderStatus { .ok }
+
+        func encode(_: VideoFrame, frameTypes: [EncodedVideoFrame.FrameType]) -> VideoEncoderStatus {
+            lastFrameTypes = frameTypes
+            return .ok
+        }
+
+        func setBitrate(_: UInt32, framerate _: UInt32) -> VideoEncoderStatus { .ok }
+
+        func releaseEncoder() -> VideoEncoderStatus {
+            releaseCount += 1
+            return .ok
+        }
+    }
+
+    final class FakeFactory: VideoEncoderFactory {
+        let supportedCodecs: [VideoCodecInfo]
+        let encoder: FakeEncoder
+
+        init(_ codecs: [VideoCodecInfo], encoder: FakeEncoder = FakeEncoder()) {
+            supportedCodecs = codecs
+            self.encoder = encoder
+        }
+
+        func createEncoder(for _: VideoCodecInfo) -> (any VideoEncoder)? { encoder }
+    }
+
+    let h264 = VideoCodecInfo(name: "H264", parameters: ["packetization-mode": "1"])
+
+    func makeEncodedFrame(packetizationMode: EncodedVideoFrame.PacketizationMode? = nil, qp: Int? = nil) -> EncodedVideoFrame {
+        EncodedVideoFrame(data: Data([0, 0, 0, 1, 0x65]),
+                          dimensions: Dimensions(width: 16, height: 16),
+                          rtpTimestamp: 90000,
+                          frameType: .key,
+                          qp: qp,
+                          packetizationMode: packetizationMode)
+    }
+
+    func makeRTCFrame() throws -> LKRTCVideoFrame {
+        var pixelBuffer: CVPixelBuffer?
+        CVPixelBufferCreate(nil, 16, 16, kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange, nil, &pixelBuffer)
+        let buffer = try LKRTCCVPixelBuffer(pixelBuffer: #require(pixelBuffer))
+        let frame = LKRTCVideoFrame(buffer: buffer, rotation: ._0, timeStampNs: 1_000_000)
+        frame.timeStamp = 90000
+        return frame
+    }
+
+    // MARK: - set(videoEncoderFactory:) validation
+
+    @Test func rejectsEmptyCodecList() {
+        let error = #expect(throws: LiveKitError.self) {
+            try LiveKitSDK.set(videoEncoderFactory: FakeFactory([]))
+        }
+        #expect(error?.type == .invalidParameter)
+    }
+
+    @Test(arguments: ["VP8", "VP9", "AV1"])
+    func rejectsUnbridgeableCodec(name: String) {
+        let error = #expect(throws: LiveKitError.self) {
+            try LiveKitSDK.set(videoEncoderFactory: FakeFactory([VideoCodecInfo(name: name)]))
+        }
+        #expect(error?.type == .invalidParameter)
+    }
+
+    // MARK: - Codec normalization
+
+    @Test func h264WithoutPacketizationModeAdvertisesModeOne() {
+        let normalized = VideoCodecInfo(name: "H264").normalizedForAdvertising()
+        #expect(normalized.parameters["packetization-mode"] == "1")
+    }
+
+    @Test func explicitPacketizationModeIsKept() {
+        let codec = VideoCodecInfo(name: "H264", parameters: ["packetization-mode": "0"])
+        #expect(codec.normalizedForAdvertising().parameters["packetization-mode"] == "0")
+        #expect(codec.negotiatedPacketizationMode == .singleNalUnit)
+        #expect(h264.negotiatedPacketizationMode == .nonInterleaved)
+    }
+
+    @Test func h265IsNotNormalized() {
+        let codec = VideoCodecInfo(name: "H265")
+        #expect(codec.normalizedForAdvertising().parameters.isEmpty)
+    }
+
+    // MARK: - Factory adapter
+
+    @Test func adapterDeclinesCodecsItDidNotAdvertise() {
+        let adapter = VideoEncoderFactoryAdapter(factory: FakeFactory([h264]), supportedCodecs: [h264])
+        #expect(adapter.supportedCodecs().map(\.name) == ["H264"])
+        #expect(adapter.createEncoder(h264.toRTCType()) != nil)
+        #expect(adapter.createEncoder(VideoCodecInfo(name: "VP8").toRTCType()) == nil)
+        #expect(adapter.createEncoder(VideoCodecInfo(name: "H265").toRTCType()) == nil)
+    }
+
+    @Test func adapterUsesSnapshotNotFactoryList() {
+        // The factory claims H264 and VP8, but only the validated snapshot counts.
+        let factory = FakeFactory([h264, VideoCodecInfo(name: "VP8")])
+        let adapter = VideoEncoderFactoryAdapter(factory: factory, supportedCodecs: [h264])
+        #expect(adapter.supportedCodecs().map(\.name) == ["H264"])
+        #expect(adapter.createEncoder(VideoCodecInfo(name: "VP8").toRTCType()) == nil)
+    }
+
+    // MARK: - Encoder adapter
+
+    @Test func frameTypesKeepArityAndMapUnknownToDelta() throws {
+        let factory = FakeFactory([h264])
+        let encoder = try #require(VideoEncoderFactoryAdapter(factory: factory, supportedCodecs: [h264]).createEncoder(h264.toRTCType()))
+        // Key, an audio frame type WebRTC never sends for video, delta.
+        let status = try encoder.encode(makeRTCFrame(), codecSpecificInfo: nil, frameTypes: [3, 1, 4])
+        #expect(status == VideoEncoderStatus.ok.rawValue)
+        #expect(factory.encoder.lastFrameTypes == [.key, .delta, .delta])
+    }
+
+    @Test func callbackIsAttachedOnceAndDroppedAfterRelease() throws {
+        let factory = FakeFactory([h264])
+        let encoder = try #require(VideoEncoderFactoryAdapter(factory: factory, supportedCodecs: [h264]).createEncoder(h264.toRTCType()))
+        let delivered = StateSync(0)
+
+        encoder.setCallback { _, _ in delivered.mutate { $0 += 1 }; return true }
+        encoder.setCallback { _, _ in delivered.mutate { $0 += 1 }; return true }
+        // Consecutive registrations reuse the closure handed to the encoder.
+        #expect(factory.encoder.setCallbackCount == 1)
+
+        let frame = makeEncodedFrame()
+        #expect(factory.encoder.callback?(frame) == true)
+        #expect(delivered.read { $0 } == 1)
+
+        // Release clears the box: a stale delivery is dropped without reaching WebRTC.
+        _ = encoder.release()
+        #expect(factory.encoder.callback?(frame) == false)
+        #expect(delivered.read { $0 } == 1)
+
+        // Registering again after release attaches a fresh closure.
+        encoder.setCallback { _, _ in true }
+        #expect(factory.encoder.setCallbackCount == 2)
+        #expect(factory.encoder.callback?(frame) == true)
+
+        // Clearing forwards nil to the encoder.
+        encoder.setCallback(nil)
+        #expect(factory.encoder.callback == nil)
+    }
+
+    // MARK: - Encoded frame conversion
+
+    @Test func codecInfoFollowsEncoderCodec() {
+        let (image, info) = makeEncodedFrame().toRTCType(codec: h264)
+        #expect(image.timeStamp == 90000)
+        #expect(image.frameType == .videoFrameKey)
+        #expect(image.qp.intValue == -1)
+        let h264Info = info as? LKRTCCodecSpecificInfoH264
+        #expect(h264Info?.packetizationMode == .nonInterleaved)
+    }
+
+    @Test func packetizationModeFollowsNegotiatedParameterThenFrame() {
+        let modeZero = VideoCodecInfo(name: "H264", parameters: ["packetization-mode": "0"])
+        let (_, negotiated) = makeEncodedFrame().toRTCType(codec: modeZero)
+        #expect((negotiated as? LKRTCCodecSpecificInfoH264)?.packetizationMode == .singleNalUnit)
+
+        let (_, explicit) = makeEncodedFrame(packetizationMode: .singleNalUnit).toRTCType(codec: h264)
+        #expect((explicit as? LKRTCCodecSpecificInfoH264)?.packetizationMode == .singleNalUnit)
+    }
+
+    @Test func h265GetsH265Info() {
+        let (image, info) = makeEncodedFrame(qp: 30).toRTCType(codec: VideoCodecInfo(name: "H265"))
+        #expect(info is LKRTCCodecSpecificInfoH265)
+        #expect(image.qp.intValue == 30)
+    }
+}


### PR DESCRIPTION
Adds `LiveKitSDK.set(videoEncoderFactory:)` with SDK-owned `VideoEncoderFactory` / `VideoEncoder` protocols, so apps can supply their own H264 or H265 encoder (e.g. a software openH264 encoder) without `LiveKitWebRTC` types in the public API. Supersedes #1082, thanks @sergeyphi for the PR and the detailed testing notes.

Addresses the requests from that thread:
- `VideoFrame.rtpTimestamp` carries the 90kHz RTP timestamp WebRTC assigns before `encode`, and `EncodedVideoFrame.rtpTimestamp` must be copied from it.
- `VideoBuffer.toI420()` / `VideoFrame.toI420()` give access to I420 planes for NV12 camera frames. `supportsNativeHandle` only gates crop/scale in WebRTC, so this is the route to planar data.
- `VideoEncoderSettings` has a public init for testing.
- Encode timing and NTP fields were requested but are intentionally not exposed: `FrameEncodeMetadataWriter` overwrites them for every frame it matches by RTP timestamp, so encoder-provided values never reach stats or the wire.

Scope for v1, kept to what demonstrably reaches WebRTC (verified against the fork source):
- H264 and H265 only. VP8/VP9 need per frame layer info and AV1 a dependency descriptor, none of which the ObjC `RTCCodecSpecificInfo` bridge can carry, so `set` rejects them. AV1 can follow once the bridge can emit a descriptor.
- `EncodedVideoFrame` carries `data`, `dimensions`, `rtpTimestamp`, `frameType`, `qp` and an optional H264 `packetizationMode`. Capture time, rotation and content type are filled by WebRTC from its own record of the source frame, so they are not part of the type.
- Codec specific info is always built for the codec the encoder was created for. Frames without a mode follow the negotiated `packetization-mode`; an H264 format advertised without that parameter is normalized to mode 1, matching the built in factory and how frames are packetized.
- `VideoEncoderStatus` names only codes WebRTC acts on. Positive codes are omitted since the simulcast adapter stops encoding the remaining layers on anything other than OK.
- `resolutionAlignment` and `scalabilityModes` are left out: the ObjC bridge always reports alignment 1 (fix in webrtc-sdk/webrtc#289) and the bridge reports every encoder as hardware accelerated. Both return as additive changes once a WebRTC release carries the fixes.
- The built in VideoToolbox encoders remain the simulcast fallback, both for codecs the factory declines and when an encoder returns `.fallbackSoftware`. `set` throws if either the encoder factory or the peer connection factory has already been initialized.

Testing: 12 unit tests exercise the bridge with fake factories and encoders (validation and normalization, codec gate, frame type arity, callback lifecycle, codec info selection). Compile verified on macOS and iOS Simulator. No real encoder has run through the path yet, and H265 is compile verified only. Swift only for now; ObjC encoders need a thin Swift shim.
