### PR TITLE
Start published video at 90% of its target bitrate (`x-google-start-bitrate`)

### DIFF
--- a/.changes/video-publish-start-bitrate
+++ b/.changes/video-publish-start-bitrate
@@ -1,0 +1,1 @@
+minor type="changed" "Published video starts at 90% of the track's target bitrate (capped at 1 Mbps unless it is a screen share) instead of libwebrtc's ~300 kbps default, by declaring `x-google-start-bitrate` on the video codecs' fmtp in the publisher's offer — the same behaviour as client-sdk-js and rust-sdks"

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -61,6 +61,9 @@ final class Transport: NSObject, Loggable {
     private var _onOffer: OnOfferBlock?
     private var _isRestartingIce: Bool = false
     private var _latestOfferId: UInt32 = 0
+    /// `x-google-start-bitrate` (kbps) per video sender id, munged into the offer's matching
+    /// `a=msid` section; see ``mungeVideoStartBitrate(_:kbpsBySenderId:)``.
+    private var _startBitrateKbpsBySenderId: [String: Int] = [:]
 
     // forbid direct access to PeerConnection; the box parks its blocking release on deinit
     private let _pcBox: RTCBox<LKRTCPeerConnection>
@@ -197,10 +200,14 @@ final class Transport: NSObject, Loggable {
             _latestOfferId += 1
             var offer = try await createOffer(for: constraints)
             // The direction rewrite is required to receive media in single PC mode; the
-            // stereo preference is optional and must be the one dropped on rejection.
+            // stereo preference and the video start bitrate are optional and are dropped
+            // from the right on rejection.
+            let startBitrate: (String) -> String = { [kbpsBySenderId = _startBitrateKbpsBySenderId] in
+                Self.mungeVideoStartBitrate($0, kbpsBySenderId: kbpsBySenderId)
+            }
             offer = try await set(localDescription: offer, munging: singlePCMode
-                ? [Self.mungeInactiveToRecvOnlyForMedia, Self.mungeOpusStereoForAllAudio]
-                : [])
+                ? [Self.mungeInactiveToRecvOnlyForMedia, Self.mungeOpusStereoForAllAudio, startBitrate]
+                : [startBitrate])
             try await _onOffer(offer, _latestOfferId)
         }
 
@@ -326,6 +333,71 @@ extension Transport {
             document.mediaSections[index].appendFmtpParameter("stereo=1", forPayload: payload)
         }
         return document.write()
+    }
+
+    /// Video codecs libwebrtc reads `x-google-start-bitrate` from.
+    nonisolated static let startBitrateCodecs: Set<String> = ["VP8", "VP9", "AV1", "H264", "H265"]
+
+    /// Largest start bitrate hinted for a non-screen-share track, in kbps. Stops the
+    /// bandwidth estimator from opening too aggressively on high-bitrate (e.g. 4K) tracks.
+    nonisolated static let maxStartBitrateKbps = 1000
+
+    /// Start bitrate hinted to libwebrtc's bandwidth estimator for a video sender whose
+    /// encodings total `targetBps`, or `nil` to leave libwebrtc's default in place.
+    ///
+    /// libwebrtc starts every new video send stream at roughly 300 kbps and ramps up from
+    /// there, regardless of the encodings' `maxBitrate`, so the first seconds of a published
+    /// track are visibly blurry. The hint is 90% of the target bitrate: high enough to skip
+    /// most of the ramp, with headroom for the estimator to settle. The same multiplier is
+    /// used for every codec because the target already reflects the codec's efficiency.
+    /// Camera and other sources are capped at ``maxStartBitrateKbps``; screen share is not,
+    /// because its content needs the bitrate immediately to be legible. Targets under
+    /// 300 kbps get no hint — libwebrtc's default already covers them.
+    ///
+    /// Same formula as client-sdk-js (`PCTransport.setTrackCodecBitrate`) and rust-sdks
+    /// (`compute_start_bitrate_kbps`).
+    nonisolated static func startBitrateKbps(targetBps: Int, isScreenShare: Bool) -> Int? {
+        let targetKbps = targetBps / 1000
+        guard targetKbps >= 300 else { return nil }
+        let startKbps = Int((Double(targetKbps) * 0.9).rounded())
+        return isScreenShare ? startKbps : min(startKbps, maxStartBitrateKbps)
+    }
+
+    /// ``startBitrateKbps(targetBps:isScreenShare:)`` for a sender's encodings: the target is
+    /// the sum of the active encodings' `maxBitrate` — every simulcast layer, since they are
+    /// independent streams the estimator has to fund together; for a single (or SVC) encoding
+    /// that is simply its own `maxBitrate`. Encodings without a `maxBitrate` contribute
+    /// nothing, so a track that declares none gets no hint.
+    nonisolated static func startBitrateKbps(for encodings: [LKRTCRtpEncodingParameters], isScreenShare: Bool) -> Int? {
+        let targetBps = encodings.filter(\.isActive).compactMap { $0.maxBitrateBps?.intValue }.reduce(0, +)
+        return startBitrateKbps(targetBps: targetBps, isScreenShare: isScreenShare)
+    }
+
+    /// Munge the offer to declare `x-google-start-bitrate=<kbps>` on every video codec's fmtp
+    /// of the sections sending the tracks in `kbpsBySenderId`, inserting an fmtp line for
+    /// payloads (typically VP8) that have none and replacing an existing value.
+    ///
+    /// Sections are matched to senders through the track id of their `a=msid` line, which
+    /// libwebrtc sets to the sender id — the same match client-sdk-js makes on `cid` in
+    /// `PCTransport.setTrackCodecBitrate`. Sections without a matching sender are untouched,
+    /// and an SDP with nothing to change is returned unmodified.
+    nonisolated static func mungeVideoStartBitrate(_ sdp: String, kbpsBySenderId: [String: Int]) -> String {
+        guard !kbpsBySenderId.isEmpty else { return sdp }
+        var document = SDP(parsing: sdp)
+        var modified = false
+        for index in document.mediaSections.indices {
+            let section = document.mediaSections[index]
+            guard section.mediaType == "video",
+                  let msid = section.attributeValue("msid"),
+                  let senderId = msid.split(separator: " ").dropFirst().first.map(String.init),
+                  let kbps = kbpsBySenderId[senderId] else { continue }
+            for rtpmap in section.rtpmaps where startBitrateCodecs.contains(rtpmap.codec.uppercased()) {
+                if document.mediaSections[index].setFmtpParameter("x-google-start-bitrate", value: "\(kbps)", forPayload: rtpmap.payload) {
+                    modified = true
+                }
+            }
+        }
+        return modified ? document.write() : sdp
     }
 
     /// Applies `munges` composed left-to-right and sets the result as the local
@@ -490,11 +562,19 @@ extension Transport {
         }
     }
 
+    /// `startBitrateKbps` (see ``startBitrateKbps(targetBps:isScreenShare:)``) is recorded
+    /// against the new sender here, before returning, so the offer libwebrtc asks for in
+    /// response to this call cannot be created without it.
     func addTransceiver(with track: LKRTCMediaStreamTrack,
-                        transceiverInit: LKRTCRtpTransceiverInit) throws -> LKRTCRtpTransceiver
+                        transceiverInit: LKRTCRtpTransceiverInit,
+                        startBitrateKbps: Int? = nil) throws -> LKRTCRtpTransceiver
     {
         guard let transceiver = _pc.addTransceiver(with: track, init: transceiverInit) else {
             throw LiveKitError(.webRTC, message: "Failed to add transceiver")
+        }
+
+        if let startBitrateKbps {
+            _startBitrateKbpsBySenderId[transceiver.sender.senderId] = startBitrateKbps
         }
 
         return transceiver
@@ -515,6 +595,7 @@ extension Transport {
         guard _pc.removeTrack(raw) else {
             throw LiveKitError(.webRTC, message: "Failed to remove track")
         }
+        _startBitrateKbpsBySenderId.removeValue(forKey: sender.senderId)
 
         releaseTransceiver(sender: raw)
     }

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -517,9 +517,8 @@ extension LocalParticipant {
         // Should be already resolved...
         let dimensions = try await track.capturer.dimensionsCompleter.wait()
 
-        let encodings = Utils.computeVideoEncodings(dimensions: dimensions,
-                                                    publishOptions: publishOptions,
-                                                    overrideVideoCodec: videoCodec)
+        let isScreenShare = track.source == .screenShareVideo
+        let encodings = Utils.computeVideoEncodings(dimensions: dimensions, publishOptions: publishOptions, isScreenShare: isScreenShare, overrideVideoCodec: videoCodec)
 
         log("[Publish/Backup] Using encodings: \(encodings.map { $0.toDebugString() }.joined(separator: ", "))")
 
@@ -537,8 +536,10 @@ extension LocalParticipant {
         let degradationPreference = publishOptions.degradationPreference.resolve(for: track.source)
         log("[Publish/Backup] set degradationPreference to \(degradationPreference)")
 
+        let startBitrateKbps = Transport.startBitrateKbps(for: encodings, isScreenShare: isScreenShare)
+
         let sender = try await RTC.run {
-            let transceiver = try publisher.addTransceiver(with: track.mediaTrack.raw, transceiverInit: transInit)
+            let transceiver = try publisher.addTransceiver(with: track.mediaTrack.raw, transceiverInit: transInit, startBitrateKbps: startBitrateKbps)
             try transceiver.set(preferredVideoCodec: videoCodec)
             transceiver.sender.set(degradationPreference: degradationPreference)
             return RTCSender(transceiver.sender)
@@ -730,9 +731,15 @@ extension LocalParticipant {
                                                          populatorFunc)
             }
 
+            let startBitrateKbps = (track is LocalVideoTrack)
+                ? Transport.startBitrateKbps(for: sendEncodings, isScreenShare: track.source == .screenShareVideo)
+                : nil
+
             let negotiateFunc: @Sendable () async throws -> Void = {
                 let sender = try await RTC.run {
-                    let transceiver = try publisher.addTransceiver(with: track.mediaTrack.raw, transceiverInit: transInit)
+                    let transceiver = try publisher.addTransceiver(with: track.mediaTrack.raw,
+                                                                   transceiverInit: transInit,
+                                                                   startBitrateKbps: startBitrateKbps)
 
                     if track is LocalVideoTrack {
                         let publishOptions = (options as? VideoPublishOptions) ?? room._state.roomOptions.defaultVideoPublishOptions

--- a/Sources/LiveKit/Support/SDP/SDP.swift
+++ b/Sources/LiveKit/Support/SDP/SDP.swift
@@ -122,6 +122,31 @@ struct SDPMediaSection {
         return false
     }
 
+    /// Sets `name=value` in the fmtp config of `payload`: replaces the parameter's value
+    /// if present, appends it to an existing fmtp line otherwise, and inserts a new
+    /// `a=fmtp:<payload> <name>=<value>` line at the end of the section when the payload
+    /// has none (e.g. VP8, which libwebrtc offers without an fmtp line). Returns `true` if
+    /// the section was modified; `false` when the parameter already carries `value`.
+    @discardableResult
+    mutating func setFmtpParameter(_ name: String, value: String, forPayload payload: String) -> Bool {
+        let parameter = "\(name)=\(value)"
+        for (index, line) in lines.enumerated() {
+            guard let fmtp = Self.fmtp(fromLine: line), fmtp.payload == payload else { continue }
+            // Split without trimming so every other parameter is written back verbatim.
+            var pieces = fmtp.config.split(separator: ";", omittingEmptySubsequences: false).map(String.init)
+            if let existing = pieces.firstIndex(where: { $0.trimmingCharacters(in: .whitespaces).hasPrefix("\(name)=") }) {
+                guard pieces[existing].trimmingCharacters(in: .whitespaces) != parameter else { return false }
+                pieces[existing] = parameter
+            } else {
+                pieces.append(parameter)
+            }
+            lines[index] = "a=fmtp:\(payload) \(pieces.joined(separator: ";"))"
+            return true
+        }
+        lines.append("a=fmtp:\(payload) \(parameter)")
+        return true
+    }
+
     /// Whether an `a=rtcp-fb:<payload> <value>` line with exactly `value` exists for
     /// `payload`. Exact-value match: `nack` does not match `nack pli` (RFC 4585 §4.2
     /// — they are distinct feedback parameters).

--- a/Tests/LiveKitCoreTests/SDP/SDPTests.swift
+++ b/Tests/LiveKitCoreTests/SDP/SDPTests.swift
@@ -242,6 +242,47 @@ struct SDPTests {
         #expect(document.write() == SDPFixture.normal)
     }
 
+    /// `setFmtpParameter` replaces an existing value in place (keeping the other parameters
+    /// byte-for-byte, space padding included), appends to an existing fmtp line otherwise,
+    /// and reports no change when the value is already there.
+    @Test func setsFmtpParameterOnExistingLine() throws {
+        var section = try #require(SDP(parsing: SDPFixture.simulcast).mediaSections.last)
+
+        let replaced = section.setFmtpParameter("profile-level-id", value: "42e01f", forPayload: "97")
+        let replacedPadded = section.setFmtpParameter("max-fs", value: "1", forPayload: "98")
+        let appended = section.setFmtpParameter("x-google-start-bitrate", value: "1000", forPayload: "99")
+
+        #expect(replaced && replacedPadded && appended)
+        #expect(section.fmtp(forPayload: "97")?.config == "profile-level-id=42e01f; max-fs=3600; max-mbps=108000")
+        #expect(section.fmtp(forPayload: "98")?.config == "profile-level-id=42c00b;max-fs=1; max-mbps=3600")
+        #expect(section.fmtp(forPayload: "99")?.config == "profile-level-id=42c00b; max-fs=120; max-mbps=1800;x-google-start-bitrate=1000")
+
+        let before = section.lines
+        let sameAppended = section.setFmtpParameter("x-google-start-bitrate", value: "1000", forPayload: "99")
+        let sameReplaced = section.setFmtpParameter("max-fs", value: "1", forPayload: "98")
+        #expect(!sameAppended && !sameReplaced)
+        #expect(section.lines == before)
+    }
+
+    /// A payload with no fmtp line (VP8 in the simulcast fixture) gets one inserted at the
+    /// end of the section; the parameter name must match whole, so `sprop-stereo` is not
+    /// mistaken for `stereo`.
+    @Test func setFmtpParameterInsertsLineWhenAbsent() {
+        var document = SDP(parsing: SDPFixture.simulcast)
+
+        let inserted = document.mediaSections[1].setFmtpParameter("x-google-start-bitrate", value: "1000", forPayload: "100")
+
+        #expect(inserted)
+        #expect(document.mediaSections[1].lines.last == "a=fmtp:100 x-google-start-bitrate=1000")
+        #expect(document.mediaSections[1].fmtp(forPayload: "100")?.parameters == ["x-google-start-bitrate=1000"])
+        #expect(document.write().hasSuffix("a=fmtp:100 x-google-start-bitrate=1000"))
+
+        var opus = SDPMediaSection(lines: ["m=audio 9 UDP/TLS/RTP/SAVPF 111", "a=fmtp:111 sprop-stereo=1"])
+        let stereoAppended = opus.setFmtpParameter("stereo", value: "1", forPayload: "111")
+        #expect(stereoAppended)
+        #expect(opus.fmtp(forPayload: "111")?.config == "sprop-stereo=1;stereo=1")
+    }
+
     @Test func appendsLineAtEndOfSection() throws {
         var document = SDP(parsing: SDPFixture.jsep)
         try #require(!document.mediaSections.isEmpty)

--- a/Tests/LiveKitCoreTests/SDP/TransportMungeFallbackTests.swift
+++ b/Tests/LiveKitCoreTests/SDP/TransportMungeFallbackTests.swift
@@ -118,4 +118,38 @@ struct TransportMungeFallbackTests {
             #expect(applied.sdp != offer.sdp)
         }
     }
+
+    // MARK: - Video start bitrate
+
+    /// The premise of ``Transport/mungeVideoStartBitrate(_:kbpsBySenderId:)`` on the shipped
+    /// libwebrtc: a send-only video section's `a=msid` carries the sender id (so the map is
+    /// keyed correctly), and a local offer with `x-google-start-bitrate` set on every video
+    /// codec — inserted for VP8, appended for the rest — is accepted rather than rejected as
+    /// disallowed munging.
+    @Test func acceptsVideoStartBitrateMungedIntoTheOffer() async throws {
+        try await withTransport { transport in
+            let transceiverInit = LKRTCRtpTransceiverInit()
+            transceiverInit.direction = .sendOnly
+            let senderId = try await RTC.run {
+                try transport.addTransceiver(ofType: .video, transceiverInit: transceiverInit).sender.senderId
+            }
+            let offer = try await transport.createOffer()
+
+            let video = try #require(SDP(parsing: offer.sdp).mediaSections.first { $0.mediaType == "video" })
+            #expect(video.attributeValue("msid")?.split(separator: " ").last.map(String.init) == senderId)
+
+            let munged = Transport.mungeVideoStartBitrate(offer.sdp, kbpsBySenderId: [senderId: 1000])
+            let applied = try await transport.set(localDescription: offer, munging: [
+                { Transport.mungeVideoStartBitrate($0, kbpsBySenderId: [senderId: 1000]) },
+            ])
+
+            #expect(munged != offer.sdp)
+            #expect(applied.sdp == munged)
+            let appliedVideo = try #require(SDP(parsing: applied.sdp).mediaSections.first { $0.mediaType == "video" })
+            for rtpmap in appliedVideo.rtpmaps where Transport.startBitrateCodecs.contains(rtpmap.codec.uppercased()) {
+                #expect(appliedVideo.fmtp(forPayload: rtpmap.payload)?.parameters.contains("x-google-start-bitrate=1000") == true,
+                        "payload \(rtpmap.payload) (\(rtpmap.codec))")
+            }
+        }
+    }
 }

--- a/Tests/LiveKitCoreTests/SDP/TransportSDPMungeTests.swift
+++ b/Tests/LiveKitCoreTests/SDP/TransportSDPMungeTests.swift
@@ -15,6 +15,7 @@
  */
 
 @testable import LiveKit
+import LiveKitWebRTC
 import Testing
 
 @Suite(.tags(.media))
@@ -101,5 +102,104 @@ struct TransportSDPMungeTests {
 
         #expect(Transport.mungeOpusStereoForAllAudio(once) == once)
         #expect(Transport.mungeOpusStereoForAllAudio(Self.offer) == Self.offer)
+    }
+
+    /// A publisher offer with two video sections sending known tracks (`cam`: H.264 with two
+    /// payloads, one lower-cased and already carrying a stale start bitrate, plus VP8 without
+    /// an fmtp line and an rtx payload; `share`: VP9 and AV1), a video section whose sender is
+    /// not mapped, and an Opus audio section.
+    private static let publisherOffer = """
+    v=0
+    o=- 0 0 IN IP4 127.0.0.1
+    s=-
+    t=0 0
+    m=audio 9 UDP/TLS/RTP/SAVPF 111
+    a=mid:0
+    a=msid:- mic
+    a=rtpmap:111 opus/48000/2
+    a=fmtp:111 minptime=10;useinbandfec=1
+    a=sendonly
+    m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99
+    a=mid:1
+    a=msid:- cam
+    a=rtpmap:96 H264/90000
+    a=fmtp:96 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
+    a=rtpmap:97 h264/90000
+    a=fmtp:97 packetization-mode=0;x-google-start-bitrate=500;profile-level-id=42e01f
+    a=rtpmap:98 VP8/90000
+    a=rtpmap:99 rtx/90000
+    a=fmtp:99 apt=98
+    a=sendonly
+    m=video 9 UDP/TLS/RTP/SAVPF 100 101
+    a=mid:2
+    a=msid:- share
+    a=rtpmap:100 VP9/90000
+    a=fmtp:100 profile-id=0
+    a=rtpmap:101 AV1/90000
+    a=sendonly
+    m=video 9 UDP/TLS/RTP/SAVPF 96
+    a=mid:3
+    a=msid:- other
+    a=rtpmap:96 H264/90000
+    a=fmtp:96 packetization-mode=1
+    a=sendonly
+    """.replacingOccurrences(of: "\n", with: "\r\n") + "\r\n"
+
+    /// Each mapped sender's section gains its own start bitrate on every video codec —
+    /// matched case-insensitively, replacing a stale value, appended to an existing fmtp line
+    /// or inserted as a new one — while rtx, audio and the unmapped section are untouched.
+    @Test func declaresStartBitratePerSenderOnEveryVideoCodec() {
+        let munged = Transport.mungeVideoStartBitrate(Self.publisherOffer, kbpsBySenderId: ["cam": 1000, "share": 4500])
+        let sections = SDP(parsing: munged).mediaSections
+
+        #expect(sections[0].lines == SDP(parsing: Self.publisherOffer).mediaSections[0].lines)
+        #expect(sections[1].fmtps.map(\.config) == [
+            "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f;x-google-start-bitrate=1000",
+            "packetization-mode=0;x-google-start-bitrate=1000;profile-level-id=42e01f",
+            "apt=98",
+            "x-google-start-bitrate=1000",
+        ])
+        #expect(sections[1].lines.last == "a=fmtp:98 x-google-start-bitrate=1000")
+        #expect(sections[2].fmtps.map(\.config) == ["profile-id=0;x-google-start-bitrate=4500", "x-google-start-bitrate=4500"])
+        #expect(sections[3].lines == SDP(parsing: Self.publisherOffer).mediaSections[3].lines)
+    }
+
+    @Test func startBitrateIsIdempotentAndPreservesUnrelatedSDP() {
+        let once = Transport.mungeVideoStartBitrate(Self.publisherOffer, kbpsBySenderId: ["cam": 1000])
+
+        #expect(Transport.mungeVideoStartBitrate(once, kbpsBySenderId: ["cam": 1000]) == once)
+        #expect(once.hasSuffix("\r\n"))
+        // Nothing mapped, or no matching sender: byte-identical.
+        #expect(Transport.mungeVideoStartBitrate(Self.publisherOffer, kbpsBySenderId: [:]) == Self.publisherOffer)
+        #expect(Transport.mungeVideoStartBitrate(Self.publisherOffer, kbpsBySenderId: ["absent": 1000]) == Self.publisherOffer)
+        // Sections without an msid line are never matched.
+        #expect(Transport.mungeVideoStartBitrate(Self.singlePCOffer, kbpsBySenderId: ["cam": 1000]) == Self.singlePCOffer)
+    }
+
+    /// Same numbers as client-sdk-js and rust-sdks: 90% of the target, capped at 1 Mbps unless
+    /// the track is a screen share, and no hint at all under 300 kbps.
+    @Test func startBitrateFormula() {
+        #expect(Transport.startBitrateKbps(targetBps: 2_300_000, isScreenShare: false) == 1000) // 2070, capped
+        #expect(Transport.startBitrateKbps(targetBps: 800_000, isScreenShare: false) == 720)
+        #expect(Transport.startBitrateKbps(targetBps: 300_000, isScreenShare: false) == 270)
+        #expect(Transport.startBitrateKbps(targetBps: 5_000_000, isScreenShare: true) == 4500) // not capped
+        #expect(Transport.startBitrateKbps(targetBps: 299_999, isScreenShare: false) == nil)
+        #expect(Transport.startBitrateKbps(targetBps: 0, isScreenShare: true) == nil)
+    }
+
+    /// Simulcast layers are summed (they are independent streams), inactive layers and layers
+    /// without a `maxBitrate` contribute nothing.
+    @Test func startBitrateSumsActiveEncodings() {
+        let encodings = [(500_000, true), (1_500_000, true), (9_000_000, false)].map { bps, active in
+            let encoding = LKRTCRtpEncodingParameters()
+            encoding.maxBitrateBps = NSNumber(value: bps)
+            encoding.isActive = active
+            return encoding
+        }
+
+        #expect(Transport.startBitrateKbps(for: encodings, isScreenShare: true) == 1800)
+        #expect(Transport.startBitrateKbps(for: encodings, isScreenShare: false) == 1000)
+        #expect(Transport.startBitrateKbps(for: [LKRTCRtpEncodingParameters()], isScreenShare: false) == nil)
+        #expect(Transport.startBitrateKbps(for: [], isScreenShare: false) == nil)
     }
 }

--- a/Tests/LiveKitCoreTests/VideoEncodingsTests.swift
+++ b/Tests/LiveKitCoreTests/VideoEncodingsTests.swift
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import LiveKit
+import Testing
+
+@Suite(.tags(.media))
+struct VideoEncodingsTests {
+    /// A screen share with its own encoding, published as SVC with an H.264 backup.
+    private static let options = VideoPublishOptions(encoding: VideoEncoding(maxBitrate: 1_000_000, maxFps: 30),
+                                                     screenShareEncoding: VideoEncoding(maxBitrate: 4_000_000, maxFps: 15),
+                                                     simulcast: false,
+                                                     preferredCodec: .vp9,
+                                                     preferredBackupCodec: .h264)
+
+    /// The backup codec's encodings must come from the screen-share settings when the track is
+    /// a screen share — the same `isScreenShare` the primary sender's encodings were computed
+    /// with — so its layers and the start bitrate derived from them are the configured ones.
+    @Test func backupCodecEncodingsFollowScreenShareSettings() throws {
+        let dimensions = Dimensions(width: 1920, height: 1080)
+
+        let backup = Utils.computeVideoEncodings(dimensions: dimensions,
+                                                 publishOptions: Self.options,
+                                                 isScreenShare: true,
+                                                 overrideVideoCodec: .h264)
+        let primary = Utils.computeVideoEncodings(dimensions: dimensions,
+                                                  publishOptions: Self.options,
+                                                  isScreenShare: true)
+
+        try #require(backup.count == 1)
+        #expect(backup[0].maxBitrateBps?.intValue == 4_000_000)
+        #expect(backup[0].maxBitrateBps == primary[0].maxBitrateBps)
+        #expect(Transport.startBitrateKbps(for: backup, isScreenShare: true) == 3600)
+    }
+
+    /// Without `isScreenShare` the same call falls back to the camera encoding — the
+    /// mismatch the backup publish path used to have.
+    @Test func omittingScreenShareFlagSelectsCameraEncoding() throws {
+        let camera = Utils.computeVideoEncodings(dimensions: Dimensions(width: 1920, height: 1080),
+                                                 publishOptions: Self.options,
+                                                 overrideVideoCodec: .h264)
+
+        try #require(camera.count == 1)
+        #expect(camera[0].maxBitrateBps?.intValue == 1_000_000)
+    }
+}


### PR DESCRIPTION
Swift counterpart of livekit/client-sdk-js#1987 and livekit/rust-sdks#1226, reworked from the earlier opt-in draft after the review comment.

## Problem

libwebrtc starts every new video send stream at roughly 300 kbps and ramps up from there, regardless of the encodings' `maxBitrate`. On a healthy network we measured about 30 s to reach a 2.3 Mbps ceiling. The ObjC API exposes no way to set that starting point, so the handle is libwebrtc's own SDP-level `x-google-start-bitrate` fmtp parameter.

## Change

Same behavior as JS and Rust, no public API:

- When a video sender is added, the start bitrate is derived from its encodings: sum of the active layers' `maxBitrate`, × 0.9, capped at 1 Mbps unless the track is a screen share, and no hint under 300 kbps (`Transport.startBitrateKbps(targetBps:isScreenShare:)`).
- `x-google-start-bitrate=<kbps>` is declared on every video codec's fmtp (VP8/VP9/AV1/H264/H265) of that sender's section in the publisher's offer, matched through the `a=msid` track id — the same match `PCTransport.setTrackCodecBitrate` makes on `cid` in JS. An fmtp line is inserted for payloads that have none (VP8); an existing value is replaced (as in Rust).
- The munge is the last, optional entry of the `set(localDescription:munging:)` composition from #1068, in both single- and dual-PC negotiation, built on the `SDP` module from #1078. `Transport.addTransceiver(with:transceiverInit:startBitrateKbps:)` records the value against the new sender before returning, so the offer libwebrtc requests can't be created without it; `remove(track:)` clears it. Both `LocalParticipant` publish paths (primary and backup codec) pass it.
- New SDP helper `SDPMediaSection.setFmtpParameter(_:value:forPayload:)` (replace / append / insert, other parameters kept verbatim).
- Default `degradationPreference` by source, the other half of the JS PR, is already in `main` (#1083), so nothing to do there.

## Tests

`SDPTests`, `TransportSDPMungeTests` (formula, encodings sum, per-sender munge: codec case, replace/append/insert, rtx/audio/unmapped sections untouched, no-op identity) and, against the shipped libwebrtc in `TransportMungeFallbackTests`: a send-only video section's msid carries the sender id, and `setLocalDescription` accepts the munged offer (including the inserted VP8 line) rather than rejecting it as disallowed munging.

## Open questions

- Rust returns no hint when the target is under 300 kbps; JS has no such guard. I kept Rust's, since libwebrtc's default already covers those targets — happy to drop it if you'd rather match JS exactly.
- Only exercised end-to-end with H.264 on iOS on a healthy network. The other codecs are covered by unit tests plus the libwebrtc acceptance test, not by a live session.