### PR TITLE
fix: fail over to other regions when Cloud rejects a connection with 403

### DIFF
--- a/Sources/LiveKit/Core/Room+Region.swift
+++ b/Sources/LiveKit/Core/Room+Region.swift
@@ -137,11 +137,10 @@ extension Room {
                     throw error
                 }
 
-                if let liveKitError = error as? LiveKitError, liveKitError.type == .validation {
-                    // Don't retry other regions for validation errors.
-                    throw liveKitError
-                }
-
+                // Validation errors are terminal — another region will reject the same token the
+                // same way — except for the 403 Cloud uses to signal project-level region pinning,
+                // which is precisely the case region failover exists to recover from.
+                // `isRetryableForRegionFailover` makes that distinction on the HTTP status.
                 guard error.isRetryableForRegionFailover else {
                     throw error
                 }

--- a/Sources/LiveKit/Errors.swift
+++ b/Sources/LiveKit/Errors.swift
@@ -143,9 +143,9 @@ public class LiveKitError: NSError, @unchecked Sendable, Loggable {
     public let internalError: Error?
 
     /// HTTP status this error was derived from, when it came from an HTTP response.
-    /// Callers should branch on this rather than parsing `message`, which is a
+    /// Internal consumers branch on this rather than parsing `message`, which is a
     /// human-readable string with no stability guarantees.
-    public let statusCode: Int?
+    let statusCode: Int?
 
     @available(*, deprecated, renamed: "internalError")
     public var underlyingError: Error? { internalError }
@@ -154,33 +154,53 @@ public class LiveKitError: NSError, @unchecked Sendable, Loggable {
         [internalError].compactMap(\.self)
     }
 
-    public init(_ type: LiveKitErrorType,
-                message: String? = nil,
-                internalError: Error? = nil,
-                statusCode: Int? = nil)
+    private static func _userInfo(type: LiveKitErrorType,
+                                  message: String?,
+                                  internalError: Error?) -> [String: Any]
     {
-        func _computeDescription() -> String {
-            var suffix = ""
-            if let message {
-                suffix = "(\(message))"
-            } else if let internalError {
-                suffix = "(\(internalError.localizedDescription))"
-            }
-            return String(describing: type) + suffix
+        var suffix = ""
+        if let message {
+            suffix = "(\(message))"
+        } else if let internalError {
+            suffix = "(\(internalError.localizedDescription))"
         }
 
+        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: String(describing: type) + suffix]
+        if let internalError {
+            userInfo[NSUnderlyingErrorKey] = internalError as NSError
+        }
+        return userInfo
+    }
+
+    public init(_ type: LiveKitErrorType,
+                message: String? = nil,
+                internalError: Error? = nil)
+    {
+        self.type = type
+        self.message = message
+        self.internalError = internalError
+        statusCode = nil
+
+        super.init(domain: "io.livekit.swift-sdk",
+                   code: type.rawValue,
+                   userInfo: Self._userInfo(type: type, message: message, internalError: internalError))
+    }
+
+    /// Records the HTTP status alongside the error. Kept separate from the public initializer so
+    /// that one's signature — and the public API surface — stays unchanged.
+    init(_ type: LiveKitErrorType,
+         message: String? = nil,
+         internalError: Error? = nil,
+         statusCode: Int?)
+    {
         self.type = type
         self.message = message
         self.internalError = internalError
         self.statusCode = statusCode
 
-        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: _computeDescription()]
-        if let internalError {
-            userInfo[NSUnderlyingErrorKey] = internalError as NSError
-        }
         super.init(domain: "io.livekit.swift-sdk",
                    code: type.rawValue,
-                   userInfo: userInfo)
+                   userInfo: Self._userInfo(type: type, message: message, internalError: internalError))
     }
 
     @available(*, unavailable)

--- a/Sources/LiveKit/Errors.swift
+++ b/Sources/LiveKit/Errors.swift
@@ -142,6 +142,11 @@ public class LiveKitError: NSError, @unchecked Sendable, Loggable {
     public let message: String?
     public let internalError: Error?
 
+    /// HTTP status this error was derived from, when it came from an HTTP response.
+    /// Callers should branch on this rather than parsing `message`, which is a
+    /// human-readable string with no stability guarantees.
+    public let statusCode: Int?
+
     @available(*, deprecated, renamed: "internalError")
     public var underlyingError: Error? { internalError }
 
@@ -151,7 +156,8 @@ public class LiveKitError: NSError, @unchecked Sendable, Loggable {
 
     public init(_ type: LiveKitErrorType,
                 message: String? = nil,
-                internalError: Error? = nil)
+                internalError: Error? = nil,
+                statusCode: Int? = nil)
     {
         func _computeDescription() -> String {
             var suffix = ""
@@ -166,6 +172,7 @@ public class LiveKitError: NSError, @unchecked Sendable, Loggable {
         self.type = type
         self.message = message
         self.internalError = internalError
+        self.statusCode = statusCode
 
         var userInfo: [String: Any] = [NSLocalizedDescriptionKey: _computeDescription()]
         if let internalError {
@@ -230,9 +237,24 @@ extension Error {
         }
     }
 
-    /// Returns `true` for network/timeouts that should trigger region failover.
+    /// Returns `true` for errors that should trigger region failover: network issues, timeouts,
+    /// and the 403 LiveKit Cloud uses to signal project-level region pinning.
+    ///
+    /// Cloud returns 403 on the RTC paths when the project is not allowed in the region the client
+    /// geo-routed to, leaving `/settings/regions` reachable so the client can discover its allowed
+    /// regions and connect there. That arrives here as `.validation`, which is otherwise terminal,
+    /// so it has to be admitted on the status.
+    ///
+    /// We key on the status rather than the server's message because that message is an unversioned
+    /// human-readable string; matching it would let a copy edit break already-shipped clients. A 401
+    /// stays terminal — no other region will accept a token this one rejected — as does the 404 that
+    /// surfaces as `.serviceNotFound`. If a 403 really was a permissions failure rather than region
+    /// pinning, every region attempt fails the same way and the original error still surfaces.
     var isRetryableForRegionFailover: Bool {
         if let liveKitError = self as? LiveKitError {
+            if liveKitError.statusCode == 403 {
+                return true
+            }
             switch liveKitError.type {
             case .network, .timedOut:
                 return true

--- a/Sources/LiveKit/Support/Network/HTTP.swift
+++ b/Sources/LiveKit/Support/Network/HTTP.swift
@@ -53,12 +53,16 @@ class HTTP: NSObject {
             // Treat request/token/permissions issues as validation errors.
             // 404 is reported separately so the v1 → v0 RTC path fallback can
             // distinguish "endpoint doesn't exist" from other client errors.
+            // The status is carried on the error so callers can tell the Cloud
+            // region-pinning 403 from a terminal 401 without parsing `details`.
             if (400 ..< 500).contains(statusCode), statusCode != 429 {
-                throw LiveKitError(statusCode == 404 ? .serviceNotFound : .validation, message: details)
+                throw LiveKitError(statusCode == 404 ? .serviceNotFound : .validation,
+                                   message: details,
+                                   statusCode: statusCode)
             }
 
             // Treat server/rate-limit issues as network errors.
-            throw LiveKitError(.network, message: "Validation endpoint error: \(details)")
+            throw LiveKitError(.network, message: "Validation endpoint error: \(details)", statusCode: statusCode)
         }
     }
 

--- a/Tests/LiveKitCoreTests/RegionManagerTests.swift
+++ b/Tests/LiveKitCoreTests/RegionManagerTests.swift
@@ -117,6 +117,20 @@ import Testing
         #expect(!NSError(domain: "other", code: -1).isRetryableForRegionFailover)
     }
 
+    /// LiveKit Cloud signals project-level region pinning with a 403 on the RTC paths. It arrives
+    /// as `.validation`, which is otherwise terminal, so failover has to admit it on the status —
+    /// otherwise a client that geo-routes to a disallowed region never reaches its allowed one.
+    @Test func regionPinning403IsRetryableButOtherValidationFailuresAreNot() {
+        #expect(LiveKitError(.validation,
+                             message: "project not allowed in this region.",
+                             statusCode: 403).isRetryableForRegionFailover)
+
+        // No other region will accept a token this one rejected.
+        #expect(!LiveKitError(.validation, message: "unauthorized", statusCode: 401).isRetryableForRegionFailover)
+        // The v1 → v0 RTC path fallback owns this one; it is not a region problem.
+        #expect(!LiveKitError(.serviceNotFound, message: "not found", statusCode: 404).isRetryableForRegionFailover)
+    }
+
     @Test(arguments: [
         (401, LiveKitErrorType.validation),
         (500, LiveKitErrorType.regionManager),


### PR DESCRIPTION
Part of CLT-3325. Companion PRs: [client-sdk-js#2097](https://github.com/livekit/client-sdk-js/pull/2097), [client-sdk-flutter#1200](https://github.com/livekit/client-sdk-flutter/pull/1200).

## Problem

LiveKit Cloud enforces project-level region pinning by returning **403 on the RTC paths** (`/rtc`, `/rtc/validate`) when a project is not allowed in the region the client geo-routed to. `/settings/regions` is deliberately excluded from that gate so the client can discover its allowed regions and connect there — per the server-side comment, *"allow other APIs to pass because clients will permanently give up if they fail."*

Swift blocked that recovery **twice**. `HTTP.requestValidation` maps any 4xx except 404/429 to `.validation`, and `connectWithCloudRegionFailover` short-circuited on it:

```swift
if let liveKitError = error as? LiveKitError, liveKitError.type == .validation {
    // Don't retry other regions for validation errors.
    throw liveKitError
}
```

and even without that, `isRetryableForRegionFailover` admitted only `.network` / `.timedOut`. So a pinned project that geo-routed to a disallowed region gave up before ever fetching the region list.

## Fix

1. Carry the HTTP status on `LiveKitError` as a new optional `statusCode`, set where `HTTP.requestValidation` classifies the response.
2. Admit a 403 in `isRetryableForRegionFailover`.
3. Drop the `.validation` short-circuit in `connectWithCloudRegionFailover`, which is now redundant — `.validation` without a 403 still returns `false` and throws exactly as before.

Net behaviour change: **403 → retry other regions**; 401 stays terminal (no other region will accept the same token), as does the 404 that surfaces as `.serviceNotFound` for the v1 → v0 path fallback.

### Why status and not the error message

The server's body for this case is `"project not allowed in this region."`, but that is an unversioned human-readable string, and today it reaches Swift only embedded in `message` as `"HTTP 403: ..."`. Matching either would mean five SDKs carrying identical literals forever, and a server-side copy edit would silently break already-shipped clients — worst of all on iOS, where a released app cannot be hot-patched. Hence the structured `statusCode`.

The cost of not discriminating is bounded: if a 403 really was a permissions failure, every region attempt fails the same way and the original error still surfaces, one region lookup later.

## API impact

None. `statusCode` is **internal**, and the public `LiveKitError` initializer keeps its exact signature; a separate internal initializer records the status.

I first added a defaulted `statusCode:` parameter to the existing public init, assuming that was source-compatible — it is for callers, but the Swift API digester reports the changed signature as a *removed declaration*, and `Check Public API` failed on it. Fixed in 376d8da. Exposing `statusCode` publicly would be useful but is a separate decision that shouldn't ride along in a bugfix.

## Cross-SDK status

This bug is not universal. Rust and Android already fail over on any non-cancellation error and are unaffected; JS, Flutter and Swift all bail. Agents SDKs route through the Rust core, so **agents are unaffected**.

## Testing

`xcodebuild build -scheme LiveKit -destination 'platform=macOS'` succeeds. New test `regionPinning403IsRetryableButOtherValidationFailuresAreNot` covers 403 / 401 / 404; the existing `regionManagerShouldRetryConnection` is unchanged and still passes. `RegionManagerTests` passes in full (6 tests).

`LiveKitCoreTests` run against a local `livekit-server --dev` leaves 3 failures — `defineAndGetSchema`, `publishWithFrameMetadata`, `concurrentPush` — all data-track schema tests, which `AGENTS.md` documents as requiring `enable_participant_data_blob: true`; the `livekit-server` build available locally rejects that config key. I was not able to baseline these against `main` (the run exceeded my time budget), so I am flagging rather than asserting they are pre-existing — though this change only touches error classification on the region-failover path and has no plausible connection to data-track schemas.

## Open question

How often the RTC 403 actually fires for pinned projects has **not** been confirmed with the Cloud team — geo-routing may normally land clients in-region, making this an edge case (bad GeoDNS, anycast flap, VPN). The opt-in `prepareConnection()` warm-up also does region selection up front and would mask it for apps that call it. The fix is correct either way and works against today's servers, but severity is unconfirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
