### PR TITLE
DRAFT: mid-based track resolution + preallocated receive media sections

### DIFF
--- a/.changes/join-request-url-encoding-and-gzip
+++ b/.changes/join-request-url-encoding-and-gzip
@@ -1,0 +1,1 @@
+patch type="fixed" "The v1 signal path's `join_request` parameter is now base64url-encoded instead of standard base64, so payloads containing `+` are no longer corrupted by receivers that parse the query as form-urlencoded, and it is gzip-compressed when that makes it smaller, keeping the WebSocket upgrade request inside a single TCP segment"

--- a/.changes/offer-with-join
+++ b/.changes/offer-with-join
@@ -1,0 +1,1 @@
+minor type="changed" "In single peer connection mode the publisher offer is now created before the signal socket opens and bundled with the JOIN request, so the server answers it in the same exchange — removing a round trip from the connect path and moving the WebRTC cold start off it, which matters most on high-latency links"

--- a/Sources/LiveKit/Core/Room+Engine.swift
+++ b/Sources/LiveKit/Core/Room+Engine.swift
@@ -125,33 +125,42 @@ extension Room {
 // MARK: - Internal
 
 extension Room {
-    func configureTransports(connectResponse: SignalClient.ConnectResponse, singlePeerConnection: Bool) async throws {
-        func makeConfiguration() -> LKRTCConfiguration {
-            let connectOptions = _state.connectOptions
+    /// Builds the peer connection configuration.
+    ///
+    /// - Parameter connectResponse: The JOIN/RECONNECT response, or `nil` before the socket has
+    ///   opened. Without it the server's ICE servers and relay policy are unknown, so the result
+    ///   carries client-side settings only and must be replaced via `Transport.set(configuration:)`
+    ///   once the response arrives — see ``EarlyPublisher``.
+    func makeRTCConfiguration(connectResponse: SignalClient.ConnectResponse?) -> LKRTCConfiguration {
+        let connectOptions = _state.connectOptions
 
-            // Make a copy, instead of modifying the user-supplied RTCConfiguration object.
-            let rtcConfiguration = LKRTCConfiguration.liveKitDefault()
+        // Make a copy, instead of modifying the user-supplied RTCConfiguration object.
+        let rtcConfiguration = LKRTCConfiguration.liveKitDefault()
 
-            // Set iceServers provided by the server
-            rtcConfiguration.iceServers = connectResponse.rtcIceServers
+        // Set iceServers provided by the server
+        rtcConfiguration.iceServers = connectResponse?.rtcIceServers ?? []
 
-            if !connectOptions.iceServers.isEmpty {
-                // Override with user provided iceServers
-                rtcConfiguration.iceServers = connectOptions.iceServers.map { $0.toRTCType() }
-            }
-
-            if connectResponse.clientConfiguration.forceRelay == .enabled {
-                rtcConfiguration.iceTransportPolicy = .relay
-            } else {
-                rtcConfiguration.iceTransportPolicy = connectOptions.iceTransportPolicy.toRTCType()
-            }
-
-            rtcConfiguration.enableDscp = connectOptions.isDscpEnabled
-
-            return rtcConfiguration
+        if !connectOptions.iceServers.isEmpty {
+            // Override with user provided iceServers
+            rtcConfiguration.iceServers = connectOptions.iceServers.map { $0.toRTCType() }
         }
 
-        let rtcConfiguration = makeConfiguration()
+        if connectResponse?.clientConfiguration.forceRelay == .enabled {
+            rtcConfiguration.iceTransportPolicy = .relay
+        } else {
+            rtcConfiguration.iceTransportPolicy = connectOptions.iceTransportPolicy.toRTCType()
+        }
+
+        rtcConfiguration.enableDscp = connectOptions.isDscpEnabled
+
+        return rtcConfiguration
+    }
+
+    func configureTransports(connectResponse: SignalClient.ConnectResponse,
+                             singlePeerConnection: Bool,
+                             earlyPublisher: EarlyPublisher? = nil) async throws
+    {
+        let rtcConfiguration = makeRTCConfiguration(connectResponse: connectResponse)
 
         if case let .join(joinResponse) = connectResponse {
             log("Configuring transports with JOIN response...")
@@ -165,7 +174,8 @@ extension Room {
                                                        connection: connection,
                                                        joinResponse: joinResponse,
                                                        rtcConfiguration: rtcConfiguration,
-                                                       singlePeerConnection: singlePeerConnection)
+                                                       singlePeerConnection: singlePeerConnection,
+                                                       earlyPublisher: earlyPublisher)
             do {
                 try _state.mutate { try $0.stage.join(join) }
             } catch {
@@ -223,54 +233,93 @@ extension Room {
     func fullConnectSequence(_ url: URL, _ token: String) async throws {
         var singlePC = _state.roomOptions.singlePeerConnection
 
-        let connectResponse: SignalClient.ConnectResponse
+        // Built before the socket opens so its offer rides along with the JOIN request,
+        // removing the offer→answer round trip from the connect path, and so the WebRTC cold
+        // start overlaps the TLS/WebSocket handshake instead of following it.
+        var earlyPublisher: EarlyPublisher? = if singlePC {
+            try await EarlyPublisher.make(room: self,
+                                          rtcConfiguration: makeRTCConfiguration(connectResponse: nil))
+        } else {
+            nil
+        }
+        if earlyPublisher != nil { connectSpan?.record("early_pc_created") }
+
+        // Until `configureTransports` adopts it into the stage, the early publisher is not
+        // reachable from `cleanUp()`, so every exit before that point closes it here.
+        var isAdopted = false
+
         do {
-            connectResponse = try await signalClient.connect(url,
-                                                             token,
-                                                             connectOptions: _state.connectOptions,
-                                                             reconnectMode: _state.isReconnectingWithMode,
-                                                             adaptiveStream: _state.roomOptions.adaptiveStream,
-                                                             singlePeerConnection: singlePC,
-                                                             connectSpan: connectSpan)
-        } catch let error as LiveKitError where error.type == .serviceNotFound && singlePC {
-            log("v1 RTC path not supported, retrying with legacy path", .warning)
-            singlePC = false
-            connectResponse = try await signalClient.connect(url,
-                                                             token,
-                                                             connectOptions: _state.connectOptions,
-                                                             reconnectMode: _state.isReconnectingWithMode,
-                                                             adaptiveStream: _state.roomOptions.adaptiveStream,
-                                                             singlePeerConnection: false,
-                                                             connectSpan: connectSpan)
-        }
+            let connectResponse: SignalClient.ConnectResponse
+            do {
+                connectResponse = try await signalClient.connect(url,
+                                                                 token,
+                                                                 connectOptions: _state.connectOptions,
+                                                                 reconnectMode: _state.isReconnectingWithMode,
+                                                                 adaptiveStream: _state.roomOptions.adaptiveStream,
+                                                                 singlePeerConnection: singlePC,
+                                                                 publisherOffer: earlyPublisher?.offer,
+                                                                 connectSpan: connectSpan)
+            } catch let error as LiveKitError where error.type == .serviceNotFound && singlePC {
+                log("v1 RTC path not supported, retrying with legacy path", .warning)
+                singlePC = false
 
-        // Check cancellation after WebSocket connected
-        try Task.checkCancellation()
+                // The legacy path needs a dual-PC publisher, which differs in both `primary`
+                // and `singlePCMode` — immutable on `Transport` — so the early one cannot be
+                // reused and `configureTransports` builds a fresh pair.
+                await earlyPublisher?.close()
+                earlyPublisher = nil
 
-        connectSpan?.record("signal")
-        connectSpan?.record("join_recv")
-
-        try await configureTransports(connectResponse: connectResponse, singlePeerConnection: singlePC)
-        connectSpan?.record("pc_created")
-        // Check cancellation after configuring transports
-        try Task.checkCancellation()
-
-        // Resume after configuring transports...
-        await signalClient.resumeQueues()
-        try Task.checkCancellation()
-
-        // Eager publisher negotiation must run after `resumeQueues()` —
-        // offers are not queueable, so sending while suspended drops them.
-        if case let .join(joinResponse) = connectResponse {
-            let isSubscriberPrimary = singlePC ? false : joinResponse.subscriberPrimary
-            if singlePC || !isSubscriberPrimary || joinResponse.fastPublish {
-                try await publisherShouldNegotiate(force: true)
+                connectResponse = try await signalClient.connect(url,
+                                                                 token,
+                                                                 connectOptions: _state.connectOptions,
+                                                                 reconnectMode: _state.isReconnectingWithMode,
+                                                                 adaptiveStream: _state.roomOptions.adaptiveStream,
+                                                                 singlePeerConnection: false,
+                                                                 connectSpan: connectSpan)
             }
-        }
 
-        // Wait for transport...
-        try await primaryTransportConnectedCompleter.wait(timeout: _state.connectOptions.primaryTransportConnectTimeout)
-        try Task.checkCancellation()
+            // Check cancellation after WebSocket connected
+            try Task.checkCancellation()
+
+            connectSpan?.record("signal")
+            connectSpan?.record("join_recv")
+
+            try await configureTransports(connectResponse: connectResponse,
+                                          singlePeerConnection: singlePC,
+                                          earlyPublisher: earlyPublisher)
+            isAdopted = true
+            connectSpan?.record("pc_created")
+            // Check cancellation after configuring transports
+            try Task.checkCancellation()
+
+            // Resume after configuring transports...
+            await signalClient.resumeQueues()
+            try Task.checkCancellation()
+
+            // Eager publisher negotiation must run after `resumeQueues()` —
+            // offers are not queueable, so sending while suspended drops them.
+            if case let .join(joinResponse) = connectResponse {
+                if earlyPublisher?.offer != nil {
+                    // The offer went out with the JOIN request and the server answers it over
+                    // the signal channel, so negotiating again here would offer over the top
+                    // of it. Matches `sent_publisher_offer` in rust-sdks.
+                    _state.mutate { $0.hasPublished = true }
+                } else {
+                    let isSubscriberPrimary = singlePC ? false : joinResponse.subscriberPrimary
+                    if singlePC || !isSubscriberPrimary || joinResponse.fastPublish {
+                        try await publisherShouldNegotiate(force: true)
+                    }
+                }
+            }
+
+            // Wait for transport...
+            try await primaryTransportConnectedCompleter.wait(timeout: _state.connectOptions.primaryTransportConnectTimeout)
+            try Task.checkCancellation()
+        } catch {
+            // Once adopted, the staged join owns teardown through `cleanUp()`.
+            if !isAdopted { await earlyPublisher?.close() }
+            throw error
+        }
 
         connectSpan?.record("engine")
         connectSpan?.record("pc_connected")

--- a/Sources/LiveKit/Core/Room+EngineDelegate.swift
+++ b/Sources/LiveKit/Core/Room+EngineDelegate.swift
@@ -179,7 +179,12 @@ extension Room {
         }
 
         guard let participant else {
-            log("RemoteParticipant not found for sid: \(parseResult.participantSid), remoteParticipants: \(remoteParticipants)", .warning)
+            // In single PC mode a receive section the client preallocated is answered without an
+            // `a=msid`, so libwebrtc reports a synthesized stream id that names no participant.
+            // Those sections are identified from the description's `mid` → track SID mapping
+            // instead (see `attachReceivedMedia`), so this is expected rather than a fault.
+            let level: LogLevel = _state.transport?.publisher.singlePCMode == true ? .debug : .warning
+            log("RemoteParticipant not found for sid: \(parseResult.participantSid), remoteParticipants: \(remoteParticipants)", level)
             return
         }
 

--- a/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
+++ b/Sources/LiveKit/Core/Room+SignalClientDelegate.swift
@@ -343,7 +343,7 @@ extension Room: SignalClientDelegate {
         }
     }
 
-    func signalClient(_: SignalClient, didReceiveAnswer answer: LKRTCSessionDescription, offerId: UInt32) async {
+    func signalClient(_: SignalClient, didReceiveAnswer answer: LKRTCSessionDescription, offerId: UInt32, midToTrackSid: [String: Track.Sid]) async {
         log("Received answer for offerId: \(offerId)")
 
         // Clamp to the SDK default — libwebrtc advertises larger (~256 KiB)
@@ -357,8 +357,47 @@ extension Room: SignalClientDelegate {
         do {
             let publisher = try requirePublisher()
             try await publisher.set(remoteDescription: answer, offerId: offerId)
+
+            // After the description, so the transceivers this maps over have their mids and
+            // receivers. Only single PC mode receives media on the publisher connection.
+            if publisher.singlePCMode {
+                await attachReceivedMedia(on: publisher, midToTrackSid: midToTrackSid)
+            }
         } catch {
             log("Failed to set remote description with offerId: \(offerId), error: \(error)", .error)
+        }
+    }
+
+    /// Attaches media the server has bound to the publisher's receive sections.
+    ///
+    /// In single PC mode this is the only path that identifies received media. The `didAddTrack`
+    /// callback cannot: a section the client preallocated is answered without an `a=msid`, so
+    /// libwebrtc reports a synthesized stream id carrying no participant or track, and it does
+    /// not fire again when the server later binds a track to that section. The `mid` → track SID
+    /// mapping on each session description is what carries the binding, so applying it is what
+    /// drives the attach. Mirrors `mid_to_track_id` handling in rust-sdks.
+    private func attachReceivedMedia(on publisher: Transport, midToTrackSid: [String: Track.Sid]) async {
+        let received = await publisher.apply(midToTrackSid: midToTrackSid)
+        guard !received.isEmpty else { return }
+
+        for media in received {
+            guard let participant = _state.read({ state in
+                state.remoteParticipants.values.first { $0._state.trackPublications[media.trackSid] != nil }
+            }) else {
+                // The publication announcement can trail the description that binds it; the next
+                // one still reporting this mid retries.
+                log("No publication yet for \(media.trackSid), deferring attach", .debug)
+                await publisher.forget(mid: midToTrackSid.first { $0.value == media.trackSid }?.key)
+                continue
+            }
+
+            do {
+                try await participant.addSubscribedMediaTrack(mediaTrack: media.track,
+                                                              rtpReceiver: media.receiver,
+                                                              trackSid: media.trackSid)
+            } catch {
+                log("Failed to attach \(media.trackSid) resolved by mid: \(error)", .error)
+            }
         }
     }
 
@@ -427,18 +466,20 @@ extension Room: SignalClientDelegate {
     func signalClient(_: SignalClient, didReceiveMediaSectionsRequirement requirement: Livekit_MediaSectionsRequirement) async {
         guard case let .publisherOnly(publisher) = _state.transport else { return }
 
-        let transceiverInit = LKRTCRtpTransceiverInit()
-        transceiverInit.direction = .recvOnly
+        // The count is what the server still needs *on top of* the sections already offered, so
+        // once the initial offer preallocates enough it asks for none. Renegotiating for zero
+        // sections would offer a description identical to the current one, racing the offer a
+        // concurrent publish is making.
+        guard requirement.numAudios > 0 || requirement.numVideos > 0 else {
+            log("Media sections requirement already satisfied, skipping renegotiation", .debug)
+            return
+        }
 
         do {
-            try await RTC.run {
-                for _ in 0 ..< requirement.numAudios {
-                    _ = try publisher.addTransceiver(ofType: .audio, transceiverInit: transceiverInit)
-                }
-                for _ in 0 ..< requirement.numVideos {
-                    _ = try publisher.addTransceiver(ofType: .video, transceiverInit: transceiverInit)
-                }
-            }
+            // Additive, matching client-sdk-js and rust-sdks: these come on top of the sections
+            // the initial offer preallocated, not instead of them.
+            try await publisher.addRecvMediaSections(audio: Int(requirement.numAudios),
+                                                     video: Int(requirement.numVideos))
             try await publisherShouldNegotiate()
         } catch {
             log("Failed to add transceivers for media sections requirement: \(error)", .error)

--- a/Sources/LiveKit/Core/RoomDependencies.swift
+++ b/Sources/LiveKit/Core/RoomDependencies.swift
@@ -58,6 +58,93 @@ extension ConnectionDependencies: Equatable {
     static func == (lhs: ConnectionDependencies, rhs: ConnectionDependencies) -> Bool { lhs === rhs }
 }
 
+// MARK: - Early publisher
+
+/// A publisher peer connection built *before* the signal socket opens, so its offer can be
+/// bundled with the JOIN request and the WebRTC cold start (SSL init, peer connection factory,
+/// audio device module) overlaps the TLS/WebSocket handshake instead of following it.
+///
+/// Deliberately not a stage payload: it is owned lexically by the connect sequence, which either
+/// hands it to ``JoinDependencies/make(room:connection:joinResponse:rtcConfiguration:singlePeerConnection:earlyPublisher:)``
+/// or closes it. So the stage invariant still holds — staged transports exist if and only if the
+/// stage is `.connected`. Mirrors the `early_publisher_pc` local in rust-sdks' `RtcSession::connect`.
+struct EarlyPublisher: Sendable {
+    let transport: Transport
+    let dataChannels: PublisherDataChannels
+
+    /// The offer to bundle with the JOIN request, or `nil` when it could not be produced.
+    /// Absent means "negotiate the ordinary way", never a failed connect.
+    let offer: Livekit_SessionDescription?
+
+    /// Builds the transport, its data channels, and the deferred initial offer.
+    ///
+    /// Only ever called for single PC mode, where the publisher is primary — so the
+    /// configuration passed here carries the client-side settings only, and the server's ICE
+    /// servers are installed later by `JoinDependencies.make`.
+    static func make(room: Room, rtcConfiguration: LKRTCConfiguration) async throws -> EarlyPublisher {
+        let transport = try await Transport(config: rtcConfiguration,
+                                            target: .publisher,
+                                            primary: true,
+                                            singlePCMode: true,
+                                            delegate: room)
+
+        // Created before the offer so its `m=application` section is negotiated by the JOIN
+        // exchange rather than costing a second one.
+        let dataChannels = await PublisherDataChannels.make(on: transport)
+
+        do {
+            let initialOffer = try await transport.createInitialOffer()
+            return EarlyPublisher(transport: transport,
+                                  dataChannels: dataChannels,
+                                  offer: initialOffer.map { $0.offer.toPBType(offerId: $0.offerId) })
+        } catch {
+            // A failed offer is recoverable: drop it and let the transport negotiate normally
+            // once the JOIN response arrives.
+            room.log("Failed to create the initial publisher offer, falling back to negotiation after JOIN: \(error)", .warning)
+            await transport.clearPendingInitialOffer()
+            return EarlyPublisher(transport: transport, dataChannels: dataChannels, offer: nil)
+        }
+    }
+
+    func close() async {
+        await transport.close()
+    }
+}
+
+/// The publisher's three outbound data channels, created together so both the early and the
+/// post-JOIN publisher paths negotiate the same layout.
+struct PublisherDataChannels: Sendable {
+    let reliable: LKRTCDataChannel?
+    let lossy: LKRTCDataChannel?
+    let dataTrack: LKRTCDataChannel?
+
+    static func make(on transport: Transport) async -> PublisherDataChannels {
+        // data over pub channel for backwards compatibility
+        let reliable = await transport.dataChannel(for: LKRTCDataChannel.Labels.reliable,
+                                                   configuration: RTC.createDataChannelConfiguration())
+
+        let lossy = await transport.dataChannel(for: LKRTCDataChannel.Labels.lossy,
+                                                configuration: RTC.createDataChannelConfiguration(ordered: false, maxRetransmits: 0))
+
+        // Data track channel (unordered, unreliable — DTP handles its own sequencing).
+        let dataTrack = await transport.dataChannel(for: LKRTCDataChannel.Labels.dataTrack,
+                                                    configuration: RTC.createDataChannelConfiguration(ordered: false, maxRetransmits: 0))
+
+        return PublisherDataChannels(reliable: reliable, lossy: lossy, dataTrack: dataTrack)
+    }
+
+    /// Hands the channels to the room's pairs and to the connection-scoped data track subsystem.
+    func install(room: Room, connection: ConnectionDependencies) {
+        room.publisherDataChannel.set(reliable: reliable)
+        room.publisherDataChannel.set(lossy: lossy)
+        if let dataTrack { connection.dataTracks.setPublisherChannel(dataTrack) }
+
+        room.log("dataChannel.\(String(describing: reliable?.label)) : \(String(describing: reliable?.channelId))")
+        room.log("dataChannel.\(String(describing: lossy?.label)) : \(String(describing: lossy?.channelId))")
+        room.log("dataChannel.\(String(describing: dataTrack?.label)) : \(String(describing: dataTrack?.channelId))")
+    }
+}
+
 // MARK: - Join dependencies
 
 /// Subsystems scoped to one server JOIN: created from a JOIN response, retired on full reconnect
@@ -78,22 +165,39 @@ final class JoinDependencies: Sendable {
 
     /// Builds the join-tier graph from a JOIN response: transports, their data channels, and the
     /// hand-off of the data track channel to the connection-scoped subsystem.
+    /// - Parameter earlyPublisher: A publisher built before the socket opened, whose offer was
+    ///   bundled with this JOIN. Adopted rather than rebuilt; the server's ICE servers are
+    ///   installed onto it here, which is what releases its deferred initial offer for
+    ///   application when the answer lands. Must be `nil` unless `singlePeerConnection`.
     static func make(room: Room,
                      connection: ConnectionDependencies,
                      joinResponse: Livekit_JoinResponse,
                      rtcConfiguration: LKRTCConfiguration,
-                     singlePeerConnection: Bool) async throws -> JoinDependencies
+                     singlePeerConnection: Bool,
+                     earlyPublisher: EarlyPublisher? = nil) async throws -> JoinDependencies
     {
         let isSinglePC = singlePeerConnection
         let isSubscriberPrimary = isSinglePC ? false : joinResponse.subscriberPrimary
         room.log("subscriberPrimary: \(isSubscriberPrimary), singlePeerConnection: \(isSinglePC)")
 
-        // Publisher always created; is primary in single PC mode
-        let publisher = try await Transport(config: rtcConfiguration,
+        let publisher: Transport
+        let dataChannels: PublisherDataChannels
+
+        if let earlyPublisher {
+            publisher = earlyPublisher.transport
+            dataChannels = earlyPublisher.dataChannels
+            // The early publisher only had the client-side configuration, so ICE gathering has
+            // not started yet. This installs the server's ICE servers first.
+            try await publisher.set(configuration: rtcConfiguration)
+        } else {
+            // Publisher always created; is primary in single PC mode
+            publisher = try await Transport(config: rtcConfiguration,
                                             target: .publisher,
                                             primary: isSinglePC || !isSubscriberPrimary,
                                             singlePCMode: isSinglePC,
                                             delegate: room)
+            dataChannels = await PublisherDataChannels.make(on: publisher)
+        }
 
         await publisher.set { [weak room] offer, offerId in
             guard let room else { return }
@@ -102,25 +206,7 @@ final class JoinDependencies: Sendable {
             room.connectSpan?.record("offer_sent")
         }
 
-        // data over pub channel for backwards compatibility
-
-        let reliableDataChannel = await publisher.dataChannel(for: LKRTCDataChannel.Labels.reliable,
-                                                              configuration: RTC.createDataChannelConfiguration())
-
-        let lossyDataChannel = await publisher.dataChannel(for: LKRTCDataChannel.Labels.lossy,
-                                                           configuration: RTC.createDataChannelConfiguration(ordered: false, maxRetransmits: 0))
-
-        room.publisherDataChannel.set(reliable: reliableDataChannel)
-        room.publisherDataChannel.set(lossy: lossyDataChannel)
-
-        // Data track channel (unordered, unreliable — DTP handles its own sequencing).
-        let dataTrackChannel = await publisher.dataChannel(for: LKRTCDataChannel.Labels.dataTrack,
-                                                           configuration: RTC.createDataChannelConfiguration(ordered: false, maxRetransmits: 0))
-        if let dataTrackChannel { connection.dataTracks.setPublisherChannel(dataTrackChannel) }
-
-        room.log("dataChannel.\(String(describing: reliableDataChannel?.label)) : \(String(describing: reliableDataChannel?.channelId))")
-        room.log("dataChannel.\(String(describing: lossyDataChannel?.label)) : \(String(describing: lossyDataChannel?.channelId))")
-        room.log("dataChannel.\(String(describing: dataTrackChannel?.label)) : \(String(describing: dataTrackChannel?.channelId))")
+        dataChannels.install(room: room, connection: connection)
 
         let subscriber: Transport? = if isSinglePC {
             nil

--- a/Sources/LiveKit/Core/RoomDependencies.swift
+++ b/Sources/LiveKit/Core/RoomDependencies.swift
@@ -69,6 +69,16 @@ extension ConnectionDependencies: Equatable {
 /// or closes it. So the stage invariant still holds — staged transports exist if and only if the
 /// stage is `.connected`. Mirrors the `early_publisher_pc` local in rust-sdks' `RtcSession::connect`.
 struct EarlyPublisher: Sendable {
+    /// Receive m-sections preallocated in the initial offer, per kind.
+    ///
+    /// In single PC mode received media is assigned to the publisher's `recvonly` sections, and
+    /// the server asks for any it still needs via `MediaSectionsRequirement` — which costs an
+    /// offer/answer cycle before the first remote track can decode. Carrying a few from the start
+    /// covers the common room size without one. Matches `initialMediaSectionsAudio`/`Video` in
+    /// client-sdk-js and `add_recv_media_sections(pc, 3, 3)` in rust-sdks.
+    static let initialAudioSections = 3
+    static let initialVideoSections = 3
+
     let transport: Transport
     let dataChannels: PublisherDataChannels
 
@@ -91,6 +101,16 @@ struct EarlyPublisher: Sendable {
         // Created before the offer so its `m=application` section is negotiated by the JOIN
         // exchange rather than costing a second one.
         let dataChannels = await PublisherDataChannels.make(on: transport)
+
+        do {
+            // Likewise before the offer, so these sections are negotiated by the JOIN exchange.
+            // A failure only costs the preallocation: the server still asks for what it needs
+            // through `MediaSectionsRequirement`.
+            try await transport.addRecvMediaSections(audio: Self.initialAudioSections,
+                                                     video: Self.initialVideoSections)
+        } catch {
+            room.log("Failed to preallocate receive media sections: \(error)", .warning)
+        }
 
         do {
             let initialOffer = try await transport.createInitialOffer()

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -151,6 +151,7 @@ actor SignalClient: Loggable {
                  participantSid: Participant.Sid? = nil,
                  adaptiveStream: Bool,
                  singlePeerConnection: Bool,
+                 publisherOffer: Livekit_SessionDescription? = nil,
                  connectSpan: Span? = nil) async throws -> ConnectResponse
     {
         await cleanUp()
@@ -164,7 +165,8 @@ actor SignalClient: Loggable {
                                           connectOptions: connectOptions,
                                           reconnectMode: reconnectMode,
                                           participantSid: participantSid,
-                                          adaptiveStream: adaptiveStream)
+                                          adaptiveStream: adaptiveStream,
+                                          publisherOffer: publisherOffer)
         } else {
             try Utils.buildUrl(url,
                                connectOptions: connectOptions,

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -405,7 +405,8 @@ private extension SignalClient {
 
         case let .answer(sd):
             let (rtcDescription, offerId) = sd.toRTCType()
-            _delegate.notifyDetached { await $0.signalClient(self, didReceiveAnswer: rtcDescription, offerId: offerId) }
+            let midToTrackSid = sd.midToTrackID.mapValues { Track.Sid(from: $0) }
+            _delegate.notifyDetached { await $0.signalClient(self, didReceiveAnswer: rtcDescription, offerId: offerId, midToTrackSid: midToTrackSid) }
 
         case let .offer(sd):
             let (rtcDescription, offerId) = sd.toRTCType()

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -59,6 +59,14 @@ final class Transport: NSObject, Loggable {
 
     private var _reNegotiate: Bool = false
 
+    /// The server's `mid` → track SID mapping from the most recent session description.
+    ///
+    /// The authority for identifying received media in single PC mode. Lives here rather than on
+    /// `Room` because it is keyed by this peer connection's mids, so it is retired exactly when
+    /// the connection is — surviving a quick reconnect (same PC, same mids) and going away with a
+    /// full one.
+    private var _midToTrackSid: [String: Track.Sid] = [:]
+
     /// A local offer that has been signalled but not yet applied with
     /// `setLocalDescription`. See ``createInitialOffer()``.
     private var _pendingInitialOffer: LKRTCSessionDescription?
@@ -573,6 +581,79 @@ extension Transport {
         }
 
         return transceiver
+    }
+
+    /// Adds `recvonly` transceivers, the m-sections received media is assigned to in single PC mode.
+    ///
+    /// Shared by the two paths that need them: the initial offer preallocates a few so the first
+    /// subscriptions land without another negotiation, and `MediaSectionsRequirement` adds more
+    /// when the server needs sections beyond those. Unused sections stay idle, so over-allocating
+    /// costs SDP size rather than correctness.
+    func addRecvMediaSections(audio: Int, video: Int) throws {
+        let transceiverInit = LKRTCRtpTransceiverInit()
+        transceiverInit.direction = .recvOnly
+
+        for _ in 0 ..< audio {
+            _ = try addTransceiver(ofType: .audio, transceiverInit: transceiverInit)
+        }
+        for _ in 0 ..< video {
+            _ = try addTransceiver(ofType: .video, transceiverInit: transceiverInit)
+        }
+    }
+
+    /// Drops a mid from the applied mapping so the next description that still reports it is
+    /// treated as a fresh binding. Used when the binding arrived before its publication.
+    func forget(mid: String?) {
+        guard let mid else { return }
+        _midToTrackSid[mid] = nil
+    }
+
+    /// One receive m-section the server has bound to a published track.
+    struct ReceivedMedia {
+        let trackSid: Track.Sid
+        let track: RTCMediaTrack
+        let receiver: RTCReceiver
+    }
+
+    /// Applies the server's `mid` → track SID mapping and reports the sections that became bound
+    /// since the last call.
+    ///
+    /// Replaces rather than merges: each session description carries the complete mapping, so a
+    /// mid dropping out means the server unbound it.
+    ///
+    /// - Returns: The newly bound sections whose receiver already has a track, for the caller to
+    ///   attach. Empty when nothing changed.
+    func apply(midToTrackSid mapping: [String: Track.Sid]) -> [ReceivedMedia] {
+        let previous = _midToTrackSid
+        _midToTrackSid = mapping
+
+        let newlyBound = mapping.filter { previous[$0.key] != $0.value }
+        guard !newlyBound.isEmpty else { return [] }
+
+        // `mid` is documented as nil until negotiation completes, and again after a rollback,
+        // despite the ObjC declaration not being nullability-audited.
+        var transceiversByMid: [String: LKRTCRtpTransceiver] = [:]
+        for transceiver in _pc.transceivers {
+            guard let mid = transceiver.mid as String?, !mid.isEmpty else { continue }
+            if transceiversByMid[mid] == nil { transceiversByMid[mid] = transceiver }
+        }
+
+        return newlyBound.compactMap { mid, trackSid in
+            guard let transceiver = transceiversByMid[mid] else {
+                log("No transceiver for mid \(mid) bound to \(trackSid)", .warning)
+                return nil
+            }
+            guard let track = transceiver.receiver.track else {
+                // The section is negotiated but carries no track yet; a later description that
+                // still maps this mid re-reports it, since the mapping only advances on change.
+                log("Transceiver for mid \(mid) has no receiver track yet", .debug)
+                _midToTrackSid[mid] = nil
+                return nil
+            }
+            return ReceivedMedia(trackSid: trackSid,
+                                 track: RTCMediaTrack(track),
+                                 receiver: RTCReceiver(transceiver.receiver))
+        }
     }
 
     func remove(track sender: RTCSender) throws {

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -58,6 +58,10 @@ final class Transport: NSObject, Loggable {
     private let _debounce = Debounce(delay: 0.02) // 20ms
 
     private var _reNegotiate: Bool = false
+
+    /// A local offer that has been signalled but not yet applied with
+    /// `setLocalDescription`. See ``createInitialOffer()``.
+    private var _pendingInitialOffer: LKRTCSessionDescription?
     private var _onOffer: OnOfferBlock?
     private var _isRestartingIce: Bool = false
     private var _latestOfferId: UInt32 = 0
@@ -125,6 +129,55 @@ final class Transport: NSObject, Loggable {
         _onOffer = block
     }
 
+    /// Creates the offer that rides along with the JOIN request, *without* applying it.
+    ///
+    /// `setLocalDescription` is deferred until the answer arrives, because applying it
+    /// starts ICE gathering — and at this point the peer connection has only the
+    /// client-side configuration, so it would gather without the server's TURN servers
+    /// and never produce relay candidates. ``set(remoteDescription:)`` applies the
+    /// pending offer once ``set(configuration:)`` has installed them, mirroring
+    /// `createInitialOffer` in client-sdk-js and `create_initial_offer` in rust-sdks.
+    ///
+    /// - Returns: The offer to signal and its id, or `nil` outside single PC mode
+    ///   (the dual-PC subscriber-primary flow has the server offer first).
+    /// - Note: The munges are applied here and the result is signalled as-is, so unlike
+    ///   ``set(localDescription:munging:)`` a munge libwebrtc rejects cannot be dropped
+    ///   and retried — the peer has already been told what we offered. Both munges on
+    ///   this path are the ones every single PC mode offer already carries.
+    func createInitialOffer() async throws -> (offer: LKRTCSessionDescription, offerId: UInt32)? {
+        guard singlePCMode else { return nil }
+
+        guard signalingState == .stable else {
+            log("Signaling state is \(signalingState), cannot create the initial offer", .warning)
+            return nil
+        }
+
+        let offer = try await createOffer()
+        let mungedSDP = [Self.mungeInactiveToRecvOnlyForMedia, Self.mungeOpusStereoForAllAudio]
+            .reduce(offer.sdp) { $1($0) }
+        let munged = mungedSDP == offer.sdp ? offer : RTC.createSessionDescription(type: offer.type, sdp: mungedSDP)
+
+        _latestOfferId += 1
+        _pendingInitialOffer = munged
+        return (munged, _latestOfferId)
+    }
+
+    /// Drops an initial offer that will never be answered, so the transport falls back to
+    /// ordinary negotiation. Used when the JOIN it was bundled with did not succeed.
+    func clearPendingInitialOffer() {
+        _pendingInitialOffer = nil
+    }
+
+    /// Applies a deferred initial offer, if one is outstanding. Take-once, so callers on
+    /// both remote-description paths are safe.
+    private func applyPendingInitialOffer() async throws {
+        guard let pendingInitialOffer = _pendingInitialOffer else { return }
+        _pendingInitialOffer = nil
+
+        log("Applying the initial offer deferred from JOIN")
+        try await set(localDescription: pendingInitialOffer)
+    }
+
     func setIsRestartingIce() {
         _isRestartingIce = true
     }
@@ -134,6 +187,10 @@ final class Transport: NSObject, Loggable {
     }
 
     func set(remoteDescription sd: LKRTCSessionDescription, offerId: UInt32) async throws {
+        // Before the state check: an offer bundled with JOIN leaves the connection
+        // `.stable` until its answer arrives.
+        try await applyPendingInitialOffer()
+
         if signalingState != .haveLocalOffer {
             log("Received answer with unexpected signaling state: \(signalingState), expected .haveLocalOffer", .warning)
         }
@@ -148,6 +205,8 @@ final class Transport: NSObject, Loggable {
     }
 
     func set(remoteDescription sd: LKRTCSessionDescription) async throws {
+        try await applyPendingInitialOffer()
+
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             _pc.setRemoteDescription(sd) { @Sendable error in
                 if let error {
@@ -187,7 +246,11 @@ final class Transport: NSObject, Loggable {
             _isRestartingIce = true
         }
 
-        if signalingState == .haveLocalOffer, !(iceRestart && remoteDescription != nil) {
+        // A deferred initial offer counts as awaiting an answer even though the
+        // connection still reads `.stable`, so a publish racing the JOIN queues a
+        // renegotiation instead of offering over the top of it.
+        let isAwaitingAnswer = signalingState == .haveLocalOffer || _pendingInitialOffer != nil
+        if isAwaitingAnswer, !(iceRestart && remoteDescription != nil) {
             _reNegotiate = true
             return
         }
@@ -216,6 +279,8 @@ final class Transport: NSObject, Loggable {
     func close() async {
         // prevent debounced negotiate firing
         await _debounce.cancel()
+
+        _pendingInitialOffer = nil
 
         // Stop listening to delegate
         _pc.delegate = nil

--- a/Sources/LiveKit/Extensions/Data.swift
+++ b/Sources/LiveKit/Extensions/Data.swift
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+extension Data {
+    /// Base64 using the URL-safe alphabet from
+    /// [RFC 4648 §5](https://datatracker.ietf.org/doc/html/rfc4648#section-5).
+    ///
+    /// Required for values carried in a query string: `URLComponents` leaves
+    /// `+` and `/` unescaped in a query value, and a receiver that parses the
+    /// query as form-urlencoded decodes `+` as a space — silently corrupting
+    /// standard base64. Padding is kept, matching client-sdk-js and rust-sdks.
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+    }
+}

--- a/Sources/LiveKit/Protocols/SignalClientDelegate.swift
+++ b/Sources/LiveKit/Protocols/SignalClientDelegate.swift
@@ -21,7 +21,9 @@ internal import LiveKitWebRTC
 protocol SignalClientDelegate: AnyObject, Sendable {
     func signalClient(_ signalClient: SignalClient, didUpdateConnectionState newState: ConnectionState, oldState: ConnectionState, disconnectError: LiveKitError?) async
     func signalClient(_ signalClient: SignalClient, didReceiveConnectResponse connectResponse: SignalClient.ConnectResponse) async
-    func signalClient(_ signalClient: SignalClient, didReceiveAnswer answer: LKRTCSessionDescription, offerId: UInt32) async
+    /// - Parameter midToTrackSid: The server's `mid` → track SID mapping, the authority for
+    ///   identifying received media in single PC mode. Empty before any track is bound.
+    func signalClient(_ signalClient: SignalClient, didReceiveAnswer answer: LKRTCSessionDescription, offerId: UInt32, midToTrackSid: [String: Track.Sid]) async
     func signalClient(_ signalClient: SignalClient, didReceiveOffer offer: LKRTCSessionDescription, offerId: UInt32) async
     func signalClient(_ signalClient: SignalClient, didReceiveIceCandidate iceCandidate: IceCandidate, target: Livekit_SignalTarget) async
     func signalClient(_ signalClient: SignalClient, didUnpublishLocalTrack localTrack: Livekit_TrackUnpublishedResponse) async

--- a/Sources/LiveKit/Support/Gzip.swift
+++ b/Sources/LiveKit/Support/Gzip.swift
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Compression
+import Foundation
+
+/// Minimal gzip ([RFC 1952](https://datatracker.ietf.org/doc/html/rfc1952)) encoder.
+///
+/// Apple's Compression framework has no gzip container: `COMPRESSION_ZLIB`
+/// produces a raw DEFLATE stream ([RFC 1951](https://datatracker.ietf.org/doc/html/rfc1951))
+/// with no header, checksum or length trailer. This wraps that stream in the
+/// gzip framing the LiveKit server expects, rather than linking zlib just for
+/// its container.
+enum Gzip {
+    /// Fixed 10-byte gzip header: magic, DEFLATE method, no flags, no mtime,
+    /// no extra flags, unknown OS. The mtime is left zero so the same input
+    /// always encodes to the same bytes and no clock value is disclosed.
+    private static let header: [UInt8] = [0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF]
+
+    /// Compresses `data` into a gzip stream.
+    ///
+    /// - Returns: The gzip stream, or `nil` when `data` is empty or DEFLATE
+    ///   fails. Callers are expected to fall back to the uncompressed payload.
+    /// - Note: DEFLATE can expand incompressible input, so the result is not
+    ///   guaranteed to be smaller than `data`. Compare the sizes before use.
+    static func compress(_ data: Data) -> Data? {
+        guard !data.isEmpty else { return nil }
+
+        // Worst-case DEFLATE expansion plus room for the block headers.
+        let capacity = data.count + data.count / 16 + 64
+        var deflated = Data(count: capacity)
+
+        let deflatedCount = deflated.withUnsafeMutableBytes { destination -> Int in
+            guard let destinationStart = destination.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
+
+            return data.withUnsafeBytes { source -> Int in
+                guard let sourceStart = source.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
+
+                return compression_encode_buffer(destinationStart, capacity,
+                                                 sourceStart, data.count,
+                                                 nil, COMPRESSION_ZLIB)
+            }
+        }
+
+        // `compression_encode_buffer` reports failure as zero bytes written.
+        guard deflatedCount > 0 else { return nil }
+
+        var result = Data(header)
+        result.append(deflated.prefix(deflatedCount))
+        result.append(littleEndian: crc32(data))
+        // ISIZE is the uncompressed size modulo 2^32.
+        result.append(littleEndian: UInt32(truncatingIfNeeded: data.count))
+        return result
+    }
+
+    /// CRC-32 as specified by gzip: reflected polynomial `0xEDB88320`,
+    /// pre-inverted and post-inverted.
+    static func crc32(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        for byte in data {
+            let index = Int((crc ^ UInt32(byte)) & 0xFF)
+            crc = crcTable[index] ^ (crc >> 8)
+        }
+        return crc ^ 0xFFFF_FFFF
+    }
+
+    private static let crcTable: [UInt32] = (0 ..< 256).map { index in
+        (0 ..< 8).reduce(UInt32(index)) { value, _ in
+            (value & 1) != 0 ? 0xEDB8_8320 ^ (value >> 1) : value >> 1
+        }
+    }
+}
+
+private extension Data {
+    mutating func append(littleEndian value: UInt32) {
+        var value = value.littleEndian
+        append(contentsOf: Swift.withUnsafeBytes(of: &value) { Array($0) })
+    }
+}

--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -299,12 +299,25 @@ class Utils: Loggable {
         }
 
         let joinRequestData = try joinRequest.serializedData()
+
+        // The request travels in the WebSocket upgrade URL, so keeping it within
+        // a single TCP segment avoids paying a retransmission timeout before the
+        // handshake even starts on a lossy link. Mirrors client-sdk-js and
+        // rust-sdks: gzip, but keep the compressed form only when it is actually
+        // smaller — gzip framing exceeds the savings on a small request.
+        let (payload, compression): (Data, Livekit_WrappedJoinRequest_Compression) =
+            if let compressed = Gzip.compress(joinRequestData), compressed.count < joinRequestData.count {
+                (compressed, .gzip)
+            } else {
+                (joinRequestData, .none)
+            }
+
         let wrappedData = try Livekit_WrappedJoinRequest.with {
-            $0.compression = .none
-            $0.joinRequest = joinRequestData
+            $0.compression = compression
+            $0.joinRequest = payload
         }.serializedData()
 
-        return wrappedData.base64EncodedString()
+        return wrappedData.base64URLEncodedString()
     }
 }
 

--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -214,6 +214,7 @@ class Utils: Loggable {
         reconnectMode: ReconnectMode? = nil,
         participantSid: Participant.Sid? = nil,
         adaptiveStream: Bool,
+        publisherOffer: Livekit_SessionDescription? = nil,
     ) throws -> URL {
         let connectOptions = connectOptions ?? ConnectOptions()
 
@@ -239,7 +240,8 @@ class Utils: Loggable {
         let encoded = try buildWrappedJoinRequest(connectOptions: connectOptions,
                                                   reconnectMode: reconnectMode,
                                                   participantSid: participantSid,
-                                                  adaptiveStream: adaptiveStream)
+                                                  adaptiveStream: adaptiveStream,
+                                                  publisherOffer: publisherOffer)
 
         builder.queryItems = [URLQueryItem(name: "join_request", value: encoded)]
 
@@ -272,6 +274,7 @@ class Utils: Loggable {
         reconnectMode: ReconnectMode?,
         participantSid: Participant.Sid?,
         adaptiveStream: Bool,
+        publisherOffer: Livekit_SessionDescription?,
     ) throws -> String {
         let joinRequest = Livekit_JoinRequest.with { request in
             request.clientInfo = Livekit_ClientInfo.with {
@@ -287,6 +290,12 @@ class Utils: Loggable {
             request.connectionSettings = Livekit_ConnectionSettings.with {
                 $0.autoSubscribe = connectOptions.autoSubscribe
                 $0.adaptiveStream = adaptiveStream
+            }
+
+            // Bundling the publisher offer lets the server answer it in the same exchange,
+            // removing a round trip from the connect path.
+            if let publisherOffer {
+                request.publisherOffer = publisherOffer
             }
 
             if reconnectMode == .quick {

--- a/Tests/LiveKitCoreTests/GzipTestSupport.swift
+++ b/Tests/LiveKitCoreTests/GzipTestSupport.swift
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Compression
+import Foundation
+
+/// Test-only gzip reader, used to prove the container the SDK writes is well formed and to
+/// read back `join_request` parameters. The SDK itself only ever encodes.
+enum TestGunzip {
+    static func decompress(_ data: Data) -> Data? {
+        // Fixed 10-byte header, 8-byte trailer; the SDK never emits optional fields.
+        guard data.count > 18 else { return nil }
+        let deflated = Data(data.dropFirst(10).dropLast(8))
+        guard let expectedSize = data.suffix(4).littleEndianUInt32 else { return nil }
+
+        var result = Data(count: Int(expectedSize))
+        let written = result.withUnsafeMutableBytes { destination -> Int in
+            guard let destinationStart = destination.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
+
+            return deflated.withUnsafeBytes { source -> Int in
+                guard let sourceStart = source.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
+
+                return compression_decode_buffer(destinationStart, Int(expectedSize),
+                                                 sourceStart, deflated.count,
+                                                 nil, COMPRESSION_ZLIB)
+            }
+        }
+
+        guard written == Int(expectedSize) else { return nil }
+        return result
+    }
+}
+
+extension Data {
+    init?(base64URLEncoded string: String) {
+        var base64 = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        // Restore any stripped padding so Foundation accepts the string.
+        if base64.count % 4 != 0 {
+            base64 += String(repeating: "=", count: 4 - base64.count % 4)
+        }
+        self.init(base64Encoded: base64)
+    }
+
+    var littleEndianUInt32: UInt32? {
+        guard count == 4 else { return nil }
+        // `enumerated()` offsets are slice-relative, unlike `indices`.
+        return enumerated().reduce(UInt32(0)) { $0 | UInt32($1.element) << (8 * $1.offset) }
+    }
+}

--- a/Tests/LiveKitCoreTests/JoinRequestUrlTests.swift
+++ b/Tests/LiveKitCoreTests/JoinRequestUrlTests.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import Compression
 import Foundation
 @testable import LiveKit
 import Testing
@@ -57,7 +56,7 @@ import Testing
         let wrapped = try Livekit_WrappedJoinRequest(serializedBytes: wrappedData)
 
         let joinRequestData: Data = switch wrapped.compression {
-        case .gzip: try #require(Gunzip.decompress(wrapped.joinRequest))
+        case .gzip: try #require(TestGunzip.decompress(wrapped.joinRequest))
         default: wrapped.joinRequest
         }
 
@@ -104,7 +103,7 @@ struct GzipTests {
         #expect(trailer.prefix(4).littleEndianUInt32 == Gzip.crc32(original))
         #expect(trailer.suffix(4).littleEndianUInt32 == UInt32(original.count))
 
-        #expect(Gunzip.decompress(compressed) == original)
+        #expect(TestGunzip.decompress(compressed) == original)
     }
 
     @Test func compressReturnsNilForEmptyData() {
@@ -122,54 +121,8 @@ struct GzipTests {
         }
 
         let compressed = try #require(Gzip.compress(random))
-        #expect(Gunzip.decompress(compressed) == random)
+        #expect(TestGunzip.decompress(compressed) == random)
     }
 }
 
-// MARK: - Test helpers
-
-/// Test-only gzip reader, used to prove the container the SDK writes is well
-/// formed. The SDK itself only ever encodes.
-private enum Gunzip {
-    static func decompress(_ data: Data) -> Data? {
-        // Fixed 10-byte header, 8-byte trailer; the SDK never emits optional fields.
-        guard data.count > 18 else { return nil }
-        let deflated = data.dropFirst(10).dropLast(8)
-        guard let expectedSize = data.suffix(4).littleEndianUInt32 else { return nil }
-
-        var result = Data(count: Int(expectedSize))
-        let written = result.withUnsafeMutableBytes { destination -> Int in
-            guard let destinationStart = destination.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
-
-            return Data(deflated).withUnsafeBytes { source -> Int in
-                guard let sourceStart = source.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
-
-                return compression_decode_buffer(destinationStart, Int(expectedSize),
-                                                 sourceStart, deflated.count,
-                                                 nil, COMPRESSION_ZLIB)
-            }
-        }
-
-        guard written == Int(expectedSize) else { return nil }
-        return result
-    }
-}
-
-private extension Data {
-    init?(base64URLEncoded string: String) {
-        var base64 = string
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-        // Restore any stripped padding so Foundation accepts the string.
-        if base64.count % 4 != 0 {
-            base64 += String(repeating: "=", count: 4 - base64.count % 4)
-        }
-        self.init(base64Encoded: base64)
-    }
-
-    var littleEndianUInt32: UInt32? {
-        guard count == 4 else { return nil }
-        // `enumerated()` offsets are slice-relative, unlike `indices`.
-        return enumerated().reduce(UInt32(0)) { $0 | UInt32($1.element) << (8 * $1.offset) }
-    }
-}
+// Shared `TestGunzip` / `Data` helpers live in GzipTestSupport.swift.

--- a/Tests/LiveKitCoreTests/JoinRequestUrlTests.swift
+++ b/Tests/LiveKitCoreTests/JoinRequestUrlTests.swift
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Compression
+import Foundation
+@testable import LiveKit
+import Testing
+
+@Suite(.tags(.networking)) struct JoinRequestUrlTests {
+    private static let url = URL(string: "wss://example.livekit.cloud")!
+
+    private func joinRequestParam(reconnectMode: ReconnectMode? = nil) throws -> String {
+        let url = try Utils.buildJoinRequestUrl(Self.url,
+                                                connectOptions: ConnectOptions(),
+                                                reconnectMode: reconnectMode,
+                                                participantSid: nil,
+                                                adaptiveStream: true)
+
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        // The percent-encoded query is what actually goes on the wire.
+        let query = try #require(components.percentEncodedQuery)
+        let param = try #require(query.split(separator: "&")
+            .first { $0.hasPrefix("join_request=") }?
+            .dropFirst("join_request=".count))
+        return String(param)
+    }
+
+    /// `URLComponents` does not escape `+` or `/` in a query value, so standard
+    /// base64 reaches the server intact only by luck — a receiver parsing the
+    /// query as form-urlencoded turns `+` into a space.
+    @Test func joinRequestParamIsUrlSafe() throws {
+        let param = try joinRequestParam()
+
+        #expect(!param.contains("+"), "Standard base64 leaked into the query: \(param)")
+        #expect(!param.contains("/"), "Standard base64 leaked into the query: \(param)")
+    }
+
+    @Test(arguments: [nil, ReconnectMode.quick] as [ReconnectMode?])
+    func joinRequestRoundTrips(reconnectMode: ReconnectMode?) throws {
+        let param = try joinRequestParam(reconnectMode: reconnectMode)
+
+        let decodedParam = try #require(param.removingPercentEncoding)
+        let wrappedData = try #require(Data(base64URLEncoded: decodedParam))
+        let wrapped = try Livekit_WrappedJoinRequest(serializedBytes: wrappedData)
+
+        let joinRequestData: Data = switch wrapped.compression {
+        case .gzip: try #require(Gunzip.decompress(wrapped.joinRequest))
+        default: wrapped.joinRequest
+        }
+
+        let joinRequest = try Livekit_JoinRequest(serializedBytes: joinRequestData)
+        #expect(joinRequest.clientInfo.sdk == .swift)
+        #expect(joinRequest.clientInfo.version == LiveKitSDK.version)
+        #expect(joinRequest.connectionSettings.adaptiveStream)
+        #expect(joinRequest.reconnect == (reconnectMode == .quick))
+    }
+
+    /// A minimal join request is small enough that gzip framing outweighs the
+    /// savings, so it must stay uncompressed rather than growing the URL.
+    @Test func smallRequestIsNotCompressed() throws {
+        let param = try joinRequestParam()
+
+        let decodedParam = try #require(param.removingPercentEncoding)
+        let wrappedData = try #require(Data(base64URLEncoded: decodedParam))
+        let wrapped = try Livekit_WrappedJoinRequest(serializedBytes: wrappedData)
+
+        #expect(wrapped.compression == .none)
+    }
+}
+
+struct GzipTests {
+    /// Known-answer vector for CRC-32 of "123456789".
+    @Test func crc32MatchesKnownVector() throws {
+        let data = try #require("123456789".data(using: .utf8))
+        #expect(Gzip.crc32(data) == 0xCBF4_3926)
+    }
+
+    @Test func crc32OfEmptyDataIsZero() {
+        #expect(Gzip.crc32(Data()) == 0)
+    }
+
+    @Test func compressProducesValidGzipStream() throws {
+        // Repetitive enough that DEFLATE wins by a wide margin.
+        let original = try #require(String(repeating: "livekit join request ", count: 200).data(using: .utf8))
+        let compressed = try #require(Gzip.compress(original))
+
+        #expect(compressed.count < original.count)
+        #expect(Array(compressed.prefix(3)) == [0x1F, 0x8B, 0x08], "Missing gzip magic and DEFLATE method")
+
+        let trailer = compressed.suffix(8)
+        #expect(trailer.prefix(4).littleEndianUInt32 == Gzip.crc32(original))
+        #expect(trailer.suffix(4).littleEndianUInt32 == UInt32(original.count))
+
+        #expect(Gunzip.decompress(compressed) == original)
+    }
+
+    @Test func compressReturnsNilForEmptyData() {
+        #expect(Gzip.compress(Data()) == nil)
+    }
+
+    /// Incompressible input may expand; the encoder must still emit a stream the
+    /// caller can measure and reject, never a corrupt one.
+    @Test func compressHandlesIncompressibleData() throws {
+        var random = Data(count: 4096)
+        random.withUnsafeMutableBytes { buffer in
+            for index in buffer.indices {
+                buffer[index] = UInt8.random(in: .min ... .max)
+            }
+        }
+
+        let compressed = try #require(Gzip.compress(random))
+        #expect(Gunzip.decompress(compressed) == random)
+    }
+}
+
+// MARK: - Test helpers
+
+/// Test-only gzip reader, used to prove the container the SDK writes is well
+/// formed. The SDK itself only ever encodes.
+private enum Gunzip {
+    static func decompress(_ data: Data) -> Data? {
+        // Fixed 10-byte header, 8-byte trailer; the SDK never emits optional fields.
+        guard data.count > 18 else { return nil }
+        let deflated = data.dropFirst(10).dropLast(8)
+        guard let expectedSize = data.suffix(4).littleEndianUInt32 else { return nil }
+
+        var result = Data(count: Int(expectedSize))
+        let written = result.withUnsafeMutableBytes { destination -> Int in
+            guard let destinationStart = destination.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
+
+            return Data(deflated).withUnsafeBytes { source -> Int in
+                guard let sourceStart = source.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
+
+                return compression_decode_buffer(destinationStart, Int(expectedSize),
+                                                 sourceStart, deflated.count,
+                                                 nil, COMPRESSION_ZLIB)
+            }
+        }
+
+        guard written == Int(expectedSize) else { return nil }
+        return result
+    }
+}
+
+private extension Data {
+    init?(base64URLEncoded string: String) {
+        var base64 = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        // Restore any stripped padding so Foundation accepts the string.
+        if base64.count % 4 != 0 {
+            base64 += String(repeating: "=", count: 4 - base64.count % 4)
+        }
+        self.init(base64Encoded: base64)
+    }
+
+    var littleEndianUInt32: UInt32? {
+        guard count == 4 else { return nil }
+        // `enumerated()` offsets are slice-relative, unlike `indices`.
+        return enumerated().reduce(UInt32(0)) { $0 | UInt32($1.element) << (8 * $1.offset) }
+    }
+}

--- a/Tests/LiveKitCoreTests/OfferWithJoinTests.swift
+++ b/Tests/LiveKitCoreTests/OfferWithJoinTests.swift
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+@testable import LiveKit
+import LiveKitWebRTC
+import Testing
+
+/// Covers the offer bundled with the JOIN request: the deferral of `setLocalDescription`
+/// until the answer arrives, and the offer's trip through the join_request parameter.
+@Suite(.tags(.networking)) struct OfferWithJoinTests {
+    private static let url = URL(string: "wss://example.livekit.cloud")!
+
+    /// Records nothing; `Transport` requires a delegate but none of these tests exercise it.
+    private final class StubDelegate: TransportDelegate {
+        func transport(_: Transport, didUpdateState _: LKRTCPeerConnectionState) {}
+        func transport(_: Transport, didGenerateIceCandidate _: IceCandidate) {}
+        func transport(_: Transport, didOpenDataChannel _: LKRTCDataChannel) {}
+        func transport(_: Transport, didAddTrack _: RTCMediaTrack, rtpReceiver _: RTCReceiver, streamIds _: [String]) {}
+        func transport(_: Transport, didRemoveTrackWithId _: String) {}
+        func transportShouldNegotiate(_: Transport) {}
+    }
+
+    private func makeTransport(singlePCMode: Bool, delegate: StubDelegate) async throws -> Transport {
+        try await Transport(config: LKRTCConfiguration.liveKitDefault(),
+                            target: .publisher,
+                            primary: true,
+                            singlePCMode: singlePCMode,
+                            delegate: delegate)
+    }
+
+    /// The dual-PC flow has the server offer first, so there is nothing to bundle.
+    @Test func noInitialOfferOutsideSinglePCMode() async throws {
+        let delegate = StubDelegate()
+        let transport = try await makeTransport(singlePCMode: false, delegate: delegate)
+        defer { Task { await transport.close() } }
+
+        let initial = try await transport.createInitialOffer()
+        #expect(initial == nil)
+    }
+
+    /// The point of the whole mechanism: the offer is produced and signalled, but not applied,
+    /// so ICE gathering cannot start before the server's ICE servers are installed.
+    @Test func initialOfferIsDeferredUntilAnswer() async throws {
+        let delegate = StubDelegate()
+        let transport = try await makeTransport(singlePCMode: true, delegate: delegate)
+        defer { Task { await transport.close() } }
+
+        _ = await transport.dataChannel(for: LKRTCDataChannel.Labels.reliable,
+                                        configuration: RTC.createDataChannelConfiguration())
+
+        let initial = try await transport.createInitialOffer()
+        let offer = try #require(initial)
+
+        #expect(offer.offer.type == .offer)
+        #expect(offer.offerId == 1, "The bundled offer must claim an id the answer can be matched against")
+        #expect(!offer.offer.sdp.isEmpty)
+        #expect(await transport.localDescription == nil, "setLocalDescription must be deferred")
+        #expect(await transport.signalingState == .stable)
+
+        // Answer it the way the SFU would, from a second peer connection.
+        let answer = try await answer(to: offer.offer)
+        try await transport.set(remoteDescription: answer, offerId: offer.offerId)
+
+        #expect(await transport.localDescription != nil, "The deferred offer must be applied with the answer")
+        #expect(await transport.remoteDescription != nil)
+        #expect(await transport.signalingState == .stable)
+    }
+
+    /// A JOIN that never completes must not leave the transport wedged waiting for an answer
+    /// to an offer nobody holds.
+    @Test func clearingThePendingOfferRestoresOrdinaryNegotiation() async throws {
+        let delegate = StubDelegate()
+        let transport = try await makeTransport(singlePCMode: true, delegate: delegate)
+        defer { Task { await transport.close() } }
+
+        _ = try await transport.createInitialOffer()
+        await transport.clearPendingInitialOffer()
+
+        let sentOffers = SentOffers()
+        await transport.set { offer, offerId in
+            await sentOffers.append(offer: offer, offerId: offerId)
+        }
+        try await transport.negotiate(force: true)
+
+        #expect(await sentOffers.count == 1, "Negotiation must proceed once the pending offer is cleared")
+        #expect(await transport.localDescription != nil)
+    }
+
+    /// While an initial offer is outstanding the connection still reads `.stable`, so the
+    /// deferred offer — not the signaling state — has to gate renegotiation.
+    @Test func negotiationDefersWhileTheInitialOfferIsPending() async throws {
+        let delegate = StubDelegate()
+        let transport = try await makeTransport(singlePCMode: true, delegate: delegate)
+        defer { Task { await transport.close() } }
+
+        let initial = try await transport.createInitialOffer()
+        let offer = try #require(initial)
+
+        let sentOffers = SentOffers()
+        await transport.set { offer, offerId in
+            await sentOffers.append(offer: offer, offerId: offerId)
+        }
+
+        try await transport.negotiate(force: true)
+        #expect(await sentOffers.count == 0, "Must not offer over the top of the bundled offer")
+
+        // Applying the answer releases the queued renegotiation.
+        let answer = try await answer(to: offer.offer)
+        try await transport.set(remoteDescription: answer, offerId: offer.offerId)
+
+        #expect(await sentOffers.count == 1)
+    }
+
+    @Test func joinRequestCarriesThePublisherOffer() throws {
+        let sdp = "v=0\r\no=- 1 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=group:BUNDLE 0\r\n"
+        let publisherOffer = Livekit_SessionDescription.with {
+            $0.sdp = sdp
+            $0.type = "offer"
+            $0.id = 1
+        }
+
+        let url = try Utils.buildJoinRequestUrl(Self.url,
+                                                connectOptions: ConnectOptions(),
+                                                adaptiveStream: true,
+                                                publisherOffer: publisherOffer)
+
+        let joinRequest = try Self.decodeJoinRequest(from: url)
+        #expect(joinRequest.hasPublisherOffer)
+        #expect(joinRequest.publisherOffer.sdp == sdp)
+        #expect(joinRequest.publisherOffer.type == "offer")
+        #expect(joinRequest.publisherOffer.id == 1)
+    }
+
+    @Test func joinRequestOmitsTheOfferWhenThereIsNone() throws {
+        let url = try Utils.buildJoinRequestUrl(Self.url,
+                                                connectOptions: ConnectOptions(),
+                                                adaptiveStream: true)
+
+        let joinRequest = try Self.decodeJoinRequest(from: url)
+        #expect(!joinRequest.hasPublisherOffer)
+    }
+
+    // MARK: - Helpers
+
+    /// Accumulates offers handed to `Transport.set(onOfferBlock:)`.
+    private actor SentOffers {
+        private var offers: [(LKRTCSessionDescription, UInt32)] = []
+        var count: Int { offers.count }
+        func append(offer: LKRTCSessionDescription, offerId: UInt32) { offers.append((offer, offerId)) }
+    }
+
+    /// Answers `offer` from an independent peer connection, standing in for the SFU.
+    private func answer(to offer: LKRTCSessionDescription) async throws -> LKRTCSessionDescription {
+        let peer = StubDelegate()
+        let remote = try await makeTransport(singlePCMode: false, delegate: peer)
+        defer { Task { await remote.close() } }
+
+        try await remote.set(remoteDescription: offer)
+        let answer = try await remote.createAnswer()
+        try await remote.set(localDescription: answer)
+        return answer
+    }
+
+    private static func decodeJoinRequest(from url: URL) throws -> Livekit_JoinRequest {
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let param = try #require(components.queryItems?.first { $0.name == "join_request" }?.value)
+        let wrappedData = try #require(Data(base64URLEncoded: param))
+        let wrapped = try Livekit_WrappedJoinRequest(serializedBytes: wrappedData)
+
+        let joinRequestData: Data = switch wrapped.compression {
+        case .gzip: try #require(TestGunzip.decompress(wrapped.joinRequest))
+        default: wrapped.joinRequest
+        }
+        return try Livekit_JoinRequest(serializedBytes: joinRequestData)
+    }
+}


### PR DESCRIPTION
**Draft — blocked on a server-side gap. Do not merge.** Opened so the implementation and the findings are visible to whoever picks up the SFU conversation.

Stacked on #1111. CLT-3303 (ticket 3) + the prerequisite that turned out to be needed.

## What this contains

**A — mid-based track resolution.** Stores the server's `mid` → track SID mapping from each session description on the publisher `Transport`, plumbs it through `SignalClientDelegate.didReceiveAnswer`, and attaches received media from the answer handler. Matches `mid_to_track_id` handling in rust-sdks (`rtc_session.rs:1345-1348`, `room/mod.rs:1340-1350`), which Swift has never implemented — the field exists in the protos with zero references in `Sources/`.

**B — preallocate 3 audio + 3 video `recvonly` sections** in the initial offer, matching `initialMediaSectionsAudio`/`Video` in client-sdk-js and `add_recv_media_sections(pc, 3, 3)` in rust-sdks. Plus a guard against renegotiating on a zero-count `MediaSectionsRequirement`.

## Why it is blocked

B does not work against **either** server tested:

| Server | Result |
|---|---|
| `livekit-server` 1.13.1 (local) | `audioTrack(V1)`, `reconnect(V1)` fail — remote track never attaches |
| Staging Cloud | Same two, **plus** `dataChannel(V1)` times out |

All dual-PC cases pass in both. The failure is specific to single PC with preallocation.

**Mechanism**, established by instrumenting the wire:

1. The client offers 6 `recvonly` sections.
2. The server answers them with **no `a=msid`** (verified: `msids: []`), because no track is bound yet.
3. libwebrtc creates receivers for the negotiated sections and fires `didAddTrack` ×6 with one synthesized UUID stream shared across them.
4. When a track is later published, **no further event arrives** — no `TR_…` track id, no `PA_…|TR_…` stream, ever.

Normally the binding is delivered by: subscription → server sends `MediaSectionsRequirement` → client offers → **server's answer stamps the msid**. Preallocation makes the server compute "0 more sections needed", so it sends `(0,0)` and never triggers the renegotiation that would stamp the msid. The section stays bound to nothing.

A cannot rescue this either: instrumentation shows the subscriber's `midToTrackID` is **empty on every answer** (`map=[:]` ×25). The populated maps observed belong to clients that are *publishing* — they map a client's own send sections, not its subscriptions.

So the information needed to identify the media never reaches the client through any channel. This needs a server-side change, not a client one.

## What is verified

**A validates green standalone.** Before enabling B, A alone passed **9/9 E2E, both PC modes** against `livekit-server` 1.13.1. So the resolution path is sound; it is simply inert against current servers, since the mapping is empty for exactly the subscriptions it would resolve.

**No dual-PC impact.** Every new path is single-PC gated:

| Change | Reaches dual PC? |
|---|---|
| `addRecvMediaSections` via `EarlyPublisher.make` | ❌ single-PC only by construction |
| `addRecvMediaSections` via the requirement handler | ❌ pre-existing `.publisherOnly` guard |
| Zero-requirement guard | ❌ same guard |
| `attachReceivedMedia` | ❌ `if publisher.singlePCMode` |
| Warning → debug downgrade | shared path, but evaluates to `.warning` in dual PC — identical output |

Confirmed empirically: every `V0 (Dual PC)` case passes on both servers.

## Open question for the SFU team

client-sdk-js and rust-sdks both preallocate 3/3 against this same server family. Either browsers re-fire `ontrack` when a section gains a track (making this native-libwebrtc-specific, consistent with JS skipping preallocation on React Native and citing livekit/rust-sdks#1151), or Rust hits the same wall and it is not covered by its tests. Worth confirming before any client-side follow-up.

## If picked up later

Splitting A and B into separate PRs is the better shape — A is independently verifiable against the working path, which is how the failure here was isolated to B. They are together only because that was requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
