### PR TITLE
Fix join_request encoding and add gzip compression to the v1 signal URL

### DIFF
--- a/.changes/join-request-url-encoding-and-gzip
+++ b/.changes/join-request-url-encoding-and-gzip
@@ -1,0 +1,1 @@
+patch type="fixed" "The v1 signal path's `join_request` parameter is now base64url-encoded instead of standard base64, so payloads containing `+` are no longer corrupted by receivers that parse the query as form-urlencoded, and it is gzip-compressed when that makes it smaller, keeping the WebSocket upgrade request inside a single TCP segment"

--- a/Sources/LiveKit/Extensions/Data.swift
+++ b/Sources/LiveKit/Extensions/Data.swift
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+extension Data {
+    /// Base64 using the URL-safe alphabet from
+    /// [RFC 4648 §5](https://datatracker.ietf.org/doc/html/rfc4648#section-5).
+    ///
+    /// Required for values carried in a query string: `URLComponents` leaves
+    /// `+` and `/` unescaped in a query value, and a receiver that parses the
+    /// query as form-urlencoded decodes `+` as a space — silently corrupting
+    /// standard base64. Padding is kept, matching client-sdk-js and rust-sdks.
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+    }
+}

--- a/Sources/LiveKit/Support/Gzip.swift
+++ b/Sources/LiveKit/Support/Gzip.swift
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Compression
+import Foundation
+
+/// Minimal gzip ([RFC 1952](https://datatracker.ietf.org/doc/html/rfc1952)) encoder.
+///
+/// Apple's Compression framework has no gzip container: `COMPRESSION_ZLIB`
+/// produces a raw DEFLATE stream ([RFC 1951](https://datatracker.ietf.org/doc/html/rfc1951))
+/// with no header, checksum or length trailer. This wraps that stream in the
+/// gzip framing the LiveKit server expects, rather than linking zlib just for
+/// its container.
+enum Gzip {
+    /// Fixed 10-byte gzip header: magic, DEFLATE method, no flags, no mtime,
+    /// no extra flags, unknown OS. The mtime is left zero so the same input
+    /// always encodes to the same bytes and no clock value is disclosed.
+    private static let header: [UInt8] = [0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF]
+
+    /// Compresses `data` into a gzip stream.
+    ///
+    /// - Returns: The gzip stream, or `nil` when `data` is empty or DEFLATE
+    ///   fails. Callers are expected to fall back to the uncompressed payload.
+    /// - Note: DEFLATE can expand incompressible input, so the result is not
+    ///   guaranteed to be smaller than `data`. Compare the sizes before use.
+    static func compress(_ data: Data) -> Data? {
+        guard !data.isEmpty else { return nil }
+
+        // Worst-case DEFLATE expansion plus room for the block headers.
+        let capacity = data.count + data.count / 16 + 64
+        var deflated = Data(count: capacity)
+
+        let deflatedCount = deflated.withUnsafeMutableBytes { destination -> Int in
+            guard let destinationStart = destination.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
+
+            return data.withUnsafeBytes { source -> Int in
+                guard let sourceStart = source.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
+
+                return compression_encode_buffer(destinationStart, capacity,
+                                                 sourceStart, data.count,
+                                                 nil, COMPRESSION_ZLIB)
+            }
+        }
+
+        // `compression_encode_buffer` reports failure as zero bytes written.
+        guard deflatedCount > 0 else { return nil }
+
+        var result = Data(header)
+        result.append(deflated.prefix(deflatedCount))
+        result.append(littleEndian: crc32(data))
+        // ISIZE is the uncompressed size modulo 2^32.
+        result.append(littleEndian: UInt32(truncatingIfNeeded: data.count))
+        return result
+    }
+
+    /// CRC-32 as specified by gzip: reflected polynomial `0xEDB88320`,
+    /// pre-inverted and post-inverted.
+    static func crc32(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        for byte in data {
+            let index = Int((crc ^ UInt32(byte)) & 0xFF)
+            crc = crcTable[index] ^ (crc >> 8)
+        }
+        return crc ^ 0xFFFF_FFFF
+    }
+
+    private static let crcTable: [UInt32] = (0 ..< 256).map { index in
+        (0 ..< 8).reduce(UInt32(index)) { value, _ in
+            (value & 1) != 0 ? 0xEDB8_8320 ^ (value >> 1) : value >> 1
+        }
+    }
+}
+
+private extension Data {
+    mutating func append(littleEndian value: UInt32) {
+        var value = value.littleEndian
+        append(contentsOf: Swift.withUnsafeBytes(of: &value) { Array($0) })
+    }
+}

--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -299,12 +299,25 @@ class Utils: Loggable {
         }
 
         let joinRequestData = try joinRequest.serializedData()
+
+        // The request travels in the WebSocket upgrade URL, so keeping it within
+        // a single TCP segment avoids paying a retransmission timeout before the
+        // handshake even starts on a lossy link. Mirrors client-sdk-js and
+        // rust-sdks: gzip, but keep the compressed form only when it is actually
+        // smaller — gzip framing exceeds the savings on a small request.
+        let (payload, compression): (Data, Livekit_WrappedJoinRequest_Compression) =
+            if let compressed = Gzip.compress(joinRequestData), compressed.count < joinRequestData.count {
+                (compressed, .gzip)
+            } else {
+                (joinRequestData, .none)
+            }
+
         let wrappedData = try Livekit_WrappedJoinRequest.with {
-            $0.compression = .none
-            $0.joinRequest = joinRequestData
+            $0.compression = compression
+            $0.joinRequest = payload
         }.serializedData()
 
-        return wrappedData.base64EncodedString()
+        return wrappedData.base64URLEncodedString()
     }
 }
 

--- a/Tests/LiveKitCoreTests/JoinRequestUrlTests.swift
+++ b/Tests/LiveKitCoreTests/JoinRequestUrlTests.swift
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Compression
+import Foundation
+@testable import LiveKit
+import Testing
+
+@Suite(.tags(.networking)) struct JoinRequestUrlTests {
+    private static let url = URL(string: "wss://example.livekit.cloud")!
+
+    private func joinRequestParam(reconnectMode: ReconnectMode? = nil) throws -> String {
+        let url = try Utils.buildJoinRequestUrl(Self.url,
+                                                connectOptions: ConnectOptions(),
+                                                reconnectMode: reconnectMode,
+                                                participantSid: nil,
+                                                adaptiveStream: true)
+
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        // The percent-encoded query is what actually goes on the wire.
+        let query = try #require(components.percentEncodedQuery)
+        let param = try #require(query.split(separator: "&")
+            .first { $0.hasPrefix("join_request=") }?
+            .dropFirst("join_request=".count))
+        return String(param)
+    }
+
+    /// `URLComponents` does not escape `+` or `/` in a query value, so standard
+    /// base64 reaches the server intact only by luck — a receiver parsing the
+    /// query as form-urlencoded turns `+` into a space.
+    @Test func joinRequestParamIsUrlSafe() throws {
+        let param = try joinRequestParam()
+
+        #expect(!param.contains("+"), "Standard base64 leaked into the query: \(param)")
+        #expect(!param.contains("/"), "Standard base64 leaked into the query: \(param)")
+    }
+
+    @Test(arguments: [nil, ReconnectMode.quick] as [ReconnectMode?])
+    func joinRequestRoundTrips(reconnectMode: ReconnectMode?) throws {
+        let param = try joinRequestParam(reconnectMode: reconnectMode)
+
+        let decodedParam = try #require(param.removingPercentEncoding)
+        let wrappedData = try #require(Data(base64URLEncoded: decodedParam))
+        let wrapped = try Livekit_WrappedJoinRequest(serializedBytes: wrappedData)
+
+        let joinRequestData: Data = switch wrapped.compression {
+        case .gzip: try #require(Gunzip.decompress(wrapped.joinRequest))
+        default: wrapped.joinRequest
+        }
+
+        let joinRequest = try Livekit_JoinRequest(serializedBytes: joinRequestData)
+        #expect(joinRequest.clientInfo.sdk == .swift)
+        #expect(joinRequest.clientInfo.version == LiveKitSDK.version)
+        #expect(joinRequest.connectionSettings.adaptiveStream)
+        #expect(joinRequest.reconnect == (reconnectMode == .quick))
+    }
+
+    /// A minimal join request is small enough that gzip framing outweighs the
+    /// savings, so it must stay uncompressed rather than growing the URL.
+    @Test func smallRequestIsNotCompressed() throws {
+        let param = try joinRequestParam()
+
+        let decodedParam = try #require(param.removingPercentEncoding)
+        let wrappedData = try #require(Data(base64URLEncoded: decodedParam))
+        let wrapped = try Livekit_WrappedJoinRequest(serializedBytes: wrappedData)
+
+        #expect(wrapped.compression == .none)
+    }
+}
+
+struct GzipTests {
+    /// Known-answer vector for CRC-32 of "123456789".
+    @Test func crc32MatchesKnownVector() throws {
+        let data = try #require("123456789".data(using: .utf8))
+        #expect(Gzip.crc32(data) == 0xCBF4_3926)
+    }
+
+    @Test func crc32OfEmptyDataIsZero() {
+        #expect(Gzip.crc32(Data()) == 0)
+    }
+
+    @Test func compressProducesValidGzipStream() throws {
+        // Repetitive enough that DEFLATE wins by a wide margin.
+        let original = try #require(String(repeating: "livekit join request ", count: 200).data(using: .utf8))
+        let compressed = try #require(Gzip.compress(original))
+
+        #expect(compressed.count < original.count)
+        #expect(Array(compressed.prefix(3)) == [0x1F, 0x8B, 0x08], "Missing gzip magic and DEFLATE method")
+
+        let trailer = compressed.suffix(8)
+        #expect(trailer.prefix(4).littleEndianUInt32 == Gzip.crc32(original))
+        #expect(trailer.suffix(4).littleEndianUInt32 == UInt32(original.count))
+
+        #expect(Gunzip.decompress(compressed) == original)
+    }
+
+    @Test func compressReturnsNilForEmptyData() {
+        #expect(Gzip.compress(Data()) == nil)
+    }
+
+    /// Incompressible input may expand; the encoder must still emit a stream the
+    /// caller can measure and reject, never a corrupt one.
+    @Test func compressHandlesIncompressibleData() throws {
+        var random = Data(count: 4096)
+        random.withUnsafeMutableBytes { buffer in
+            for index in buffer.indices {
+                buffer[index] = UInt8.random(in: .min ... .max)
+            }
+        }
+
+        let compressed = try #require(Gzip.compress(random))
+        #expect(Gunzip.decompress(compressed) == random)
+    }
+}
+
+// MARK: - Test helpers
+
+/// Test-only gzip reader, used to prove the container the SDK writes is well
+/// formed. The SDK itself only ever encodes.
+private enum Gunzip {
+    static func decompress(_ data: Data) -> Data? {
+        // Fixed 10-byte header, 8-byte trailer; the SDK never emits optional fields.
+        guard data.count > 18 else { return nil }
+        let deflated = data.dropFirst(10).dropLast(8)
+        guard let expectedSize = data.suffix(4).littleEndianUInt32 else { return nil }
+
+        var result = Data(count: Int(expectedSize))
+        let written = result.withUnsafeMutableBytes { destination -> Int in
+            guard let destinationStart = destination.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
+
+            return Data(deflated).withUnsafeBytes { source -> Int in
+                guard let sourceStart = source.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
+
+                return compression_decode_buffer(destinationStart, Int(expectedSize),
+                                                 sourceStart, deflated.count,
+                                                 nil, COMPRESSION_ZLIB)
+            }
+        }
+
+        guard written == Int(expectedSize) else { return nil }
+        return result
+    }
+}
+
+private extension Data {
+    init?(base64URLEncoded string: String) {
+        var base64 = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        // Restore any stripped padding so Foundation accepts the string.
+        if base64.count % 4 != 0 {
+            base64 += String(repeating: "=", count: 4 - base64.count % 4)
+        }
+        self.init(base64Encoded: base64)
+    }
+
+    var littleEndianUInt32: UInt32? {
+        guard count == 4 else { return nil }
+        // `enumerated()` offsets are slice-relative, unlike `indices`.
+        return enumerated().reduce(UInt32(0)) { $0 | UInt32($1.element) << (8 * $1.offset) }
+    }
+}

--- a/Tests/LiveKitCoreTests/JoinRequestUrlTests.swift
+++ b/Tests/LiveKitCoreTests/JoinRequestUrlTests.swift
@@ -83,8 +83,8 @@ import Testing
 
 struct GzipTests {
     /// Known-answer vector for CRC-32 of "123456789".
-    @Test func crc32MatchesKnownVector() throws {
-        let data = try #require("123456789".data(using: .utf8))
+    @Test func crc32MatchesKnownVector() {
+        let data = Data("123456789".utf8)
         #expect(Gzip.crc32(data) == 0xCBF4_3926)
     }
 


### PR DESCRIPTION
Fixes CLT-2201.

The v1 signal path (`/rtc/v1`) carries the `JoinRequest` protobuf as a base64 query parameter, built in `Utils.buildWrappedJoinRequest`. Two things diverged from client-sdk-js and rust-sdks.

## 1. Standard base64 instead of base64url

`wrappedData.base64EncodedString()` emits `+` and `/`. `URLComponents` percent-encodes `=` but leaves `+` and `/` literal in the query:

```
wss://host/rtc/v1?join_request=ab+cd/ef%3Dgh
```

A receiver that parses the query as form-urlencoded decodes `+` as a space, which corrupts the payload. Go's `net/url` does exactly this. Both other SDKs avoid it deliberately:

- rust-sdks: `BASE64_URL_SAFE.encode(&wrapped_bytes)` — *"URL-safe base64 avoids percent-encoding issues in query parameters"* (`livekit-signaling/src/lib.rs:876-879`)
- client-sdk-js: `.replace(/\+/g, '-').replace(/\//g, '_')` (`src/api/SignalClient.ts:1457`)

This has likely gone unnoticed because the v1 path only runs with `RoomOptions.singlePeerConnection = true`, which is `false` by default in Swift. **This is the part that needs a confirming run against a real server** — the intent in the other two SDKs is unambiguous, but I have not reproduced the server-side corruption end to end. Padding is preserved, matching both other SDKs.

## 2. Compression was hardcoded to `.none`

The request travels in the WebSocket upgrade URL, so an oversized request splits across TCP segments — on a lossy path one lost segment costs an RTO before the handshake begins. Rust always gzips and keeps the compressed form only when smaller (`lib.rs:853-871`); JS gzips whenever `CompressionStream` exists (`SignalClient.ts:1425-1450`). This adopts the same rule.

Apple's Compression framework has no gzip container — `COMPRESSION_ZLIB` produces a raw DEFLATE stream with no header, checksum or length trailer — so `Gzip` wraps it in RFC 1952 framing with a table-driven CRC-32 rather than linking zlib solely for its container. The mtime field is left zero so encoding is deterministic and no clock value is disclosed.

### What this actually saves today

Measured with the same encoder on realistic payloads:

| payload | base64 in URL, uncompressed | with gzip |
|---|---|---|
| minimal join request (today) | 44 B | 68 B → **stays uncompressed** |
| join request + 4-section SDP publisher offer | 3032 B | **592 B** |

So there is **no change on the wire today** beyond the encoding fix: a minimal join request is smaller than gzip's framing, so the size comparison correctly declines to compress it (covered by `smallRequestIsNotCompressed`). The payoff arrives with offer-with-join (CLT ticket 2), where the SDP makes the payload multi-KB — which is why JS gates offer-with-join on compression being available (`isPublisherOfferWithJoinSupported = isCompressionStreamSupported() && !isFireFox()`). Landing this first unblocks that work.

## Testing

New `JoinRequestUrlTests` / `GzipTests` (8 tests, all passing):

- `join_request` contains no `+` or `/` in the percent-encoded query
- Round-trips through base64url → `WrappedJoinRequest` → gunzip → `JoinRequest`, for both fresh connect and quick reconnect
- A minimal request stays `.none`
- CRC-32 known-answer vector (`"123456789"` → `0xCBF43926`), and empty input → `0`
- Gzip magic + method bytes, CRC and ISIZE trailer values, and a full decompress round-trip
- Incompressible (random) input still produces a decodable stream, and empty input returns `nil`

Builds verified on macOS, Mac Catalyst and iOS Simulator; tvOS/visionOS SDKs aren't installed locally, so CI covers those (the Compression framework is available on all of them).

`swiftlint` and `swiftformat --lint` clean. No public API change — `Gzip` and the `Data` extension are internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
