### PR TITLE
Bump vendored nanopb runtime to 0.4.9.2

### DIFF
--- a/.changes/nanopb-0.4.9.2
+++ b/.changes/nanopb-0.4.9.2
@@ -1,0 +1,1 @@
+patch type="changed" "Vendored nanopb runtime updated from 0.4.9.1 to 0.4.9.2 (GHSA-p24j-vqcp-x988); the SDK's generated code has no callback fields, so it was not exposed to the oneof callback type confusion, and the wire format is unchanged"

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -99,7 +99,7 @@ names are flat** (`Livekit_DataPacket_Kind`), and **enums are open**
 
 Three layers:
 
-1. **`CLiveKitProto`** — vendored nanopb 0.4.9.1 runtime + generated C structs
+1. **`CLiveKitProto`** — vendored nanopb 0.4.9.2 runtime + generated C structs
    and field descriptors. All fields use `FT_POINTER` (heap-allocated), so
    structs are small and `pb_release` frees everything. ABI defines and the
    `pb_*` → `lk_pb_*` symbol renames live in `lk_pb_config.h` /

--- a/Sources/CLiveKitProto/LICENSE-nanopb.txt
+++ b/Sources/CLiveKitProto/LICENSE-nanopb.txt
@@ -1,7 +1,8 @@
 The nanopb runtime vendored in this directory (pb.h, pb_common.h/.c,
-pb_decode.h/.c, pb_encode.h/.c) is the nanopb 0.4.9.1 release (tag 0.4.9.1,
-commit cad3c18e) from https://github.com/nanopb/nanopb — the same version
-the generator is pinned to in the Makefile. pb.h contains one clearly marked
+pb_decode.h/.c, pb_encode.h/.c) is the nanopb 0.4.9.2 release (tag 0.4.9.2,
+commit 160d4f09) from https://github.com/nanopb/nanopb. The generator stays
+pinned to 0.4.9.1 in the Makefile (0.4.9.2 is not on PyPI); both emit the same
+generated-code format (PB_PROTO_HEADER_VERSION 40). pb.h contains one clearly marked
 LiveKit block (an altered version per clause 2 below) that includes
 lk_pb_config.h — a LiveKit file providing ABI configuration and lk_-prefixed
 symbol renames (lk_pb_rename.h); the other upstream files are unmodified. Used under the zlib license:

--- a/Sources/CLiveKitProto/include/pb.h
+++ b/Sources/CLiveKitProto/include/pb.h
@@ -65,6 +65,9 @@
 /* #define PB_C99_STATIC_ASSERT 1 */
 /* #define PB_NO_STATIC_ASSERT 1 */
 
+/* Limit for depth of recursive message structure */
+/* #define PB_MESSAGE_NESTING_MAX 10 */
+
 /******************************************************************
  * You usually don't need to change anything below this line.     *
  * Feel free to look around and use the defined macros, though.   *
@@ -73,7 +76,7 @@
 
 /* Version of the nanopb library. Just in case you want to check it in
  * your own program. */
-#define NANOPB_VERSION "nanopb-0.4.9.1"
+#define NANOPB_VERSION "nanopb-0.4.9.2"
 
 /* Include all the system headers needed by nanopb. You will need the
  * definitions of the following:
@@ -135,13 +138,17 @@ extern "C" {
 #endif
 
 /* Detect endianness */
+#if !defined(CHAR_BIT) && defined(__CHAR_BIT__)
+#define CHAR_BIT __CHAR_BIT__
+#endif
+
 #ifndef PB_LITTLE_ENDIAN_8BIT
 #if ((defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN) || \
      (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) || \
       defined(__LITTLE_ENDIAN__) || defined(__ARMEL__) || \
       defined(__THUMBEL__) || defined(__AARCH64EL__) || defined(_MIPSEL) || \
       defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM)) \
-     && CHAR_BIT == 8
+     && defined(CHAR_BIT) && CHAR_BIT == 8
 #define PB_LITTLE_ENDIAN_8BIT 1
 #endif
 #endif
@@ -767,20 +774,20 @@ struct pb_extension_s {
  */
 
 #define PB_FIELDINFO_1(tag, type, data_offset, data_size, size_offset, array_size) \
-    (0 | (((tag) << 2) & 0xFF) | ((type) << 8) | (((uint32_t)(data_offset) & 0xFF) << 16) | \
+    (0 | (((uint32_t)(tag) << 2) & 0xFF) | ((type) << 8) | (((uint32_t)(data_offset) & 0xFF) << 16) | \
      (((uint32_t)(size_offset) & 0x0F) << 24) | (((uint32_t)(data_size) & 0x0F) << 28)),
 
 #define PB_FIELDINFO_2(tag, type, data_offset, data_size, size_offset, array_size) \
-    (1 | (((tag) << 2) & 0xFF) | ((type) << 8) | (((uint32_t)(array_size) & 0xFFF) << 16) | (((uint32_t)(size_offset) & 0x0F) << 28)), \
+    (1 | (((uint32_t)(tag) << 2) & 0xFF) | ((type) << 8) | (((uint32_t)(array_size) & 0xFFF) << 16) | (((uint32_t)(size_offset) & 0x0F) << 28)), \
     (((uint32_t)(data_offset) & 0xFFFF) | (((uint32_t)(data_size) & 0xFFF) << 16) | (((uint32_t)(tag) & 0x3c0) << 22)),
 
 #define PB_FIELDINFO_4(tag, type, data_offset, data_size, size_offset, array_size) \
-    (2 | (((tag) << 2) & 0xFF) | ((type) << 8) | (((uint32_t)(array_size) & 0xFFFF) << 16)), \
+    (2 | (((uint32_t)(tag) << 2) & 0xFF) | ((type) << 8) | (((uint32_t)(array_size) & 0xFFFF) << 16)), \
     ((uint32_t)(int_least8_t)(size_offset) | (((uint32_t)(tag) << 2) & 0xFFFFFF00)), \
     (data_offset), (data_size),
 
 #define PB_FIELDINFO_8(tag, type, data_offset, data_size, size_offset, array_size) \
-    (3 | (((tag) << 2) & 0xFF) | ((type) << 8)), \
+    (3 | (((uint32_t)(tag) << 2) & 0xFF) | ((type) << 8)), \
     ((uint32_t)(int_least8_t)(size_offset) | (((uint32_t)(tag) << 2) & 0xFFFFFF00)), \
     (data_offset), (data_size), (array_size), 0, 0, 0,
 

--- a/Sources/CLiveKitProto/include/pb_decode.h
+++ b/Sources/CLiveKitProto/include/pb_decode.h
@@ -54,12 +54,24 @@ struct pb_istream_s
     /* Pointer to constant (ROM) string when decoding function returns error */
     const char *errmsg;
 #endif
+
+#ifdef PB_MESSAGE_NESTING_MAX
+    pb_size_t depth;
+#endif
 };
 
-#ifndef PB_NO_ERRMSG
-#define PB_ISTREAM_EMPTY {0,0,0,0}
+#ifdef PB_MESSAGE_NESTING_MAX
+# ifndef PB_NO_ERRMSG
+#  define PB_ISTREAM_EMPTY {0,0,0,0,0}
+# else
+#  define PB_ISTREAM_EMPTY {0,0,0,0}
+# endif
 #else
-#define PB_ISTREAM_EMPTY {0,0,0}
+# ifndef PB_NO_ERRMSG
+#  define PB_ISTREAM_EMPTY {0,0,0,0}
+# else
+#  define PB_ISTREAM_EMPTY {0,0,0}
+# endif
 #endif
 
 /***************************

--- a/Sources/CLiveKitProto/pb_decode.c
+++ b/Sources/CLiveKitProto/pb_decode.c
@@ -161,6 +161,9 @@ pb_istream_t pb_istream_from_buffer(const pb_byte_t *buf, size_t msglen)
 #ifndef PB_NO_ERRMSG
     stream.errmsg = NULL;
 #endif
+#ifdef PB_MESSAGE_NESTING_MAX
+    stream.depth = 0;
+#endif
     return stream;
 }
 
@@ -369,6 +372,12 @@ bool checkreturn pb_make_string_substream(pb_istream_t *stream, pb_istream_t *su
     if (substream->bytes_left < size)
         PB_RETURN_ERROR(stream, "parent stream too short");
     
+#ifdef PB_MESSAGE_NESTING_MAX
+    substream->depth++;
+    if (substream->depth > PB_MESSAGE_NESTING_MAX)
+        PB_RETURN_ERROR(stream, "max depth");
+#endif
+
     substream->bytes_left = (size_t)size;
     stream->bytes_left -= (size_t)size;
     return true;
@@ -751,6 +760,18 @@ static bool checkreturn decode_pointer_field(pb_istream_t *stream, pb_wire_type_
 
 static bool checkreturn decode_callback_field(pb_istream_t *stream, pb_wire_type_t wire_type, pb_field_iter_t *field)
 {
+    /* Clear any data that may have been decoded for another oneof field
+     * that has come before this callback field.
+     */
+    if (PB_HTYPE(field->type) == PB_HTYPE_ONEOF)
+    {
+        if (*(pb_size_t*)field->pSize != 0 && *(pb_size_t*)field->pSize != field->tag)
+        {
+            memset(field->pData, 0, (size_t)field->data_size);
+        }
+        *(pb_size_t*)field->pSize = field->tag;
+    }
+
     if (!field->descriptor->field_callback)
         return pb_skip_field(stream, wire_type);
 
@@ -761,6 +782,22 @@ static bool checkreturn decode_callback_field(pb_istream_t *stream, pb_wire_type
         
         if (!pb_make_string_substream(stream, &substream))
             return false;
+
+        /* If the callback field is inside a submsg, first call the submsg_callback which
+         * should set the decoder for the callback field. */
+        if (PB_LTYPE(field->type) == PB_LTYPE_SUBMSG_W_CB && field->pSize != NULL) {
+            pb_callback_t* callback;
+            *(pb_size_t*)field->pSize = field->tag;
+            callback = (pb_callback_t*)field->pSize - 1;
+
+            if (callback->funcs.decode)
+            {
+                if (!callback->funcs.decode(&substream, field, &callback->arg)) {
+                    PB_SET_ERROR(stream, substream.errmsg ? substream.errmsg : "submsg callback failed");
+                    return false;
+                }
+            }
+        }
         
         do
         {

--- a/Sources/CLiveKitProto/pb_encode.c
+++ b/Sources/CLiveKitProto/pb_encode.c
@@ -54,9 +54,18 @@ static bool checkreturn buf_write(pb_ostream_t *stream, const pb_byte_t *buf, si
 {
     pb_byte_t *dest = (pb_byte_t*)stream->state;
     stream->state = dest + count;
-    
-    memcpy(dest, buf, count * sizeof(pb_byte_t));
-    
+
+    /* Skip the copy if buf is NULL. Callers should not invoke this with NULL,
+     * but pb_write may pass NULL for sizing passes. Some compilers
+     * (e.g. picolibc/arm-zephyr-eabi GCC 12.2) emit a -Wnonnull warning
+     * against memcpy's nonnull argument even though count would be 0 in
+     * that case. See #1141.
+     */
+    if (buf != NULL)
+    {
+        memcpy(dest, buf, count * sizeof(pb_byte_t));
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Updates the vendored nanopb runtime from 0.4.9.1 to 0.4.9.2 for [GHSA-p24j-vqcp-x988](https://github.com/nanopb/nanopb/security/advisories/GHSA-p24j-vqcp-x988); the SDK was not vulnerable since its generated code has no callback fields, and the wire format and generated code are unchanged.